### PR TITLE
Masks not visible when image opened in napari

### DIFF
--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -278,14 +278,12 @@ class BaseZarr:
             data = da.from_zarr(mask_path)
             # Split masks into separate channels, 1 per layer
             for n in range(data.shape[1]):
-                masks.append((
-                    data[:, n, :, :, :],
-                    {
-                        "name": name,
-                        "color": colors,
-                        "visible": False
-                    },
-                    "labels")
+                masks.append(
+                    (
+                        data[:, n, :, :, :],
+                        {"name": name, "color": colors, "visible": False},
+                        "labels",
+                    )
                 )
         return masks
 

--- a/ome_zarr.py
+++ b/ome_zarr.py
@@ -278,8 +278,14 @@ class BaseZarr:
             data = da.from_zarr(mask_path)
             # Split masks into separate channels, 1 per layer
             for n in range(data.shape[1]):
-                masks.append(
-                    (data[:, n, :, :, :], {"name": name, "color": colors}, "labels")
+                masks.append((
+                    data[:, n, :, :, :],
+                    {
+                        "name": name,
+                        "color": colors,
+                        "visible": False
+                    },
+                    "labels")
                 )
         return masks
 


### PR DESCRIPTION
I think this will prevent loading of Masks in `napari` until the user makes the labels layer visible.
To test:

```
napari 'https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/'
```

Labels layer is not visible. I think `napari` won't try to load the mask until the layer is shown.

![Screenshot 2020-08-14 at 13 30 21](https://user-images.githubusercontent.com/900055/90249470-715ef100-de32-11ea-88bd-52327b98ae06.png)
