### PR TITLE
Support opening of masks

### DIFF
--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -258,10 +258,11 @@ class BaseZarr:
                 color_dict = mask_attrs.get('color')
                 colors = {int(k):self.to_rgba(v) for (k, v) in color_dict.items()}
             data = da.from_zarr(mask_path)
-            # mask data is 5D (t, c, z, y, x) but each layer in napari is 4D (no C)
-            # NB: Assume we want 'first Channel'
-            data = data[:,0,:,:,:]
-            masks.append((data, {'name': name, 'color': colors}, 'labels'))
+            # Split masks into separate channels, 1 per layer
+            for n in range(data.shape[1]):
+                masks.append((data[:,n,:,:,:],
+                              {'name': name, 'color': colors},
+                              'labels'))
         return masks
 
 

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -295,12 +295,17 @@ class RemoteZarr(BaseZarr):
             return {}
 
     def get_mask_names(self):
-        # TODO: find mask dirs remotely
+        # If this is a mask, the names are in root .zattrs
+        masks = self.root_attrs.get('masks')
+        if masks is not None:
+            return masks
         return []
 
     def has_ome_masks(self):
-        # TODO: check for /masks/
-        return False
+        # check for /masks/.zattrs with 'masks' key
+        mask_attrs = self.get_json('masks/.zattrs')
+        masks = mask_attrs.get('masks')
+        return masks is not None and len(masks) > 0
 
 def info(path):
     """


### PR DESCRIPTION
Currently supports opening of local zarr masks.

To test:
 - Export masks as described in https://github.com/ome/omero-cli-zarr/pull/11
 - Open image in napari e.g. ```$ omero napari view Image:5514375```
 - In `napari` console, do ```viewer.open('path/to/5514375.zarr/masks/')```

![Screenshot 2020-07-03 at 16 51 59](https://user-images.githubusercontent.com/900055/86484305-dc0a1080-bd4d-11ea-95b7-4a3d3027d9fb.png)
