### PR TITLE
Fix labels of differing dtype

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
   - ome
   - conda-forge
 dependencies:
-  - pyside2
   - napari
   - flake8
   - ipython

--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -200,7 +200,9 @@ class Scaler:
                     for z in range(Z):
                         out = func(fiveD[t][c][z][:], Y, X)
                         if smaller is None:
-                            smaller = np.zeros((T, C, Z, out.shape[0], out.shape[1]))
+                            smaller = np.zeros(
+                                (T, C, Z, out.shape[0], out.shape[1]), dtype=base.dtype
+                            )
                         smaller[t][c][z] = out
             rv.append(smaller)
         return rv


### PR DESCRIPTION
The first scale of the label was uint16 while following
levels were floating point:

```
cat 6001237.zarr/labels/masks/*/.zarray | grep dtype
    "dtype": "<i8",
    "dtype": "<f8",
    "dtype": "<f8",
    "dtype": "<f8",
    "dtype": "<f8",
```

cc: @will-moore @tischi