### PR TITLE
Depend on napari_plugin_engine

### DIFF
--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -24,7 +24,7 @@ from dask.diagnostics import ProgressBar
 from vispy.color import Colormap
 
 from urllib.parse import urlparse
-from pluggy import HookimplMarker
+from napari_plugin_engine import napari_hook_implementation
 
 import logging
 # DEBUG logging for s3fs so we can track remote calls
@@ -38,9 +38,6 @@ LayerData = Union[Tuple[Any], Tuple[Any, Dict], Tuple[Any, Dict, str]]
 PathLike = Union[str, List[str]]
 ReaderFunction = Callable[[PathLike], List[LayerData]]
 # END type hint stuff.
-
-napari_hook_implementation = HookimplMarker("napari")
-
 
 
 @napari_hook_implementation

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires += ['s3fs'],
 install_requires += ['requests'],
 install_requires += ['toolz'],
 install_requires += ['vispy'],
-install_requires += ['pluggy'],
+install_requires += ['napari-plugin-engine'],
 
 
 setup(


### PR DESCRIPTION
This is a modification to #13.

You are welcome to reject this PR and continue depending on `pluggy` for the `HookImplMarker` if you'd like, we have no plans to break that backward compatibility.  But we are recommending that people use the `napari_plugin_engine` in case we add/remove capabilities going forward.  For instance, one feature that you can only get from napari_plugin_engine is the ability to mark functions as providing napari hookspec, [without renaming the function itself](https://napari.org/docs/plugins/for_plugin_developers.html#matching-hook-implementations-to-specifications).  (that feature merged into pluggy master a while ago, but the timeline of pluggy releases is unclear at the moment)