### PR TITLE
Add support for label properties in zattrs and plugin

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           channels: conda-forge,ome

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           channels: conda-forge,ome

--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -155,11 +155,14 @@ def create_zarr(
         write_multiscale(labels, label_grp)
 
         colors = []
+        properties = []
         for x in range(1, 9):
             rgba = [randrange(0, 256) for i in range(4)]
             colors.append({"label-value": x, "rgba": rgba})
+            properties.append({"label-value": x, "class": f"class {x}"})
         label_grp.attrs["image-label"] = {
             "version": "0.1",
             "colors": colors,
+            "properties": properties,
             "source": {"image": "../../"},
         }

--- a/ome_zarr/napari.py
+++ b/ome_zarr/napari.py
@@ -62,6 +62,24 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                     layer_type = "labels"
                     if "colormap" in metadata:
                         del metadata["colormap"]
+                    if "properties" in metadata:
+                        props = metadata["properties"]
+                        reader_props = {}
+                        label_indices = list(props.keys())
+                        reader_props["index"] = label_indices
+
+                        # properties may be ragged, so we need to know all possible properties
+                        all_keys = set()
+                        for index in label_indices:
+                            all_keys = all_keys.union(set(props[index].keys()))
+
+                        # napari expects lists of equal length so we must fill with None
+                        for prop_key in all_keys:
+                            reader_props[prop_key] = [
+                                props[i][prop_key] if prop_key in props[i] else "None"
+                                for i in label_indices
+                            ]
+                        metadata['properties'] = reader_props
 
                 elif shape[CHANNEL_DIMENSION] > 1:
                     metadata["channel_axis"] = CHANNEL_DIMENSION

--- a/ome_zarr/napari.py
+++ b/ome_zarr/napari.py
@@ -76,7 +76,7 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                         # napari expects lists of equal length so we must fill with None
                         for prop_key in all_keys:
                             reader_props[prop_key] = [
-                                props[i][prop_key] if prop_key in props[i] else "None"
+                                props[i][prop_key] if prop_key in props[i] else None
                                 for i in label_indices
                             ]
                         metadata['properties'] = reader_props

--- a/ome_zarr/napari.py
+++ b/ome_zarr/napari.py
@@ -6,7 +6,7 @@ It implements the ``napari_get_reader`` hook specification, (to create a reader 
 
 import logging
 import warnings
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set
 
 from .data import CHANNEL_DIMENSION
 from .io import parse_url
@@ -68,7 +68,8 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                         label_indices = list(props.keys())
                         reader_props["index"] = label_indices
 
-                        # properties may be ragged, so we need to know all possible properties
+                        # properties may be ragged, so we need all possible properties
+                        all_keys: Set[str]
                         all_keys = set()
                         for index in label_indices:
                             all_keys = all_keys.union(set(props[index].keys()))
@@ -79,7 +80,7 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                                 props[i][prop_key] if prop_key in props[i] else None
                                 for i in label_indices
                             ]
-                        metadata['properties'] = reader_props
+                        metadata["properties"] = reader_props
 
                 elif shape[CHANNEL_DIMENSION] > 1:
                     metadata["channel_axis"] = CHANNEL_DIMENSION

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -216,6 +216,14 @@ class Label(Spec):
                 except Exception as e:
                     LOGGER.error(f"invalid color - {color}: {e}")
 
+        properties: Dict[int, Dict[str, str]] = {}
+        props_list = image_label.get('properties', [])
+        if props_list:
+            for props in props_list:
+                label_val = props['label-value']
+                del props['label-value']
+                properties[label_val] =  props
+
         # TODO: a metadata transform should be provided by specific impls.
         name = self.zarr.basename()
         node.metadata.update(
@@ -223,6 +231,7 @@ class Label(Spec):
                 "visible": node.visible,
                 "name": name,
                 "color": colors,
+                "properties": properties,
                 "metadata": {"image": self.lookup("image", {}), "path": name},
             }
         )

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -217,12 +217,12 @@ class Label(Spec):
                     LOGGER.error(f"invalid color - {color}: {e}")
 
         properties: Dict[int, Dict[str, str]] = {}
-        props_list = image_label.get('properties', [])
+        props_list = image_label.get("properties", [])
         if props_list:
             for props in props_list:
-                label_val = props['label-value']
+                label_val = props["label-value"]
                 properties[label_val] = dict(props)
-                del properties[label_val]['label-value']
+                del properties[label_val]["label-value"]
 
         # TODO: a metadata transform should be provided by specific impls.
         name = self.zarr.basename()
@@ -235,12 +235,8 @@ class Label(Spec):
             }
         )
         if properties:
-            node.metadata.update(
-                {
-                    "properties": properties
+            node.metadata.update({"properties": properties})
 
-                }
-            )
 
 class Multiscales(Spec):
     @staticmethod

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -221,8 +221,8 @@ class Label(Spec):
         if props_list:
             for props in props_list:
                 label_val = props['label-value']
-                del props['label-value']
-                properties[label_val] =  props
+                properties[label_val] = dict(props)
+                del properties[label_val]['label-value']
 
         # TODO: a metadata transform should be provided by specific impls.
         name = self.zarr.basename()
@@ -231,10 +231,16 @@ class Label(Spec):
                 "visible": node.visible,
                 "name": name,
                 "color": colors,
-                "properties": properties,
                 "metadata": {"image": self.lookup("image", {}), "path": name},
             }
         )
+        if properties:
+            node.metadata.update(
+                {
+                    "properties": properties
+
+                }
+            )
 
 
 class Multiscales(Spec):

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -242,7 +242,6 @@ class Label(Spec):
                 }
             )
 
-
 class Multiscales(Spec):
     @staticmethod
     def matches(zarr: BaseZarrLocation) -> bool:

--- a/tests/test_napari.py
+++ b/tests/test_napari.py
@@ -13,7 +13,7 @@ class TestNapari:
         self.path = tmpdir.mkdir("data")
         create_zarr(str(self.path), astronaut, "astronaut")
 
-    def assert_layers(self, layers, visible_1, visible_2):
+    def assert_layers(self, layers, visible_1, visible_2, label_props=None):
         # TODO: check name
 
         assert len(layers) == 2
@@ -27,6 +27,8 @@ class TestNapari:
 
         data, metadata, layer_type = self.assert_layer(label)
         assert visible_2 == metadata["visible"]
+        if label_props:
+            assert label_props == metadata["properties"]
 
     def assert_layer(self, layer_data):
         data, metadata, layer_type = layer_data
@@ -47,7 +49,11 @@ class TestNapari:
     def test_label(self):
         filename = str(self.path.join("labels", "astronaut"))
         layers = napari_get_reader(filename)()
-        self.assert_layers(layers, False, True)
+        properties = {
+            "index": [i for i in range(1, 9)],
+            "class": [f"class {i}" for i in range(1, 9)],
+        }
+        self.assert_layers(layers, False, True, properties)
 
     @pytest.mark.skipif(
         not sys.platform.startswith("darwin") or sys.version_info < (3, 7),


### PR DESCRIPTION
Add support for label properties of the form

```
        "properties": [
            {
                "label-value": 1,
                "class": "Urban",
                "m2": "100"
            },
            {
                "label-value": 2,
                "class": "Water",
                "m2": "200"

            },
            {
                "label-value": 3,
                "class": "Deciduous Woody Horticulture"

            },
            {
                "label-value": 4,
                "class": "Evergreen Woody Horticulture"

            },
            ...
```
as discussed in #60 .

Read these properties in as dictionary of `label-value` to properties.

Transform these properties in the napari reader to:
```
{
    "index": [
        1,
        2,
        3,
        4,
       ...
    ],
    "class": [
        "Urban",
        "Water",
        "Deciduous Woody Horticulture",
        "Evergreen Woody Horticulture",
        ...
    ],
    "m2": [
        "100",
        "200",
        "None",
        "None",
        "None",
       ...
    ]
}
```

This is the very first pass, so would appreciate feedback on the general approach before I move on to updating spec, documentation, tests, etc.

We probably also wish to consider what types of property keys and values we want to accept. 