### PR TITLE
Download zarr

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,15 @@
 ome-zarr-py
 ===========
 
-Experimental implementation of images in Zarr files.
+Experimental support for images stored in Zarr filesets.
 
 
 Features
 --------
 
 - Use as a image reader plugin for `napari`_. The `napari`_ plugin was generated with `Cookiecutter`_ along with `@napari`_'s `cookiecutter-napari-plugin`_ template.
+- Simple command-line to read and download conforming Zarr filesets.
+- Helper methods for parsing related metadata.
 
 
 Installation
@@ -31,9 +33,14 @@ Usage
 
 Open Zarr filesets containing images with associated OME metadata.
 
+Use the `ome_zarr` command to interrogate and download Zarr datasets:
+
+    $ ome_zarr info https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/
+    $ ome_zarr download https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/
+    $ ome_zarr info 6001240.zarr/
+
 For example, to load select images by their ID in the Image Data Resource
 such as http://idr.openmicroscopy.org/webclient/?show=image-6001240::
-
 
     $ napari 'https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/'
 

--- a/ome_zarr
+++ b/ome_zarr
@@ -8,12 +8,13 @@ def info(args):
     zarr_info(args.path)
 
 def download(args):
-    zarr_download(args.path, args.target)
+    zarr_download(args.path, args.output, args.name)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest='command')
+    subparsers.required = True
 
     # foo
     parser_info = subparsers.add_parser('info')
@@ -23,7 +24,8 @@ if __name__ == "__main__":
     # download
     parser_download = subparsers.add_parser('download')
     parser_download.add_argument('path')
-    parser_download.add_argument('--target', default='')
+    parser_download.add_argument('--output', default='')
+    parser_download.add_argument('--name', default='')
     parser_download.set_defaults(func=download)
 
     args = parser.parse_args()

--- a/ome_zarr
+++ b/ome_zarr
@@ -1,10 +1,30 @@
 #!/usr/bin/env python
 
 import argparse
-from ome_zarr import info
+from ome_zarr import info as zarr_info
+from ome_zarr import download as zarr_download
+
+def info(args):
+    zarr_info(args.path)
+
+def download(args):
+    zarr_download(args.path, args.target)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("path")
+    subparsers = parser.add_subparsers()
+
+    # foo
+    parser_info = subparsers.add_parser('info')
+    parser_info.add_argument('path')
+    parser_info.set_defaults(func=info)
+
+    # download
+    parser_download = subparsers.add_parser('download')
+    parser_download.add_argument('path')
+    parser_download.add_argument('--target', default='')
+    parser_download.set_defaults(func=download)
+
     args = parser.parse_args()
-    info(args.path)
+    args.func(args)

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -180,7 +180,7 @@ def info(path):
     """
     zarr = parse_url(path)
     if not zarr.is_ome_zarr():
-        print(f"not an ome-zarr: {zarr}")
+        print(f"not an ome-zarr: {path}")
         return
     reader = zarr.get_reader_function()
     data = reader(path)

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -74,6 +74,14 @@ class BaseZarr:
             self.image_data = self.get_json("omero.json")
             self.root_attrs = self.get_json(".zattrs")
 
+    def __str__(self):
+        suffix = ""
+        if self.zgroup:
+            suffix += " [zgroup]"
+        if self.zarray:
+            suffix += " [zarray]"
+        return f"{self.zarr_path}{suffix}"
+
     def is_zarr(self):
         return self.zarray or self.zgroup
 
@@ -85,7 +93,7 @@ class BaseZarr:
 
     def get_reader_function(self):
         if not self.is_zarr():
-            raise Exception("not a zarr")
+            raise Exception(f"not a zarr: {self}")
         return self.reader_function
 
     def reader_function(self, path: PathLike) -> List[LayerData]:
@@ -180,7 +188,7 @@ def info(path):
     """
     zarr = parse_url(path)
     if not zarr.is_ome_zarr():
-        print(f"not an ome-zarr: {path}")
+        print(f"not an ome-zarr: {zarr}")
         return
     reader = zarr.get_reader_function()
     data = reader(path)

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -195,7 +195,7 @@ def info(path):
     print(data)
 
 
-def download(path, dir_name=''):
+def download(path, output_dir='.', zarr_name=''):
     """
     download zarr from URL
     """
@@ -203,8 +203,10 @@ def download(path, dir_name=''):
     if not omezarr.is_ome_zarr():
         print(f"not an ome-zarr: {path}")
 
-    image_id = omezarr.image_data['id']
+    image_id = omezarr.image_data.get('id', 'unknown')
     print('image_id', image_id)
+    if not zarr_name:
+        zarr_name = f'{image_id}.zarr'
 
     try:
         datasets = [x['path'] for x in omezarr.root_attrs["multiscales"][0]["datasets"]]
@@ -214,7 +216,7 @@ def download(path, dir_name=''):
     resolutions = [da.from_zarr(path, component=str(i)) for i in datasets]
     # levels = list(range(len(resolutions)))
 
-    target_dir = os.path.join(dir_name, f'{image_id}.zarr')
+    target_dir = os.path.join(output_dir, f'{zarr_name}')
     print(f'downloading to {target_dir}')
 
     pbar = ProgressBar()

--- a/ome_zarr_cli.py
+++ b/ome_zarr_cli.py
@@ -4,14 +4,16 @@ import argparse
 from ome_zarr import info as zarr_info
 from ome_zarr import download as zarr_download
 
+
 def info(args):
     zarr_info(args.path)
+
 
 def download(args):
     zarr_download(args.path, args.output, args.name)
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ setup(
         'or later (GPLv2+)',
     ],
     entry_points={
+        'console_scripts': [
+            'ome_zarr = ome_zarr_cli:main',
+        ],
         'napari.plugin': [
             'ome_zarr = ome_zarr',
         ],


### PR DESCRIPTION
To test:

NB: try with and without the ```--target test``` option
Would also be good to test on windows?

```
$ ./ome_zarr download 'https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/' --target test
image_id 6001240
datasets ['0', '1']
downloading to test/6001240.zarr
resolution 1...
[########################################] | 100% Completed | 13.8s
resolution 0...
[########################################] | 100% Completed | 18.8s
```

This should include the `.zattrs` and `.zgroup` files.

Also ```./ome_zarr info 'https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/' ``` (moved into info subcommand)