### PR TITLE
Cross-platform path handling

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Clone gl-ci-helpers
+        env:
+          GIT_CURL_VERBOSE: 1
+          GIT_TRACE: 1
+          GIT_TRACE_PACKET: 1
         run: git clone --depth 1 git://github.com/vtkiorg/gl-ci-helpers.git
 
       - name: Install opengl

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,7 +32,9 @@ jobs:
           GIT_CURL_VERBOSE: 1
           GIT_TRACE: 1
           GIT_TRACE_PACKET: 1
-        run: git clone --depth 1 git://github.com/vtkiorg/gl-ci-helpers.git
+        run: >
+            git clone --depth 1 git://github.com/vtkiorg/gl-ci-helpers.git ||
+            git clone --depth 1 git://github.com/vtkiorg/gl-ci-helpers.git
 
       - name: Install opengl
         shell: powershell

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import os
 from collections import deque
 from pathlib import Path
-from typing import Sequence
+from typing import List
 
 import pytest
 
@@ -45,19 +45,19 @@ class TestCli:
         self._rotate_and_test(top, mid, bot)
 
     def _rotate_and_test(self, *hierarchy: Path, reverse: bool = True):
-        results: Sequence[str] = (
-            str(Path("d")),
-            str(Path("d") / "e"),
-            str(Path("d") / "e" / "f"),
-        )
+        results: List[List[str]] = [
+            list((Path("d")).parts),
+            list((Path("d") / "e").parts),
+            list((Path("d") / "e" / "f").parts),
+        ]
         for x in range(3):
             firstpass = deque(hierarchy)
             firstpass.rotate(1)
 
-            copy = [str(x) for x in firstpass]
+            copy = [list(x.parts) for x in firstpass]
             common = strip_common_prefix(copy)
             assert "d" == common
-            assert set(copy) == set(results)
+            assert {tuple(x) for x in copy} == {tuple(x) for x in results}
 
         if reverse:
             secondpass: deque = deque(hierarchy)


### PR DESCRIPTION
Removes the `zarr_path` variable from BaseZarrLocation, using a
pathlib.Path field in LocalZarrLocation and a URL string in
RemoteZarrLocation to properly handle the creation of subpaths across
multiple platforms. In general, use of os.path and especially
os.path.join should be avoided in favor of delegating to methods on the
zarr location objects.