### PR TITLE
Add --verbose option to CLI (fix #26)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,11 @@ Usage
 Open Zarr filesets containing images with associated OME metadata.
 The examples below use the image at http://idr.openmicroscopy.org/webclient/?show=image-6001240.
 
+All examples can be made more or less verbose by passing `-v` or `-q` one or more times::
+
+    # ome_zarr -vvv ...
+
+
 info
 ====
 

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -34,9 +34,6 @@ except ImportError:
 
 
 import logging
-# DEBUG logging for s3fs so we can track remote calls
-logging.basicConfig(level=logging.INFO)
-logging.getLogger('s3fs').setLevel(logging.DEBUG)
 LOGGER = logging.getLogger("ome_zarr")
 
 # for optional type hints only, otherwise you can delete/ignore this stuff
@@ -238,8 +235,9 @@ class RemoteZarr(BaseZarr):
         url = f"{self.zarr_path}{subpath}"
         try:
             rsp = requests.get(url)
-        except:
-            LOGGER.warn(f"unreachable: {url}")
+        except Exception as e:
+            LOGGER.warn(f"unreachable: {url} -- details logged at debug")
+            LOGGER.debug("exception details:", exc_info=True)
             return {}
         try:
             if rsp.status_code in (403, 404):  # file doesn't exist

--- a/ome_zarr_cli.py
+++ b/ome_zarr_cli.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import argparse
+import logging
+
 from ome_zarr import info as zarr_info
 from ome_zarr import download as zarr_download
 
@@ -15,6 +17,7 @@ def download(args):
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbose', action='count', default=0)
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True
 
@@ -31,4 +34,9 @@ def main():
     parser_download.set_defaults(func=download)
 
     args = parser.parse_args()
+    loglevel = logging.WARNING - (10 * args.verbose)
+    logging.basicConfig(level=loglevel)
+    # DEBUG logging for s3fs so we can track remote calls
+    logging.getLogger('s3fs').setLevel(logging.DEBUG)
+
     args.func(args)

--- a/ome_zarr_cli.py
+++ b/ome_zarr_cli.py
@@ -17,7 +17,10 @@ def download(args):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-v', '--verbose', action='count', default=0)
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help='increase loglevel for each use, e.g. -vvv')
+    parser.add_argument('-q', '--quiet', action='count', default=0,
+                        help='decrease loglevel for each use, e.q. -qqq')
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True
 
@@ -34,7 +37,7 @@ def main():
     parser_download.set_defaults(func=download)
 
     args = parser.parse_args()
-    loglevel = logging.WARNING - (10 * args.verbose)
+    loglevel = logging.INFO - (10 * args.verbose) + (10 * args.quiet)
     logging.basicConfig(level=loglevel)
     # DEBUG logging for s3fs so we can track remote calls
     logging.getLogger('s3fs').setLevel(logging.DEBUG)


### PR DESCRIPTION
To not swallow exceptions, `-v` (or more) can be used to
switch from WARN logging to DEBUG logging where the details
of the exceptions mentioned by @ngladitz are now printed.