### PR TITLE
Write scale less than 5D

### DIFF
--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -168,14 +168,10 @@ class Scaler:
     def local_mean(self, base: np.ndarray) -> List[np.ndarray]:
         """Downsample using :func:`skimage.transform.downscale_local_mean`."""
         rv = [base]
-        # FIXME: fix hard-coding
-        rv = [base]
+        stack_dims = base.ndim - 2
+        factors = (*(1,) * stack_dims, *(self.downscale, self.downscale))
         for i in range(self.max_layer):
-            rv.append(
-                downscale_local_mean(
-                    rv[-1], factors=(1, 1, 1, self.downscale, self.downscale)
-                )
-            )
+            rv.append(downscale_local_mean(rv[-1], factors=factors))
         return rv
 
     def zoom(self, base: np.ndarray) -> List[np.ndarray]:

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -72,11 +72,13 @@ def write_image(
     if image.ndim > 5:
         raise ValueError("Only images of 5D or less are supported")
 
-    shape_5d: Tuple[Any, ...] = (*(1,) * (5 - image.ndim), *image.shape)
-    image = image.reshape(shape_5d)
+    if fmt.version in ("0.1", "0.2"):
+        # v0.1 and v0.2 are strictly 5D
+        shape_5d: Tuple[Any, ...] = (*(1,) * (5 - image.ndim), *image.shape)
+        image = image.reshape(shape_5d)
 
     if chunks is not None:
-        chunks = _retuple(chunks, shape_5d)
+        chunks = _retuple(chunks, image.shape)
 
     if scaler is not None:
         image = scaler.nearest(image)
@@ -98,4 +100,6 @@ def _retuple(
     else:
         _chunks = chunks
 
-    return (*shape[: (5 - len(_chunks))], *_chunks)
+    dims_to_add = len(shape) - len(_chunks)
+
+    return (*shape[:dims_to_add], *_chunks)

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -5,7 +5,14 @@ from ome_zarr.scale import Scaler
 
 
 class TestScaler:
-    @pytest.fixture(params=((1, 2, 1, 256, 256),))
+    @pytest.fixture(
+        params=(
+            (1, 2, 1, 256, 256),
+            (3, 512, 512),
+            (256, 256),
+        ),
+        ids=["5D", "3D", "2D"],
+    )
     def shape(self, request):
         return request.param
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -26,9 +26,10 @@ class TestWriter:
     @pytest.fixture(
         params=(
             (1, 2, 1, 256, 256),
+            (3, 512, 512),
             (256, 256),
         ),
-        ids=["5D", "2D"],
+        ids=["5D", "3D", "2D"],
     )
     def shape(self, request):
         return request.param

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -23,7 +23,13 @@ class TestWriter:
         rng = np.random.default_rng(0)
         return rng.poisson(mean_val, size=shape).astype(dtype)
 
-    @pytest.fixture(params=((1, 2, 1, 256, 256),))
+    @pytest.fixture(
+        params=(
+            (1, 2, 1, 256, 256),
+            (256, 256),
+        ),
+        ids=["5D", "2D"],
+    )
     def shape(self, request):
         return request.param
 
@@ -49,18 +55,23 @@ class TestWriter:
     def test_writer(self, shape, scaler, format_version):
 
         data = self.create_data(shape)
+        version = format_version()
         write_image(
             image=data,
             group=self.group,
             chunks=(128, 128),
             scaler=scaler,
-            fmt=format_version(),
+            fmt=version,
         )
 
         # Verify
         reader = Reader(parse_url(f"{self.path}/test"))
         node = list(reader())[0]
         assert Multiscales.matches(node.zarr)
-        assert node.data[0].shape == shape
-        assert node.data[0].chunks == ((1,), (2,), (1,), (128, 128), (128, 128))
+        if version.version not in ("0.1", "0.2"):
+            # v0.1 and v0.2 MUST be 5D
+            assert node.data[0].shape == shape
+        else:
+            assert node.data[0].ndim == 5
+        # assert node.data[0].chunks == ((1,), (2,), (1,), (128, 128), (128, 128))
         assert np.allclose(data, node.data[0][...].compute())


### PR DESCRIPTION
Since v0.3 now supports data with less than 5D, this should also be supported by the writing and scaling functionality.

This adds support for `scaler.nearest(data, x, y)` where data is 2D - 5D.
Same for `write_image(data, scaler)`.

Also add 2D and 3D shapes to test_scaler and test_writer.