### PR TITLE
Cleanup builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,33 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-
-          - {os: windows-latest, python_Version: '3.6', toxenv: 'py36-PyQt5'}
-          - {os: windows-latest, python_Version: '3.6', toxenv: 'py36-PySide2'}
-          - {os: windows-latest, python_Version: '3.7', toxenv: 'py37-PyQt5'}
-          - {os: windows-latest, python_Version: '3.7', toxenv: 'py37-PySide2'}
-          - {os: windows-latest, python_Version: '3.8', toxenv: 'py38-PyQt5'}
-          - {os: windows-latest, python_Version: '3.8', toxenv: 'py38-PySide2'}
-          - {os: windows-latest, python_Version: '3.9', toxenv: 'py39-PyQt5'}
-          - {os: windows-latest, python_Version: '3.9', toxenv: 'py39-PySide2'}
-
-          # No Python 3.6
-          # Linux all failing on GHA
-          # {os: linux-latest, python_Version: '3.7', toxenv: 'py37-PyQt5'}
-          # {os: linux-latest, python_Version: '3.7', toxenv: 'py37-PySide2'}
-          # {os: linux-latest, python_Version: '3.8', toxenv: 'py38-PyQt5'}
-          # {os: linux-latest, python_Version: '3.8', toxenv: 'py38-PySide2'}
-          # {os: linux-latest, python_Version: '3.9', toxenv: 'py39-PyQt5'}
-          # {os: linux-latest, python_Version: '3.9', toxenv: 'py39-PySide2'}
-
-          # No Python 3.6
-          - {os: macos-latest, python_Version: '3.7', toxenv: 'py37-PyQt5'}
-          - {os: macos-latest, python_Version: '3.7', toxenv: 'py37-PySide2'}
-          - {os: macos-latest, python_Version: '3.8', toxenv: 'py38-PyQt5'}
-          - {os: macos-latest, python_Version: '3.8', toxenv: 'py38-PySide2'}
+          - {os: windows-latest, python_Version: '3.7', toxenv: 'py37'}
+          - {os: windows-latest, python_Version: '3.8', toxenv: 'py38'}
+          - {os: windows-latest, python_Version: '3.9', toxenv: 'py39'}
+          - {os: linux-latest, python_Version: '3.7', toxenv: 'py37'}
+          - {os: linux-latest, python_Version: '3.8', toxenv: 'py38'}
+          - {os: linux-latest, python_Version: '3.9', toxenv: 'py39'}
+          - {os: macos-latest, python_Version: '3.7', toxenv: 'py37'}
+          - {os: macos-latest, python_Version: '3.8', toxenv: 'py38'}
           # missing numcodecs wheels on 3.9. conda not yet an option. see gh-51
-          # {os: macos-latest, python_Version: '3.9', toxenv: 'py39-PyQt5'}
-          # {os: macos-latest, python_Version: '3.9', toxenv: 'py39-PySide2'}
+          # {os: macos-latest, python_Version: '3.9', toxenv: 'py39'}
 
     steps:
       - uses: actions/checkout@v1
@@ -77,7 +60,7 @@ jobs:
           python -m pip install -r requirements/requirements-dev.txt
 
       - name: Test
-        run: tox -e  'py37-PyQt5-coverage'
+        run: tox -e  'py37-coverage'
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,10 @@ jobs:
           - {os: windows-latest, python_Version: '3.7', toxenv: 'py37'}
           - {os: windows-latest, python_Version: '3.8', toxenv: 'py38'}
           - {os: windows-latest, python_Version: '3.9', toxenv: 'py39'}
-          - {os: linux-latest, python_Version: '3.7', toxenv: 'py37'}
-          - {os: linux-latest, python_Version: '3.8', toxenv: 'py38'}
-          - {os: linux-latest, python_Version: '3.9', toxenv: 'py39'}
+          # Linux still not working
+          # {os: linux-latest, python_Version: '3.7', toxenv: 'py37'}
+          # {os: linux-latest, python_Version: '3.8', toxenv: 'py38'}
+          # {os: linux-latest, python_Version: '3.9', toxenv: 'py39'}
           - {os: macos-latest, python_Version: '3.7', toxenv: 'py37'}
           - {os: macos-latest, python_Version: '3.8', toxenv: 'py38'}
           # missing numcodecs wheels on 3.9. conda not yet an option. see gh-51

--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: windows-latest, python_Version: '3.9', toxenv: 'py39-PySide2'}
-          - {os: macos-latest, python_Version: '3.8', toxenv: 'py38-PyQt5'}
+          - {os: windows-latest, python_Version: '3.9', toxenv: 'py39'}
+          - {os: macos-latest, python_Version: '3.8', toxenv: 'py38'}
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/zarr-dev.yml
+++ b/.github/workflows/zarr-dev.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          python -m pip install --upgrade pip wheel pytest tox .[napari]
+          python -m pip install --upgrade pip wheel pytest tox
           python -m pip install \
           git+https://github.com/zarr-developers/zarr-python.git@master
 
       - name: Run pytest
         shell: bash -l {0}
-        run: pytest --ignore=tests/test_napari.py # segfaults
+        run: pytest

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = cv2,dask,numpy,pytest,scipy,setuptools,skimage,vispy,zarr
+known_third_party = cv2,dask,numpy,pytest,scipy,setuptools,skimage,zarr
 multi_line_output=6
 include_trailing_comma=False
 force_grid_wrap=0

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Iterator, List, Optional, Type, Union, cast
 import dask.array as da
 import numpy as np
 from dask import delayed
-from vispy.color import Colormap
 
 from .io import ZarrLocation
 from .types import JSONDict
@@ -337,7 +336,7 @@ class OMERO(Spec):
                     # TODO: make this value an enumeration
                     if model == "greyscale":
                         rgb = [1, 1, 1]
-                    colormaps.append(Colormap([[0, 0, 0], rgb]))
+                    colormaps.append([[0, 0, 0], rgb])
 
                 label = ch.get("label", None)
                 if label is not None:

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,5 +1,4 @@
 black
-napari
 cython >= 0.29.16
 numpy >= 1.16.0
 pre-commit

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,4 +1,3 @@
 pytest
 pytest-cov
-pytest-qt
 codecov

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ install_requires += (["aiohttp"],)
 install_requires += (["requests"],)
 install_requires += (["scikit-image"],)
 install_requires += (["toolz"],)
-install_requires += (["vispy"],)
 install_requires += (["opencv-contrib-python-headless"],)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36-{PyQt5, PySide2}, py37-{PyQt5, PySide2}, py38-{PyQt5, PySide2}, py39-{PyQt5, PySide2}
+envlist = py37, py38, py39
 
 [testenv]
 # passenv = DISPLAY XAUTHORITY
@@ -12,14 +12,12 @@ passenv = GITHUB_ACTIONS
 deps =
     -rrequirements/requirements-dev.txt
     pytest-xvfb ; sys_platform == 'linux'
-    PyQt5: PyQt5!=5.15.0
-    PySide2: PySide2!=5.15.0
 
 commands =
     pytest {posargs:tests -s}
 
-[testenv:py37-PyQt5-coverage]
+[testenv:py37-coverage]
 usedevelop = true
 commands =
-    pytest --cov-report=xml --cov=./ome_zarr  --cov-append -k "not qt" {posargs:-v}
+    pytest --cov-report=xml --cov=./ome_zarr  --cov-append {posargs:-v}
     codecov -f codecov.xml


### PR DESCRIPTION
After the extraction of the napari plugin to `napari-ome-zarr`,
a number of the matrix builds can be eliminated. This PR attempts
to drop any dependencies on Qt-related code which should all be in
the plugin repository.