### PR TITLE
Pin tifffile<2020.09.22 on Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ def read(fname):
 
 install_requires: List[List[str]] = []
 install_requires += (["dataclasses;python_version<'3.7'"],)
+install_requires += (["tifffile<2020.09.22;python_version<'3.7'"],)
 install_requires += (["numpy"],)
 install_requires += (["dask"],)
 install_requires += (["zarr"],)


### PR DESCRIPTION
`pip install --upgrade napari` on Python 3.6 attempts
to update tifffile to versions which require Python 3.7+