### PR TITLE
csv to label properties

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           channels: conda-forge,ome

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           channels: conda-forge,ome

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,41 @@ the metadata::
 
     $ napari '/tmp/6001240.zarr/0'
 
+csv to labels
+=============
+
+The `csv_to_labels` command uses a CSV file to add key:value properties to labels
+under an OME-Zarr Image or Plate.
+
+The OME-Zarr labels metadata must already contain a `properties`
+list of `{key:value}` objects, each with a unique key:ID. This key is `omero:shapeId`
+in the example below.
+
+This ID can be used to identify a single row of the CSV table by specifying the name of
+a column with unique values, e.g. `shape_id` below.
+This row is used to add additional column_name:value data to the label properties.
+
+You also need to specify which columns from the CSV to use, e.g. `"area,X,Y,Width,Height"`.
+You can also specify the column types (as in https://github.com/ome/omero-metadata/)
+to specify the data-type for each column (string by default).
+
+ - `d`: `DoubleColumn`, for floating point numbers
+ - `l`: `LongColumn`, for integer numbers
+ - `s`: `StringColumn`, for text
+ - `b`: `BoolColumn`, for true/false
+
+Use e.g. `#d` as a suffix in the column name to denote a `float` column, no spaces etc:
+```
+"area#d,label_text#s,Width#l,Height#l"
+```
+
+For example, to take values from columns named `area`, `label_text`, `Width` and `Height`
+within a CSV file named `labels_data.csv` with an ID column named `shape_id` and add these
+values to label properties with an ID key of `omero:shapeId` in an Image or Plate named `123.zarr`::
+
+    ome_zarr csv_to_labels labels_data.csv shape_id "area#d,label_text#s,Width#l,Height#l" 123.zarr omero:shapeId```
+
+
 Release process
 ---------------
 

--- a/ome_zarr/cli.py
+++ b/ome_zarr/cli.py
@@ -4,6 +4,7 @@ import logging
 import sys
 from typing import List
 
+from .csv import csv_to_zarr
 from .data import astronaut, coins, create_zarr
 from .scale import Scaler
 from .utils import download as zarr_download
@@ -62,6 +63,14 @@ def scale(args: argparse.Namespace) -> None:
         method=args.method,
     )
     scaler.scale(args.input_array, args.output_directory)
+
+
+def csv_to_labels(args: argparse.Namespace) -> None:
+    """Adds csv data to labels properties"""
+
+    print("csv_to_labels", args.csv_path, args.zarr_path)
+
+    csv_to_zarr(args.csv_path, args.csv_id, args.csv_keys, args.zarr_path, args.zarr_id)
 
 
 def main(args: List[str] = None) -> None:
@@ -125,6 +134,25 @@ def main(args: List[str] = None) -> None:
     parser_scale.add_argument("--downscale", type=int, default=2)
     parser_scale.add_argument("--max_layer", type=int, default=4)
     parser_scale.set_defaults(func=scale)
+
+    # csv to label properties
+    parser_csv_to_labels = subparsers.add_parser("csv_to_labels")
+    parser_csv_to_labels.add_argument("csv_path", help="path to csv file")
+    parser_csv_to_labels.add_argument(
+        "csv_id",
+        help="csv column name containing ID for identifying label properties to update",
+    )
+    parser_csv_to_labels.add_argument(
+        "csv_keys", help="Comma-separated list of columns to read from csv to zarr"
+    )
+    parser_csv_to_labels.add_argument(
+        "zarr_path", help="path to local zarr plate or image"
+    )
+    parser_csv_to_labels.add_argument(
+        "zarr_id",
+        help="Labels properties key. Values should match csv_id column values",
+    )
+    parser_csv_to_labels.set_defaults(func=csv_to_labels)
 
     ns = parser.parse_args(args)
 

--- a/ome_zarr/csv.py
+++ b/ome_zarr/csv.py
@@ -32,7 +32,20 @@ def csv_to_zarr(
     csv_path: str, csv_id: str, csv_keys: str, zarr_path: str, zarr_id: str
 ) -> None:
     """
-    - URL of the form: path/to/ID.zarr/
+    Add keys:values from a CSV file to the label properties of a Plate.
+
+    For each labels properties dict in the Plate at zarr_path, we pick the value
+    of the property named zarr_id. This value should match a value from a row of the
+    CSV table, with the column name given by csv_id. The row values under columns
+    given by csv_keys (e.g. "col1,col2,col5") will be added to the label properties.
+    Column types can be specified with #d (float), #l (int) or #b (boolean)
+    e.g. "col1#d,col2#l,col5"
+
+    @param csv_path         Path to the CSV file
+    @param csv_id           Name of the CSV column to use as a row ID
+    @param csv_keys         Names of the columns to add to properties.
+    @param zarr_path        Path to the ome-zarr Plate that has labels with properties
+    @param zarr_id          Key of the label property to use for picking csv row
     """
 
     # Use #d to denote double etc.
@@ -49,7 +62,7 @@ def csv_to_zarr(
     csv_columns = None
     id_column = None
 
-    props_by_id: Dict[str, Dict] = {}
+    props_by_id: Dict[Union[str, int], Dict] = {}
 
     with open(csv_path, newline="") as csvfile:
         row_reader = csv.reader(csvfile, delimiter=",")
@@ -76,7 +89,20 @@ def csv_to_zarr(
     dict_to_zarr(props_by_id, zarr_path, zarr_id)
 
 
-def dict_to_zarr(props_to_add: Dict, zarr_path: str, zarr_id: str) -> None:
+def dict_to_zarr(
+    props_to_add: Dict[Union[str, int], Dict], zarr_path: str, zarr_id: str
+) -> None:
+    """
+    Add keys:values to the label properties of a Plate.
+
+    For each labels properties dict in the Plate at zarr_path, we pick the value of
+    the property named zarr_id. This value should match a key of the props_to_add
+    Dict to find a Dict who's keys and values are added to the label properties.
+
+    @param props_to_add     Dict of id: {key:value}. id matches values of zarr_id prop
+    @param zarr_path        Path to the ome-zarr that has labels with properties
+    @param zarr_id          Key of label property, where value is key of props_to_add
+    """
 
     zarr = parse_url(zarr_path)
     if not zarr:

--- a/ome_zarr/csv.py
+++ b/ome_zarr/csv.py
@@ -1,0 +1,86 @@
+import csv
+import os
+from typing import Dict
+
+from zarr.convenience import open as zarr_open
+
+from .io import parse_url
+
+
+def csv_to_zarr(
+    csv_path: str, csv_id: str, csv_keys: str, zarr_path: str, zarr_id: str
+) -> None:
+    """
+    - URL of the form: path/to/ID.zarr/
+    """
+
+    cols_to_read = csv_keys.split(",")
+
+    csv_columns = None
+    id_column = None
+
+    props_by_id: Dict[str, Dict] = {}
+
+    with open(csv_path, newline="") as csvfile:
+        row_reader = csv.reader(csvfile, delimiter=",")
+        for row in row_reader:
+            # For the first row, find the Column that has the ID
+            if csv_columns is None:
+                csv_columns = row
+                if csv_id not in csv_columns:
+                    raise ValueError(
+                        f"csv_id '{csv_id}' should match a"
+                        f"csv column name: {csv_columns}"
+                    )
+                id_column = csv_columns.index(csv_id)
+                print("id_column", id_column)
+            else:
+                row_id = row[id_column]
+                row_props = {}
+                for col_name, value in zip(csv_columns, row):
+                    if col_name in cols_to_read:
+                        row_props[col_name] = value
+                props_by_id[row_id] = row_props
+
+    dict_to_zarr(props_by_id, zarr_path, zarr_id)
+
+
+def dict_to_zarr(props_to_add: Dict, zarr_path: str, zarr_id: str) -> None:
+
+    zarr = parse_url(zarr_path)
+    print("zarr", zarr)
+    if not zarr:
+        print(f"No zarr found at {zarr_path}")
+        return
+
+    print(zarr.root_attrs)
+    plate_attrs = zarr.root_attrs.get("plate", None)
+    if plate_attrs is None:
+        print(f"zarr_path must be to plate.zarr. No 'plate' in {zarr_path}.zattrs")
+    well_paths = [w["path"] for w in plate_attrs.get("wells", [])]
+
+    # look for 'label/0' under the first field of each Well
+    field = "0"
+    for well in well_paths:
+        path_to_labels = os.path.join(zarr_path, well, field, "labels", "0")
+        print("path_to_labels", path_to_labels)
+
+        label_group = zarr_open(path_to_labels)
+        attrs = label_group.attrs.asdict()
+        properties = attrs.get("image-label", {}).get("properties")
+        if properties is None:
+            continue
+
+        print("attrs", attrs)
+        attrs["test"] = True
+
+        for props_dict in properties:
+            props_id = str(props_dict.get(zarr_id))
+            print("props_id", props_id)
+
+            # Look for key-value pairs to add to these properties
+            if props_id in props_to_add:
+                for key, value in props_to_add[props_id].items():
+                    props_dict[key] = value
+
+        label_group.attrs.update(attrs)

--- a/ome_zarr/csv.py
+++ b/ome_zarr/csv.py
@@ -1,10 +1,31 @@
 import csv
 import os
-from typing import Dict
+from typing import Dict, Union
 
 from zarr.convenience import open as zarr_open
 
 from .io import parse_url
+
+# d: DoubleColumn, for floating point numbers
+# l: LongColumn, for integer numbers
+# s: StringColumn, for text
+# b: BoolColumn, for true/false
+COLUMN_TYPES = ["d", "l", "s", "b"]
+
+
+def parse_csv_value(value: str, col_type: str) -> Union[str, float, int, bool]:
+    """Parse string value from csv, according to COLUMN_TYPES"""
+    rv: Union[str, float, int, bool] = value
+    try:
+        if col_type == "d":
+            rv = float(value)
+        elif col_type == "l":
+            rv = int(round(float(value)))
+        elif col_type == "b":
+            rv = bool(value)
+    except ValueError:
+        pass
+    return rv
 
 
 def csv_to_zarr(
@@ -14,7 +35,16 @@ def csv_to_zarr(
     - URL of the form: path/to/ID.zarr/
     """
 
-    cols_to_read = csv_keys.split(",")
+    # Use #d to denote double etc.
+    # e.g. "area (pixels)#d,well_label#s,Width#l,Height#l"
+    cols_types_by_name: Dict[str, str] = {}
+    for col_name_type in csv_keys.split(","):
+        if "#" in col_name_type:
+            col_name, col_type = col_name_type.rsplit("#", 1)
+            col_type = col_type if col_type in COLUMN_TYPES else "s"
+            cols_types_by_name[col_name] = col_type
+        else:
+            cols_types_by_name[col_name_type] = "s"
 
     csv_columns = None
     id_column = None
@@ -33,13 +63,14 @@ def csv_to_zarr(
                         f"csv column name: {csv_columns}"
                     )
                 id_column = csv_columns.index(csv_id)
-                print("id_column", id_column)
             else:
                 row_id = row[id_column]
                 row_props = {}
                 for col_name, value in zip(csv_columns, row):
-                    if col_name in cols_to_read:
-                        row_props[col_name] = value
+                    if col_name in cols_types_by_name:
+                        row_props[col_name] = parse_csv_value(
+                            value, cols_types_by_name[col_name]
+                        )
                 props_by_id[row_id] = row_props
 
     dict_to_zarr(props_by_id, zarr_path, zarr_id)
@@ -48,22 +79,20 @@ def csv_to_zarr(
 def dict_to_zarr(props_to_add: Dict, zarr_path: str, zarr_id: str) -> None:
 
     zarr = parse_url(zarr_path)
-    print("zarr", zarr)
     if not zarr:
-        print(f"No zarr found at {zarr_path}")
-        return
+        raise Exception(f"No zarr found at {zarr_path}")
 
-    print(zarr.root_attrs)
     plate_attrs = zarr.root_attrs.get("plate", None)
     if plate_attrs is None:
-        print(f"zarr_path must be to plate.zarr. No 'plate' in {zarr_path}.zattrs")
+        raise Exception(
+            f"zarr_path must be to plate.zarr. No 'plate' in {zarr_path}.zattrs"
+        )
     well_paths = [w["path"] for w in plate_attrs.get("wells", [])]
 
     # look for 'label/0' under the first field of each Well
     field = "0"
     for well in well_paths:
         path_to_labels = os.path.join(zarr_path, well, field, "labels", "0")
-        print("path_to_labels", path_to_labels)
 
         label_group = zarr_open(path_to_labels)
         attrs = label_group.attrs.asdict()
@@ -71,12 +100,8 @@ def dict_to_zarr(props_to_add: Dict, zarr_path: str, zarr_id: str) -> None:
         if properties is None:
             continue
 
-        print("attrs", attrs)
-        attrs["test"] = True
-
         for props_dict in properties:
             props_id = str(props_dict.get(zarr_id))
-            print("props_id", props_id)
 
             # Look for key-value pairs to add to these properties
             if props_id in props_to_add:


### PR DESCRIPTION
Takes a csv file with 1 row per Mask (e.g. exported from OMERO with `Batch_ROI_Export`) and uses it to
add properties to the labels metadata in `ome-zarr`.
You need to specify which column of the csv contains an ID that matches a specified ID of each properties dict.

E.g. if you have exported labels from OMERO with https://github.com/ome/omero-cli-zarr/pull/50 then each properties dict will have e.g. `"omero:shapeId": 123` and this will correspond to the `shape_id` column of the Batch_ROI_Export.csv.

You also want to specify columns from the csv to use, e.g. `"area (pixels),X,Y,Width,Height"`.
You can also specify the column types (as in https://github.com/ome/omero-metadata/) to specify the data-type for each column (string by default).

 - `d`: `DoubleColumn`, for floating point numbers
 - `l`: `LongColumn`, for integer numbers
 - `s`: `StringColumn`, for text
 - `b`: `BoolColumn`, for true/false

Use e.g. `#d` as a suffix in the column name to denote a `float` column, no spaces etc:
```
"area (pixels)#d,well_label#s,Width#l,Height#l"
```

If you have a Plate exported to ome-zarr as "251.zarr", then you can do this:

```ome_zarr csv_to_labels plate251_ch1.csv shape_id "area (pixels)#d,well_label#s,Width#l,Height#l" 251.zarr omero:shapeId```

Then you can open a Well (field 0) in napari, and the properties will be read by https://github.com/ome/ome-zarr-py/pull/61 cc @DragaDoncila and you will be able to see the properties from the csv (bottom left) when you mouse over a label

```napari 251.zarr/A/1/0```

![Screenshot 2020-11-19 at 09 13 55](https://user-images.githubusercontent.com/900055/99645820-9d989800-2a47-11eb-9400-3815a3d368a6.png)

You can then use the properties to update label colors:

```
layer = viewer.layers[-1]

for c, value in enumerate(layer.properties["area (pixels)"]):
    index = layer.properties["index"][c]
    if value > 2500:
        layer.color[index] = np.array([1, 0, 1, 1], dtype=np.float32)
    elif value < 2000:
        layer.color[index] = np.array([1, 1, 1, 1], dtype=np.float32)
    else:
        layer.color[index] = np.array([0, 1, 0, 1], dtype=np.float32)
   
# force refresh
layer.color_mode = "direct"
```

![Screenshot 2020-11-19 at 13 28 40](https://user-images.githubusercontent.com/900055/99672402-42789c80-2a6b-11eb-812f-c6cc01f975ac.png)


TODO:

 - [ ] Also support single Images in ome-zarr instead of whole Plate
 - [x] Parse csv number columns as numbers