### PR TITLE
Update Embassy URLs to use new Embassy Cloud object storage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ info
 Use the `ome_zarr` command to interrogate Zarr datasets::
 
     # Remote data
-    $ ome_zarr info https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/
+    $ ome_zarr info https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/
 
     # Local data (after downloading as below)
     $ ome_zarr info 6001240.zarr/
@@ -56,10 +56,10 @@ download
 To download all the resolutions and metadata for an image::
 
     # creates local 6001240.zarr/
-    $ ome_zarr download https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/
+    $ ome_zarr download https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/
 
     # Specify output directory
-    $ ome_zarr download https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/ --output image_dir
+    $ ome_zarr download https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/ --output image_dir
 
 csv to labels
 =============

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,9 +17,9 @@ class TestCli:
     @pytest.fixture(params=["0.1", "0.2", "0.3"], ids=["v0.1", "v0.2", "v0.3"])
     def s3_address(self, request):
         urls = {
-            "0.1": "https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr",
-            "0.2": "https://s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001240.zarr",
-            "0.3": "https://s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr",
+            "0.1": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr",
+            "0.2": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.2/6001240.zarr",
+            "0.3": "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr",
         }
         return urls[request.param]
 


### PR DESCRIPTION
See https://forum.image.sc/t/hcs-ome-zarr-data-unable-to-download/57114/6

The current S3 URLs are regularly hitting 503 errors which might be related to the fact these resources are being EOL'ed.

The three  OME-Zarr samples have been sync'ed to the new Embassy Cloud v4 storage.

Opening this PR as a prererequisite of the overall migration