### PR TITLE
Add Framework :: napari trove classifier to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: BSD License",
+        "Framework :: napari",
     ],
     entry_points={
         "console_scripts": ["ome_zarr = ome_zarr.cli:main"],


### PR DESCRIPTION
This will help napari discover this package as a plugin from the UI, among other things.

Ref:
https://github.com/pypa/trove-classifiers/pull/53