### PR TITLE
download: exit early if target exists (fix #14)

### DIFF
--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -229,6 +229,9 @@ def download(path, output_dir='.', zarr_name=''):
     # levels = list(range(len(resolutions)))
 
     target_dir = os.path.join(output_dir, f'{zarr_name}')
+    if os.path.exists(target_dir):
+        print(f'{target_dir} already exists!')
+        return
     print(f'downloading to {target_dir}')
 
     pbar = ProgressBar()


### PR DESCRIPTION
Likely will need to move to throwing exceptions and setting return codes soon (_a la_ yaclifw)

cc: @sbesson 