### PR TITLE
Include packages in setup.py

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,14 +4,14 @@ commit = True
 tag = True
 sign_tags = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values = 
+values =
 	dev
 	prod
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     url="https://github.com/ome/ome-zarr-py",
     description="Implementation of images in Zarr files.",
     long_description=read("README.rst"),
+    packages=["ome_zarr"],
     py_modules=["ome_zarr"],
     python_requires=">=3.6",
     install_requires=install_requires,


### PR DESCRIPTION
I was unable to use `ome_zarr` when installating through PiPy (`pip install ome_zarr`) or locally `pip install .`:

```bash
% ome_zarr 
Traceback (most recent call last):
  File "/Users/eric/nobackup/jax/ENV/bin/ome_zarr", line 5, in <module>
    from ome_zarr.cli import main
ModuleNotFoundError: No module named 'ome_zarr'
```

Developer mode works fine (`pip install -e .`) as this creates the required link (`ENV/lib/python3.8/site-packages/ome-zarr.egg-link`.)

Reproducible with python3.8 under ubuntu 20.04 (docker) and MacOS with a clean virtualenv.

One work around is to use `packages`. I don't know why `py_modules` is insufficient.