### PR TITLE
Update to v0.2 (nested storage) with FSStore

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = cv2,dask,numpy,pytest,requests,scipy,setuptools,skimage,vispy,zarr
+known_third_party = cv2,dask,numpy,pytest,scipy,setuptools,skimage,vispy,zarr
 multi_line_output=6
 include_trailing_comma=False
 force_grid_wrap=0

--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -11,6 +11,7 @@ from skimage.measure import label
 from skimage.morphology import closing, remove_small_objects, square
 from skimage.segmentation import clear_border
 
+from .io import parse_url
 from .scale import Scaler
 from .writer import write_multiscale
 
@@ -101,8 +102,9 @@ def create_zarr(
     """Generate a synthetic image pyramid with labels."""
     pyramid, labels = method()
 
-    store = zarr.DirectoryStore(zarr_directory)
-    grp = zarr.group(store)
+    loc = parse_url(zarr_directory, mode="w")
+    assert loc
+    grp = zarr.group(loc.store)
     write_multiscale(pyramid, grp)
 
     if pyramid[0].shape[CHANNEL_DIMENSION] == 1:
@@ -151,7 +153,7 @@ def create_zarr(
             colors.append({"label-value": x, "rgba": rgba})
             properties.append({"label-value": x, "class": f"class {x}"})
         label_grp.attrs["image-label"] = {
-            "version": "0.1",
+            "version": "0.2",
             "colors": colors,
             "properties": properties,
             "source": {"image": "../../"},

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -5,11 +5,9 @@ Primary entry point is the :func:`~ome_zarr.io.parse_url` method.
 
 import json
 import logging
-import os
-from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List, Optional
-from urllib.parse import urljoin, urlparse
+from typing import List, Optional, Union
+from urllib.parse import urljoin
 
 import dask.array as da
 from zarr.core import Array
@@ -20,18 +18,38 @@ from .types import JSONDict
 LOGGER = logging.getLogger("ome_zarr.io")
 
 
-class BaseZarrLocation(ABC):
+class ZarrLocation:
     """
-    Base IO primitive for reading Zarr data.
+    IO primitive for reading and writing Zarr data. Uses FSStore for all
+    data access.
 
     No assumptions about the existence of the given path string are made.
     Attempts are made to load various metadata files and cache them internally.
     """
 
-    def __init__(self) -> None:
-        self._store: Optional[FSStore] = None
+    def __init__(self, path: Union[Path, str], mode: str = "r") -> None:
 
-    def _load(self) -> None:
+        if isinstance(path, Path):
+            self.__path = str(path.resolve())
+        elif isinstance(path, str):
+            self.__path = path
+        else:
+            raise TypeError(f"not expecting: {type(path)}")
+
+        self.__mode = mode
+
+        kwargs = {}
+        if "r" not in mode and not self.__path.startswith("http"):
+            kwargs["auto_mkdir"] = True
+
+        self.__store = FSStore(
+            self.__path,  # TODO: open issue for using Path
+            key_separator="/",  # TODO: in 2.8 "dimension_separator"
+            mode=self.__mode,
+            **kwargs,
+        )
+        LOGGER.debug(f"Created FSStore {path}")
+
         self.zarray: JSONDict = self.get_json(".zarray")
         self.zgroup: JSONDict = self.get_json(".zgroup")
         self.__metadata: JSONDict = {}
@@ -59,8 +77,8 @@ class BaseZarrLocation(ABC):
     @property
     def store(self) -> FSStore:
         """Return the initialized store for this location"""
-        assert self._store is not None
-        return self._store
+        assert self.__store is not None
+        return self.__store
 
     @property
     def root_attrs(self) -> JSONDict:
@@ -69,172 +87,82 @@ class BaseZarrLocation(ABC):
 
     def load(self, subpath: str = "") -> da.core.Array:
         """Use dask.array.from_zarr to load the subpath."""
-        return da.from_zarr(f"{self.subpath(subpath)}")
+        array = Array(self.store, subpath)
+        return da.from_zarr(array)
 
     def __eq__(self, rhs: object) -> bool:
         if type(self) != type(rhs):
             return False
-        if not isinstance(rhs, BaseZarrLocation):
+        if not isinstance(rhs, ZarrLocation):
             return False
         return self.subpath() == rhs.subpath()
 
-    # Abstract methods to be implemented by subclasses
-
-    @abstractmethod
     def basename(self) -> str:
         """Return the last element of the underlying location.
 
-        >>> RemoteZarrLocation("https://example.com/foo").basename()
+        >>> ZarrLocation("/tmp/foo").basename()
         'foo'
+        >>> ZarrLocation("https://example.com/bar").basename()
+        'bar'
+        >>> ZarrLocation("https://example.com/baz/").basename()
+        'baz'
         """
-        raise NotImplementedError("unknown")
+        path = self.__path.endswith("/") and self.__path[0:-1] or self.__path
+        return path.split("/")[-1]
 
     # TODO: update to from __future__ import annotations with 3.7+
-    @abstractmethod
-    def create(self, path: str) -> "BaseZarrLocation":
-        """Must be implemented by subclasses."""
-        raise NotImplementedError("unknown")
-
-    @abstractmethod
-    def get_json(self, subpath: str) -> JSONDict:
-        """Must be implemented by subclasses."""
-        raise NotImplementedError("unknown")
-
-    @abstractmethod
-    def parts(self) -> List[str]:
-        """Must be implemented by subclasses."""
-        raise NotImplementedError("unknown")
-
-    @abstractmethod
-    def subpath(self, subpath: str = "") -> str:
-        """Must be implemented by subclasses."""
-        raise NotImplementedError("unknown")
-
-
-class LocalZarrLocation(BaseZarrLocation):
-    """
-    Uses the :module:`json` library for loading JSON from disk.
-    """
-
-    def __init__(self, path: Path, mode: str = "r") -> None:
-        super().__init__()
-        self.__path: Path = path
-        self.mode = mode
-        self._store = FSStore(
-            str(self.__path),  # TODO: open issue for using Path
-            auto_mkdir=True,
-            key_separator="/",
-            mode=mode,
-        )
-        LOGGER.debug("Created FSStore %s", self.basename())
-        self._load()
-
-    def basename(self) -> str:
-        return self.__path.name
-
-    def subpath(self, subpath: str = "") -> str:
-        return str((self.__path / subpath).resolve())
-
-    def parts(self) -> List[str]:
-        return list(self.__path.parts)
-
-    def create(self, path: str) -> "LocalZarrLocation":
+    def create(self, path: str) -> "ZarrLocation":
         """Create a new Zarr location for the given path."""
-        subpath = (self.__path / path).resolve()
+        subpath = self.subpath(path)
         LOGGER.debug(f"open({self.__class__.__name__}({subpath}))")
         return self.__class__(subpath)
 
     def get_json(self, subpath: str) -> JSONDict:
         """
-        Load and return a given subpath of self.__path as JSON.
-
-        If a file does not exist, an empty response is returned rather
-        than an exception.
-        """
-        filename = self.subpath(subpath)
-        if not os.path.exists(filename):
-            LOGGER.debug(f"{filename} does not exist")
-            return {}
-
-        with open(filename) as f:
-            return json.loads(f.read())
-
-
-class RemoteZarrLocation(BaseZarrLocation):
-    """ Uses the :module:`requests` library for accessing Zarr metadata files. """
-
-    def __init__(self, url: str) -> None:
-        super().__init__()
-        self.__url: str = url.endswith("/") and url or f"{url}/"
-        self._store = FSStore(
-            url, key_separator="/", mode="r"
-        )  # FIXME: allow mode "w"?
-        LOGGER.debug("Created read-only FSStore %s", self.basename())
-        self._load()
-
-    def basename(self) -> str:
-        url = self.__url.endswith("/") and self.__url[0:-1] or self.__url
-        return url.split("/")[-1]
-
-    def subpath(self, path: str = "") -> str:
-        return urljoin(self.__url, path)
-
-    def parts(self) -> List[str]:
-        return self.__url.split("/")
-
-    def create(self, path: str) -> "RemoteZarrLocation":
-        """Create a new Zarr location for the given path."""
-        subpath = self.subpath(path)
-        LOGGER.debug(f"open({self.__class__.__name__}({subpath}))")
-        return self.__class__(f"{subpath}")
-
-    def load(self, subpath: str = "") -> da.core.Array:
-        """Use dask.array.from_zarr to load the subpath."""
-        # TODO: remove base implementation?
-        array = Array(self.store, subpath)
-        return da.from_zarr(array)
-
-    def get_json(self, subpath: str) -> JSONDict:
-        """
-        Load and return a given subpath of self.__url as JSON.
+        Load and return a given subpath of store as JSON.
 
         HTTP 403 and 404 responses are treated as if the file does not exist.
         Exceptions during the remote connection are logged at the WARN level.
         All other exceptions log at the ERROR level.
         """
         try:
-            return json.loads(self.store.get(subpath))
+            data = self.store.get(subpath)
+            if not data:
+                return {}
+            return json.loads(data)
         except KeyError:
             return {}
         except Exception as e:
-            LOGGER.error(f"{e}")
+            LOGGER.exception(f"{e}")
             return {}
 
+    def parts(self) -> List[str]:
+        if self.__store.fs.protocol == "file":
+            return list(Path(self.__path).parts)
+        else:
+            return self.__path.split("/")
 
-def parse_url(path: str, mode: str = "r") -> Optional[BaseZarrLocation]:
-    """Convert a path string or URL to a BaseZarrLocation subclass.
+    def subpath(self, subpath: str = "") -> str:
+        if self.__store.fs.protocol == "file":
+            path = Path(self.__path) / subpath
+            path = path.resolve()
+            return str(path)
+        else:
+            return urljoin(self.__path, subpath)
+
+
+def parse_url(path: Union[Path, str], mode: str = "r") -> Optional[ZarrLocation]:
+    """Convert a path string or URL to a ZarrLocation subclass.
 
     >>> parse_url('does-not-exist')
     """
-    # Check is path is local directory first
-    if os.path.isdir(path):
-        LOGGER.debug(f"returning local directory {path}")
-        return LocalZarrLocation(Path(path), mode=mode)
-    else:
-        result = urlparse(path)
-        zarr_loc: Optional[BaseZarrLocation] = None
-        if result.scheme in ("", "file"):
-            # Strips 'file://' if necessary
-            zarr_loc = LocalZarrLocation(Path(result.path), mode=mode)
-            LOGGER.debug(f"found local uri {path}")
-
+    try:
+        loc = ZarrLocation(path, mode=mode)
+        if "r" in mode and not loc.exists():
+            return None
         else:
-            if mode != "r":
-                raise ValueError("Remote locations are read only")
-            zarr_loc = RemoteZarrLocation(path)
-            LOGGER.debug(f"found remote uri {path}")
-        if zarr_loc.exists() or (mode in ("a", "w")):
-            LOGGER.debug(f"uri exists or will be created: {path}")
-            return zarr_loc
-    LOGGER.debug(f"no location parsed from {path}")
-    return None
+            return loc
+    except Exception as e:
+        LOGGER.warning(f"exception on parsing: {e} (stacktrace at DEBUG)")
+        LOGGER.debug("stacktrace:", exc_info=True)
+        return None

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -10,7 +10,6 @@ from typing import List, Optional, Union
 from urllib.parse import urljoin
 
 import dask.array as da
-from zarr.core import Array
 from zarr.storage import FSStore
 
 from .types import JSONDict
@@ -46,6 +45,7 @@ class ZarrLocation:
             self.__path,  # TODO: open issue for using Path
             key_separator="/",  # TODO: in 2.8 "dimension_separator"
             mode=self.__mode,
+            normalize_keys=False,
             **kwargs,
         )
         LOGGER.debug(f"Created FSStore {path}")
@@ -87,8 +87,7 @@ class ZarrLocation:
 
     def load(self, subpath: str = "") -> da.core.Array:
         """Use dask.array.from_zarr to load the subpath."""
-        array = Array(self.store, subpath)
-        return da.from_zarr(array)
+        return da.from_zarr(self.store, subpath)
 
     def __eq__(self, rhs: object) -> bool:
         if type(self) != type(rhs):

--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -15,6 +15,8 @@ import zarr
 from scipy.ndimage import zoom
 from skimage.transform import downscale_local_mean, pyramid_gaussian, pyramid_laplacian
 
+from .io import parse_url
+
 LOGGER = logging.getLogger("ome_zarr.scale")
 
 
@@ -85,7 +87,9 @@ class Scaler:
     def __check_store(self, output_directory: str) -> MutableMapping:
         """Return a Zarr store if it doesn't already exist."""
         assert not os.path.exists(output_directory)
-        return zarr.DirectoryStore(output_directory)
+        loc = parse_url(output_directory, mode="w")
+        assert loc
+        return loc.store
 
     def __assert_values(self, pyramid: List[np.ndarray]) -> None:
         """Check for a single unique set of values for all pyramid levels."""

--- a/ome_zarr/utils.py
+++ b/ome_zarr/utils.py
@@ -28,7 +28,7 @@ def info(path: str) -> Iterator[Node]:
     for node in reader():
 
         if not node.specs:
-            print(f"not an ome-zarr: {zarr}")
+            print(f"not an ome-zarr node: {node}")
             continue
 
         print(node)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -23,7 +23,7 @@ def write_multiscale(
         group.create_dataset(str(path), data=dataset, chunks=chunks)
         paths.append({"path": str(path)})
 
-    multiscales = [{"version": "0.1", "datasets": paths}]
+    multiscales = [{"version": "0.2", "datasets": paths}]
     group.attrs["multiscales"] = multiscales
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import numpy as np
 import pytest
 import zarr
@@ -11,7 +13,7 @@ from ome_zarr.writer import write_image
 class TestWriter:
     @pytest.fixture(autouse=True)
     def initdir(self, tmpdir):
-        self.path = tmpdir.mkdir("data")
+        self.path = pathlib.Path(tmpdir.mkdir("data"))
         self.store = parse_url(self.path, mode="w").store
         self.root = zarr.group(store=self.store)
         self.group = self.root.create_group("test")

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -12,7 +12,7 @@ class TestWriter:
     @pytest.fixture(autouse=True)
     def initdir(self, tmpdir):
         self.path = tmpdir.mkdir("data")
-        self.store = zarr.DirectoryStore(self.path)
+        self.store = parse_url(self.path, mode="w").store
         self.root = zarr.group(store=self.store)
         self.group = self.root.create_group("test")
 


### PR DESCRIPTION
With the improvements to zarr.store.FSStore, all URLs can
be handled uniformly without needing to use `requests`. A
next step may in fact be to remove the ZarrLocation types.

This change does not yet support v0.2 and v0.1 at the same
time.