### PR TITLE
better error handling

### DIFF
--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -143,6 +143,7 @@ class BaseZarr:
                         return {}
             except:
                 LOGGER.warn(f"error counting channels: {channels}")
+                return {}
 
             colormaps = []
             contrast_limits = [None for x in channels]

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -169,9 +169,13 @@ class BaseZarr:
 
                 window = ch.get('window', None)
                 if window is not None:
-                    start = window.get('start', 0)
-                    end = window.get('end', -1)  # FIXME
-                    contrast_limits[idx] = [start, end]
+                    start = window.get('start', None)
+                    end = window.get('end', None)
+                    if start is None or end is None:
+                        # Disable contrast limits settings if one is missing
+                        contrast_limits = None
+                    elif contrast_limits is not None:
+                        contrast_limits[idx] = [start, end]
 
             metadata['colormap'] = colormaps
             metadata['contrast_limits'] = contrast_limits


### PR DESCRIPTION
Thanks to @tlambert03 and https://github.com/napari/napari/pull/1219, starting the plugin with a bad URL showed much more information about what went wrong. With this PR, we catch the exception and log it at `WARNING` which is _not_ shown to the user by default:

```
(py36) /opt/ome-zarr-py $napari http://localhost:8080/idr/zarr/v0.1/151.zarr
11:32:27 ERROR PluginError: Error in plugin 'builtins', hook 'napari_get_reader'
  Cause was: ValueError('Not a zarr dataset or group: http://localhost:8080/idr/zarr/v0.1/151.zarr',)
    in file: /opt/anaconda/envs/py36/lib/python3.6/site-packages/napari/utils/io.py
    at line: 272
    package: napari
    version: 0.3.1

11:32:27 WARNING No plugin found capable of reading 'http://localhost:8080/idr/zarr/v0.1/151.zarr'.
11:32:27 ERROR (1) error occured in plugins: 'builtins'. See full error logs in "Plugins → Plugin Errors..."
```