### PR TITLE
missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires += ['s3fs'],
 install_requires += ['requests'],
 install_requires += ['toolz'],
 install_requires += ['vispy'],
+install_requires += ['pluggy'],
 
 
 setup(


### PR DESCRIPTION
I installed the dev version in conda env 
Tried to run 
```
ome_zarr download https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/
```
This returns
```
 No module named 'pluggy'
```

This PR adds ``pluggy`` as a dependency

