### PR TITLE
Workaround pyramids of length 1

### DIFF
--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -161,6 +161,8 @@ class BaseZarr:
             print('resolution', resolution, 'shape (t, c, z, y, x)', data.shape, 'chunks', chunk_sizes, 'dtype', data.dtype)
             pyramid.append(data)
 
+        if len(pyramid) == 1:
+            pyramid = pyramid[0]
         metadata = self.load_omero_metadata()
         return (pyramid, {'channel_axis': 1, **metadata})
 


### PR DESCRIPTION
Passing a pyramid of length 1 leads to the exception:

```
AttributeError: 'list' object has no attribute 'shape'
```

see: https://github.com/napari/napari/issues/1225