### PR TITLE
Replace pluggy with optional napari_plugin_engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
 # command to install dependencies
 install:
-  - pip install .
+  - pip install .[napari]
   - pip install scikit-image  # only needed for tests
 # command to run tests
 script: pytest

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -24,7 +24,7 @@ from dask.diagnostics import ProgressBar
 from vispy.color import Colormap
 
 from urllib.parse import urlparse
-from pluggy import HookimplMarker
+from napari_plugin_engine import napari_hook_implementation
 
 import logging
 # DEBUG logging for s3fs so we can track remote calls
@@ -38,9 +38,6 @@ LayerData = Union[Tuple[Any], Tuple[Any, Dict], Tuple[Any, Dict, str]]
 PathLike = Union[str, List[str]]
 ReaderFunction = Callable[[PathLike], List[LayerData]]
 # END type hint stuff.
-
-napari_hook_implementation = HookimplMarker("napari")
-
 
 
 @napari_hook_implementation

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -24,7 +24,16 @@ from dask.diagnostics import ProgressBar
 from vispy.color import Colormap
 
 from urllib.parse import urlparse
-from napari_plugin_engine import napari_hook_implementation
+
+
+try:
+    from napari_plugin_engine import napari_hook_implementation
+except ImportError:
+    def napari_hook_implementation(*args, **kwargs):
+        def noop(*args, **kwargs):
+            pass
+        return noop
+
 
 import logging
 # DEBUG logging for s3fs so we can track remote calls

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -29,10 +29,8 @@ from urllib.parse import urlparse
 try:
     from napari_plugin_engine import napari_hook_implementation
 except ImportError:
-    def napari_hook_implementation(*args, **kwargs):
-        def noop(*args, **kwargs):
-            pass
-        return noop
+    def napari_hook_implementation(func, *args, **kwargs):
+        return func
 
 
 import logging

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
             'ome_zarr = ome_zarr',
         ],
     },
-    extra_require={
-        "napari": ["napari-plugin-engine"],
+    extras_require={
+        "napari": ["napari"],
     },
     tests_require=[
         'pytest',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ install_requires += ['s3fs'],
 install_requires += ['requests'],
 install_requires += ['toolz'],
 install_requires += ['vispy'],
-install_requires += ['napari-plugin-engine'],
 
 
 setup(
@@ -50,6 +49,9 @@ setup(
         'napari.plugin': [
             'ome_zarr = ome_zarr',
         ],
+    },
+    extra_require={
+        "napari": ["napari-plugin-engine"],
     },
     tests_require=[
         'pytest',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires += ['s3fs'],
 install_requires += ['requests'],
 install_requires += ['toolz'],
 install_requires += ['vispy'],
-install_requires += ['pluggy'],
+install_requires += ['napari-plugin-engine'],
 
 
 setup(


### PR DESCRIPTION
In addition to the switch from pluggy in https://github.com/ome/ome-zarr-py/pull/18 (thanks @tlambert03) this also makes the napari requirement optional.

