### PR TITLE
HCS: add Plate spec

### DIFF
--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -353,10 +353,11 @@ class Plate(Spec):
 
         # FIXME: shouldn't hard code
         self.acquisitions = ["PlateAcquisition Name 0"]
-        self.fields = ["Field_1"]
+        self.fields = ["Field_1", "Field_2", "Field_3", "Field_4"]
         self.row_labels = ascii_uppercase[0 : self.rows]
         self.col_labels = range(1, self.cols + 1)
 
+        visibility = True
         for acq in self.acquisitions:
             for row in self.row_labels:
                 for col in self.col_labels:
@@ -364,7 +365,8 @@ class Plate(Spec):
                         path = f"{acq}/{row}/{col}/{field}"
                         child_zarr = self.zarr.create(path)
                         if child_zarr.exists():
-                            node.add(child_zarr, visibility=True)
+                            node.add(child_zarr, visibility=visibility)
+                            visibility = False
 
 
 class Reader:


### PR DESCRIPTION
Setup:

```
mkfake my.plate
omero import my.plate.fake`
omero zarr export Plate:1
````
using https://github.com/ome/omero-cli-zarr/pull/28

Output:

```
(z) /opt/ome-zarr-py $ome_zarr -vvvvv info /tmp/1.zarr/
DEBUG:ome_zarr.io:/tmp/1.zarr/.zarray does not exist
DEBUG:ome_zarr.reader:treating /private/tmp/1.zarr [zgroup] as Plate
INFO:ome_zarr.reader:root_attr: plate
DEBUG:ome_zarr.reader:{'columns': 1, 'rows': 1}
DEBUG:ome_zarr.io:open(LocalZarrLocation(/private/tmp/1.zarr/PlateAcquisition Name 0/A/1/Field_1))
DEBUG:ome_zarr.io:/private/tmp/1.zarr/PlateAcquisition Name 0/A/1/Field_1/.zgroup does not exist
DEBUG:ome_zarr.io:/private/tmp/1.zarr/PlateAcquisition Name 0/A/1/Field_1/.zattrs does not exist
DEBUG:ome_zarr.reader:treating /private/tmp/1.zarr [zgroup] as ome-zarr
DEBUG:ome_zarr.reader:returning /private/tmp/1.zarr [zgroup]
/private/tmp/1.zarr [zgroup]
 - metadata
   - Plate
 - data
DEBUG:ome_zarr.utils:[]
DEBUG:ome_zarr.reader:returning /private/tmp/1.zarr/PlateAcquisition Name 0/A/1/Field_1 [zarray]
not an ome-zarr: /private/tmp/1.zarr [zgroup]
```