### PR TITLE
Plates

### DIFF
--- a/ome_zarr/napari.py
+++ b/ome_zarr/napari.py
@@ -6,7 +6,6 @@ It implements the ``napari_get_reader`` hook specification, (to create a reader 
 
 import logging
 import warnings
-from string import ascii_uppercase
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from .data import CHANNEL_DIMENSION
@@ -85,8 +84,8 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                         plate_info = metadata["metadata"]["plate"]
                         plate_width = shape[-1]
                         plate_height = shape[-2]
-                        rows = plate_info["rows"]
-                        columns = plate_info["columns"]
+                        rows = len(plate_info["rows"])
+                        columns = len(plate_info["columns"])
                         well_width = plate_width / columns
                         well_height = plate_height / rows
                         labels = []
@@ -101,7 +100,9 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                                 # bounding box we have a line
                                 # along top of Well, with label below
                                 outlines.append([[y1, x1], [y1, x2]])
-                                label = f"{ascii_uppercase[row]}{column + 1}"
+                                row_name = plate_info["rows"][row]["name"]
+                                col_name = plate_info["columns"][column]["name"]
+                                label = f"{row_name}{col_name}"
                                 labels.append(label)
                                 # Well bounding box, with no label
                                 outlines.append(

--- a/ome_zarr/napari.py
+++ b/ome_zarr/napari.py
@@ -6,8 +6,8 @@ It implements the ``napari_get_reader`` hook specification, (to create a reader 
 
 import logging
 import warnings
-from typing import Any, Callable, Dict, Iterator, List, Optional
 from string import ascii_uppercase
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from .data import CHANNEL_DIMENSION
 from .io import parse_url
@@ -115,7 +115,7 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                             "anchor": "lower_left",
                             "translation": [5, 5],
                         }
-                        rv: LayerData = (
+                        shapes: LayerData = (
                             outlines,
                             {
                                 "edge_color": "white",
@@ -126,7 +126,7 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                             },
                             "shapes",
                         )
-                        results.append(rv)
+                        results.append(shapes)
 
         return results
 

--- a/ome_zarr/napari.py
+++ b/ome_zarr/napari.py
@@ -97,14 +97,15 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                                 x2 = int((column + 1) * well_width)
                                 y1 = int(row * well_height)
                                 y2 = int((row + 1) * well_height)
-                                # Since napari will only place labels 'outside' a bounding box
-                                # we have a line along top of Well, with label below
+                                # Since napari will only place labels 'outside' a
+                                # bounding box we have a line
+                                # along top of Well, with label below
                                 outlines.append([[y1, x1], [y1, x2]])
                                 label = f"{ascii_uppercase[row]}{column + 1}"
                                 labels.append(label)
                                 # Well bounding box, with no label
                                 outlines.append(
-                                    [[y1, x1], [y2, x1], [y2, x2], [y1, x2],]
+                                    [[y1, x1], [y2, x1], [y2, x2], [y1, x2]]
                                 )
                                 labels.append("")
                         text_parameters = {

--- a/ome_zarr/napari.py
+++ b/ome_zarr/napari.py
@@ -85,8 +85,8 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                         plate_info = metadata["metadata"]["plate"]
                         plate_width = shape[-1]
                         plate_height = shape[-2]
-                        rows = plate_info['rows']
-                        columns = plate_info['columns']
+                        rows = plate_info["rows"]
+                        columns = plate_info["columns"]
                         well_width = plate_width / columns
                         well_height = plate_height / rows
                         labels = []
@@ -99,31 +99,32 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                                 y2 = int((row + 1) * well_height)
                                 # Since napari will only place labels 'outside' a bounding box
                                 # we have a line along top of Well, with label below
-                                outlines.append([[y1,  x1], [y1,  x2]])
-                                label = f'{ascii_uppercase[row]}{column + 1}'
+                                outlines.append([[y1, x1], [y1, x2]])
+                                label = f"{ascii_uppercase[row]}{column + 1}"
                                 labels.append(label)
                                 # Well bounding box, with no label
-                                outlines.append([
-                                    [ y1,  x1],
-                                    [ y2,  x1],
-                                    [ y2,  x2],
-                                    [ y1,  x2],
-                                ])
-                                labels.append('')
+                                outlines.append(
+                                    [[y1, x1], [y2, x1], [y2, x2], [y1, x2],]
+                                )
+                                labels.append("")
                         text_parameters = {
-                            'text': '{well}',
-                            'size': 12,
-                            'color': 'white',
-                            'anchor': 'lower_left',
-                            'translation': [5, 5],
+                            "text": "{well}",
+                            "size": 12,
+                            "color": "white",
+                            "anchor": "lower_left",
+                            "translation": [5, 5],
                         }
-                        rv: LayerData = (outlines,{
-                            'edge_color': 'white',
-                            'face_color': 'transparent',
-                            'name': 'Well Labels',
-                            'text': text_parameters,
-                            'properties': {'well' : labels}
-                        }, "shapes")
+                        rv: LayerData = (
+                            outlines,
+                            {
+                                "edge_color": "white",
+                                "face_color": "transparent",
+                                "name": "Well Labels",
+                                "text": text_parameters,
+                                "properties": {"well": labels},
+                            },
+                            "shapes",
+                        )
                         results.append(rv)
 
         return results

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -356,13 +356,15 @@ class Plate(Spec):
         stitched full-resolution images.
         """
         self.plate_data = self.lookup("plate", {})
-        print('self.plate_data', self.plate_data)
+        print("self.plate_data", self.plate_data)
         self.rows = self.plate_data.get("rows", 0)
         self.cols = self.plate_data.get("columns", 0)
 
         # FIXME: shouldn't hard code
         self.acquisitions = ["0"]
-        self.fields = ["Field_1",]
+        self.fields = [
+            "Field_1",
+        ]
         self.row_labels = ascii_uppercase[0 : self.rows]
         self.col_labels = range(1, self.cols + 1)
 
@@ -398,7 +400,7 @@ class Plate(Spec):
             longest_side = longest_side // 2
             target_level += 1
 
-        print('target_level', target_level)
+        print("target_level", target_level)
         # Assume this matches the sizes of the downsampled images in each field
         # Probably better to look it up - Assumed to be same for every image
         tile_sizes = []
@@ -443,7 +445,7 @@ class Plate(Spec):
         # for level in range(5):
 
         for level in [target_level]:
-            print('level', level)
+            print("level", level)
             t_stacks = []
             for t in range(size_t):
                 c_stacks = []
@@ -465,14 +467,7 @@ class Plate(Spec):
         # Use the first image's metadata for viewing the whole Plate
         node.metadata = image_node.metadata
 
-        node.metadata.update({
-            "metadata": {
-                "plate": {
-                    "rows": rows,
-                    "columns": cols,
-                }
-            }
-        })
+        node.metadata.update({"metadata": {"plate": {"rows": rows, "columns": cols,}}})
 
 
 class Reader:

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -349,6 +349,7 @@ class Plate(Spec):
     def __init__(self, node: Node) -> None:
         super().__init__(node)
         # TODO: start checking metadata version
+<<<<<<< HEAD
         self.plate_data = self.lookup("plate", {})
         self.rows = self.plate_data.get("rows", 0)
         self.cols = self.plate_data.get("columns", 0)
@@ -358,6 +359,8 @@ class Plate(Spec):
         self.fields = ["Field_1", "Field_2", "Field_3", "Field_4"]
         self.row_labels = ascii_uppercase[0 : self.rows]
         self.col_labels = range(1, self.cols + 1)
+=======
+>>>>>>> f316d76... Calculate optimal resolution level so stitched plate < 3000 pixels
 
         self.get_pyramid_lazy(node)
 
@@ -366,14 +369,29 @@ class Plate(Spec):
         Return a pyramid of dask data, where the highest resolution is the
         stitched full-resolution images.
         """
+        self.plate_data = self.lookup("plate", {})
+        print('self.plate_data', self.plate_data)
+        self.rows = self.plate_data.get("rows", 0)
+        self.cols = self.plate_data.get("columns", 0)
 
+<<<<<<< HEAD
         run = "0"
+=======
+        # FIXME: shouldn't hard code
+        self.acquisitions = ["0"]
+        self.fields = ["Field_1",]
+        self.row_labels = ascii_uppercase[0 : self.rows]
+        self.col_labels = range(1, self.cols + 1)
+
+        # TODO: support more Acquisitions - just 1st for now
+        run = self.acquisitions[0]
+>>>>>>> f316d76... Calculate optimal resolution level so stitched plate < 3000 pixels
         rows = self.rows
         cols = self.cols
         row_labels = self.row_labels
 
         # Get the first image...
-        path = f"{run}/A/1/Field_1"
+        path = f"{run}/{row_labels[0]}/{self.col_labels[0]}/{self.fields[0]}"
         image_zarr = self.zarr.create(path)
         image_node = Node(image_zarr, node)
 
@@ -386,6 +404,19 @@ class Plate(Spec):
 
         size_x = img_shape[3]
         size_y = img_shape[4]
+
+        # FIXME - if only returning a single stiched plate (not a pyramid)
+        # need to decide optimal size. E.g. longest side < 3000
+        TARGET_SIZE = 3000
+        plate_width = cols * size_x
+        plate_height = cols * size_y
+        longest_side = max(plate_width, plate_height)
+        target_level = 0
+        while longest_side > TARGET_SIZE:
+            longest_side = longest_side // 2
+            target_level += 1
+
+        print('target_level', target_level)
         # Assume this matches the sizes of the downsampled images in each field
         # Probably better to look it up - Assumed to be same for every image
         tile_sizes = []
@@ -428,8 +459,9 @@ class Plate(Spec):
 
         # This should create a pyramid of levels, but causes seg faults!
         # for level in range(5):
-        for level in [0]:
-            print("level", level)
+
+        for level in [target_level]:
+            print('level', level)
             t_stacks = []
             for t in range(size_t):
                 c_stacks = []

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -448,7 +448,7 @@ class Plate(Spec):
         # Use the first image's metadata for viewing the whole Plate
         node.metadata = image_node.metadata
 
-        node.metadata.update({"metadata": {"plate": {"rows": rows, "columns": cols,}}})
+        node.metadata.update({"metadata": {"plate": {"rows": rows, "columns": cols}}})
 
 
 class Reader:

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -423,7 +423,7 @@ class Plate(Spec):
         print("plate_data", self.plate_data)
         self.rows = self.plate_data.get("rows")
         self.columns = self.plate_data.get("columns")
-        self.acquisitions = self.plate_data.get("acquisitions", [{"path": "0"}])
+        self.acquisitions = self.plate_data.get("acquisitions")
         first_field = "0"
         row_names = [row["name"] for row in self.rows]
         col_names = [col["name"] for col in self.columns]
@@ -431,8 +431,14 @@ class Plate(Spec):
         well_paths = [well["path"] for well in self.plate_data.get("wells")]
         well_paths.sort()
 
-        # TODO: support more Acquisitions - just 1st for now
-        run = self.acquisitions[0]["path"].strip("/")
+        run = ""
+        # TEMP - support acquisition path in plate/acq/row/col hierarchy
+        # remove when we don't want to support dev versions of ome-zarr plate data
+        if len(self.acquisitions) > 0:
+            run = self.acquisitions[0].get("path", "")
+            if len(run) > 0 and not run.endswith("/"):
+                run = run + "/"
+
         row_count = len(self.rows)
         column_count = len(self.columns)
         # Get the first image...
@@ -470,7 +476,7 @@ class Plate(Spec):
         def get_tile(tile_name: str) -> np.ndarray:
             """ tile_name is 'level,z,c,t,row,col' """
             level, row, col = [int(n) for n in tile_name.split(",")]
-            path = f"{run}/{row_names[row]}/{col_names[col]}/{first_field}/{level}"
+            path = f"{run}{row_names[row]}/{col_names[col]}/{first_field}/{level}"
             print(f"LOADING tile... {path}")
 
             try:

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -448,6 +448,7 @@ class Plate(Spec):
         # Use the first image's metadata for viewing the whole Plate
         node.metadata = image_node.metadata
 
+        # "metadata" dict gets added to each 'plate' layer in napari
         node.metadata.update({"metadata": {"plate": {"rows": rows, "columns": cols}}})
 
 

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -348,20 +348,6 @@ class Plate(Spec):
 
     def __init__(self, node: Node) -> None:
         super().__init__(node)
-        # TODO: start checking metadata version
-<<<<<<< HEAD
-        self.plate_data = self.lookup("plate", {})
-        self.rows = self.plate_data.get("rows", 0)
-        self.cols = self.plate_data.get("columns", 0)
-
-        # FIXME: shouldn't hard code
-        self.acquisitions = ["PlateAcquisition Name 0", "0"]
-        self.fields = ["Field_1", "Field_2", "Field_3", "Field_4"]
-        self.row_labels = ascii_uppercase[0 : self.rows]
-        self.col_labels = range(1, self.cols + 1)
-=======
->>>>>>> f316d76... Calculate optimal resolution level so stitched plate < 3000 pixels
-
         self.get_pyramid_lazy(node)
 
     def get_pyramid_lazy(self, node: Node) -> None:
@@ -374,9 +360,6 @@ class Plate(Spec):
         self.rows = self.plate_data.get("rows", 0)
         self.cols = self.plate_data.get("columns", 0)
 
-<<<<<<< HEAD
-        run = "0"
-=======
         # FIXME: shouldn't hard code
         self.acquisitions = ["0"]
         self.fields = ["Field_1",]
@@ -385,7 +368,6 @@ class Plate(Spec):
 
         # TODO: support more Acquisitions - just 1st for now
         run = self.acquisitions[0]
->>>>>>> f316d76... Calculate optimal resolution level so stitched plate < 3000 pixels
         rows = self.rows
         cols = self.cols
         row_labels = self.row_labels
@@ -482,16 +464,15 @@ class Plate(Spec):
         node.data = pyramid
         # Use the first image's metadata for viewing the whole Plate
         node.metadata = image_node.metadata
-        visibility = True
-        for acq in self.acquisitions:
-            for row in self.row_labels:
-                for col in self.col_labels:
-                    for field in self.fields:
-                        path = f"{acq}/{row}/{col}/{field}"
-                        child_zarr = self.zarr.create(path)
-                        if child_zarr.exists():
-                            node.add(child_zarr, visibility=visibility)
-                            visibility = False
+
+        node.metadata.update({
+            "metadata": {
+                "plate": {
+                    "rows": rows,
+                    "columns": cols,
+                }
+            }
+        })
 
 
 class Reader:

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -359,9 +359,8 @@ class Plate(Spec):
         print("self.plate_data", self.plate_data)
         self.rows = self.plate_data.get("rows", 0)
         self.cols = self.plate_data.get("columns", 0)
+        self.acquisitions = self.plate_data.get('plateAcquisitions', [{"path": "0"}])
 
-        # FIXME: shouldn't hard code
-        self.acquisitions = ["0"]
         self.fields = [
             "Field_1",
         ]
@@ -369,7 +368,7 @@ class Plate(Spec):
         self.col_labels = range(1, self.cols + 1)
 
         # TODO: support more Acquisitions - just 1st for now
-        run = self.acquisitions[0]
+        run = self.acquisitions[0]['path']
         rows = self.rows
         cols = self.cols
         row_labels = self.row_labels

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -449,7 +449,7 @@ class Plate(Spec):
         node.metadata = image_node.metadata
 
         # "metadata" dict gets added to each 'plate' layer in napari
-        node.metadata.update({"metadata": {"plate": {"rows": rows, "columns": cols}}})
+        node.metadata.update({"metadata": {"plate": self.plate_data}})
 
 
 class Reader:

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -353,10 +353,11 @@ class Plate(Spec):
 
         # FIXME: shouldn't hard code
         self.acquisitions = ["PlateAcquisition Name 0"]
-        self.fields = ["Field_1"]
+        self.fields = ["Field_1", "Field_2", "Field_3", "Field_4"]
         self.row_labels = ascii_uppercase[0 : self.rows]
         self.col_labels = range(1, self.cols + 1)
 
+        visibility = True
         for acq in self.acquisitions:
             for row in self.row_labels:
                 for col in self.col_labels:
@@ -364,7 +365,8 @@ class Plate(Spec):
                         path = f"{acq}/{row}/{col}/{field}"
                         child_zarr = self.zarr.create(path)
                         if child_zarr.exists():
-                            node.add(child_zarr, visibility=True)
+                            node.add(child_zarr, visibility=visibility)
+                            visibility = False
 
 
 class Reader:

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -359,7 +359,7 @@ class Plate(Spec):
         print("self.plate_data", self.plate_data)
         self.rows = self.plate_data.get("rows", 0)
         self.cols = self.plate_data.get("columns", 0)
-        self.acquisitions = self.plate_data.get('plateAcquisitions', [{"path": "0"}])
+        self.acquisitions = self.plate_data.get("plateAcquisitions", [{"path": "0"}])
 
         self.fields = [
             "Field_1",
@@ -368,7 +368,7 @@ class Plate(Spec):
         self.col_labels = range(1, self.cols + 1)
 
         # TODO: support more Acquisitions - just 1st for now
-        run = self.acquisitions[0]['path']
+        run = self.acquisitions[0]["path"]
         rows = self.rows
         cols = self.cols
         row_labels = self.row_labels
@@ -383,10 +383,7 @@ class Plate(Spec):
 
         img_pyramid_shapes = [d.shape for d in image_node.data]
 
-        print('img_pyramid_shapes', img_pyramid_shapes)
-        size_t = img_shape[0]
-        size_c = img_shape[1]
-        size_z = img_shape[2]
+        print("img_pyramid_shapes", img_pyramid_shapes)
 
         size_y = img_shape[3]
         size_x = img_shape[4]


### PR DESCRIPTION
Test sets:

 - https://minio-dev.openmicroscopy.org/idr/idr0033-rohban-pathways/41744_illum_corrected/pr_43/5966.zarr (big plate, 9 fields per well)
 - https://minio-dev.openmicroscopy.org/idr/idr0002-heriche-condensation/plate1_1_013/pr_43/422.zarr (multi-T)
 - https://minio-dev.openmicroscopy.org/idr/idr0004-thorpe-rad52/P101/pr_43/1751.zarr (sparse plate)
 - https://minio-dev.openmicroscopy.org/idr/idr0001-graml-sysgro/JL_120731_S6A/pr_45/2551.zarr (multi-Z, multiple acquisitions)

To test: Open via e.g:
```
$ napari https://minio-dev.openmicroscopy.org/idr/idr0002-heriche-condensation/plate1_1_013/pr_43/422.zarr 
```
 - Plates should be displayed in a grid with Well labels overlaid.
 - You can view an individual Well by appending e.g. `/A/1/` to the URL (actually, this will only work with the last plate above. The others were generated with an acquisition level in the hierarchy and need to add e.g. `0/A/1` or `Run 422/A/1` for idr0002.

<img width="1267" alt="Screenshot 2020-10-23 at 07 18 04" src="https://user-images.githubusercontent.com/900055/96963549-b96c5500-1500-11eb-8627-ede32562d675.png">