### PR TITLE
Cap napari extra requirement depending on the Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ setup(
         "napari.plugin": ["ome_zarr = ome_zarr.napari"],
         "pytest11": ["napari-conftest = napari.conftest"],
     },
-    extras_require={"napari": ["napari"]},
+    extras_require={
+        "napari:python_version>='3.7'": ["napari"],
+        "napari:python_version<'3.7'": ["napari<0.4.0"],
+    },
     tests_require=["pytest"],
 )

--- a/tests/test_napari.py
+++ b/tests/test_napari.py
@@ -50,7 +50,7 @@ class TestNapari:
         self.assert_layers(layers, False, True)
 
     @pytest.mark.skipif(
-        not sys.platform.startswith("darwin"),
+        not sys.platform.startswith("darwin") or sys.version_info < (3, 7),
         reason="Qt builds are failing on Windows and Ubuntu",
     )
     def test_viewer(self, make_test_viewer):
@@ -65,7 +65,7 @@ class TestNapari:
 
         # Set canvas size to target amount
         viewer.window.qt_viewer.view.canvas.size = (800, 600)
-        list(viewer.window.qt_viewer.layer_to_visual.values())[0].on_draw(None)
+        viewer.window.qt_viewer.on_draw(None)
 
         # Check that current level is first large enough to fill the canvas with
         # a greater than one pixel depth


### PR DESCRIPTION
See https://github.com/ome/ome-zarr-py/pull/57#issuecomment-718708701

This attempts at solving the compatibility issue by adding environment markers to `extra_require`.