### PR TITLE
Validate axes for writer

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -18,16 +18,19 @@ def validate_axes_names(
     ndim: int, axes: Union[str, List[str]] = None, fmt: Format = CurrentFormat()
 ) -> Union[None, List[str]]:
 
-    if fmt.version not in ("0.1", "0.2"):
-        if axes is None:
-            if ndim == 2:
-                axes = ["y", "x"]
-            elif ndim == 5:
-                axes = ["t", "c", "z", "y", "x"]
-            else:
-                raise ValueError(
-                    "axes must be provided. Can't be guessed for 3D or 4D data"
-                )
+    if fmt.version in ("0.1", "0.2"):
+        return None
+
+    # handle version 0.3...
+    if axes is None:
+        if ndim == 2:
+            axes = ["y", "x"]
+        elif ndim == 5:
+            axes = ["t", "c", "z", "y", "x"]
+        else:
+            raise ValueError(
+                "axes must be provided. Can't be guessed for 3D or 4D data"
+            )
 
     if isinstance(axes, str):
         axes = list(axes)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -158,6 +158,9 @@ def write_image(
         # and we don't need axes
         axes = None
 
+    # check axes before trying to scale
+    _validate_axes_names(image.ndim, axes, fmt)
+
     if chunks is not None:
         chunks = _retuple(chunks, image.shape)
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -19,14 +19,18 @@ def validate_axes_names(
 ) -> Union[None, List[str]]:
 
     if fmt.version in ("0.1", "0.2"):
+        if axes is not None:
+            LOGGER.info("axes ignored for version 0.1 or 0.2")
         return None
 
     # handle version 0.3...
     if axes is None:
         if ndim == 2:
             axes = ["y", "x"]
+            LOGGER.info("Auto using axes %s for 2D data" % axes)
         elif ndim == 5:
             axes = ["t", "c", "z", "y", "x"]
+            LOGGER.info("Auto using axes %s for 5D data" % axes)
         else:
             raise ValueError(
                 "axes must be provided. Can't be guessed for 3D or 4D data"

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -14,9 +14,10 @@ from .types import JSONDict
 LOGGER = logging.getLogger("ome_zarr.writer")
 
 
-def validate_axes_names(
+def _validate_axes_names(
     ndim: int, axes: Union[str, List[str]] = None, fmt: Format = CurrentFormat()
 ) -> Union[None, List[str]]:
+    """Returns validated list of axes names or raise exception if invalid"""
 
     if fmt.version in ("0.1", "0.2"):
         if axes is not None:
@@ -95,7 +96,7 @@ def write_multiscale(
     """
 
     dims = len(pyramid[0].shape)
-    axes = validate_axes_names(dims, axes, fmt)
+    axes = _validate_axes_names(dims, axes, fmt)
 
     paths = []
     for path, dataset in enumerate(pyramid):

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -62,7 +62,8 @@ def _validate_axes_names(
             ]:
                 raise ValueError("4D data must have axes tzyx or czyx or tcyx")
         else:
-            assert val_axes == ("t", "c", "z", "y", "x"), str(val_axes)
+            if val_axes != ("t", "c", "z", "y", "x"):
+                raise ValueError("5D data must have axes ('t', 'c', 'z', 'y', 'x')")
 
     return axes
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -69,6 +69,8 @@ def write_multiscale(
     ----------
     pyramid: List of np.ndarray
       the image data to save. Largest level first
+      All image arrays MUST be up to 5-dimensional with dimensions
+      ordered (t, c, z, y, x)
     group: zarr.Group
       the group within the zarr store to store the data in
     chunks: int or tuple of ints,
@@ -113,6 +115,8 @@ def write_image(
     image: np.ndarray
       the image data to save. A downsampling of the data will be computed
       if the scaler argument is non-None.
+      Image array MUST be up to 5-dimensional with dimensions
+      ordered (t, c, z, y, x)
     group: zarr.Group
       the group within the zarr store to store the data in
     chunks: int or tuple of ints,

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -8,7 +8,7 @@ from ome_zarr.format import FormatV01, FormatV02, FormatV03
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Multiscales, Reader
 from ome_zarr.scale import Scaler
-from ome_zarr.writer import validate_axes_names, write_image
+from ome_zarr.writer import _validate_axes_names, write_image
 
 
 class TestWriter:
@@ -84,21 +84,21 @@ class TestWriter:
 
         # v0.3 MUST specify axes for 3D or 4D data
         with pytest.raises(ValueError):
-            validate_axes_names(3, axes=None, fmt=v03)
+            _validate_axes_names(3, axes=None, fmt=v03)
 
         # ndims must match axes length
         with pytest.raises(ValueError):
-            validate_axes_names(3, axes="yx", fmt=v03)
+            _validate_axes_names(3, axes="yx", fmt=v03)
 
         # axes must be ordered tczyx
         with pytest.raises(ValueError):
-            validate_axes_names(3, axes="yxt", fmt=v03)
+            _validate_axes_names(3, axes="yxt", fmt=v03)
         with pytest.raises(ValueError):
-            validate_axes_names(2, axes=["x", "y"], fmt=v03)
+            _validate_axes_names(2, axes=["x", "y"], fmt=v03)
 
         # valid axes - no change, converted to list
-        assert validate_axes_names(2, axes=["y", "x"], fmt=v03) == ["y", "x"]
-        assert validate_axes_names(5, axes="tczyx", fmt=v03) == [
+        assert _validate_axes_names(2, axes=["y", "x"], fmt=v03) == ["y", "x"]
+        assert _validate_axes_names(5, axes="tczyx", fmt=v03) == [
             "t",
             "c",
             "z",
@@ -107,12 +107,12 @@ class TestWriter:
         ]
 
         # if 2D or 5D, axes can be assigned automatically
-        assert validate_axes_names(2, axes=None, fmt=v03) == ["y", "x"]
-        assert validate_axes_names(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
+        assert _validate_axes_names(2, axes=None, fmt=v03) == ["y", "x"]
+        assert _validate_axes_names(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
 
         # for v0.1 or v0.2, axes should be None
-        assert validate_axes_names(2, axes=["y", "x"], fmt=FormatV01()) is None
-        assert validate_axes_names(2, axes=["y", "x"], fmt=FormatV02()) is None
+        assert _validate_axes_names(2, axes=["y", "x"], fmt=FormatV01()) is None
+        assert _validate_axes_names(2, axes=["y", "x"], fmt=FormatV02()) is None
 
         # check that write_image is checking axes
         data = self.create_data((125, 125))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -96,8 +96,16 @@ class TestWriter:
         with pytest.raises(ValueError):
             validate_axes_names(2, axes=["x", "y"], fmt=v03)
 
+        # valid axes
         validate_axes_names(2, axes=["y", "x"], fmt=v03)
         validate_axes_names(5, axes="tczyx", fmt=v03)
+
+        # if 2D or 5D, axes can be assigned automatically
+        assert validate_axes_names(2, axes=None, fmt=v03) == ["y", "x"]
+        assert validate_axes_names(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
+
+        # for v0.1 or v0.2, axes should be None
+        assert validate_axes_names(2, axes=["y", "x"], fmt=FormatV02()) is None
 
         # check that write_image is checking axes
         data = self.create_data((125, 125))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -8,7 +8,7 @@ from ome_zarr.format import FormatV01, FormatV02, FormatV03
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Multiscales, Reader
 from ome_zarr.scale import Scaler
-from ome_zarr.writer import write_image
+from ome_zarr.writer import validate_axes_names, write_image
 
 
 class TestWriter:
@@ -77,3 +77,34 @@ class TestWriter:
         else:
             assert node.data[0].ndim == 5
         assert np.allclose(data, node.data[0][...].compute())
+
+    def test_dim_names(self):
+
+        v03 = FormatV03()
+
+        # v0.3 MUST specify axes for 3D or 4D data
+        with pytest.raises(ValueError):
+            validate_axes_names(3, axes=None, fmt=v03)
+
+        # ndims must match axes length
+        with pytest.raises(ValueError):
+            validate_axes_names(3, axes="yx", fmt=v03)
+
+        # axes must be ordered tczyx
+        with pytest.raises(AssertionError):
+            validate_axes_names(3, axes="yxt", fmt=v03)
+        with pytest.raises(AssertionError):
+            validate_axes_names(2, axes=["x", "y"], fmt=v03)
+
+        validate_axes_names(2, axes=["y", "x"], fmt=v03)
+        validate_axes_names(5, axes="tczyx", fmt=v03)
+
+        # check that write_image is checking axes
+        data = self.create_data((125, 125))
+        with pytest.raises(ValueError):
+            write_image(
+                image=data,
+                group=self.group,
+                fmt=v03,
+                axes="xyz",
+            )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -96,15 +96,22 @@ class TestWriter:
         with pytest.raises(ValueError):
             validate_axes_names(2, axes=["x", "y"], fmt=v03)
 
-        # valid axes
-        validate_axes_names(2, axes=["y", "x"], fmt=v03)
-        validate_axes_names(5, axes="tczyx", fmt=v03)
+        # valid axes - no change, converted to list
+        assert validate_axes_names(2, axes=["y", "x"], fmt=v03) == ["y", "x"]
+        assert validate_axes_names(5, axes="tczyx", fmt=v03) == [
+            "t",
+            "c",
+            "z",
+            "y",
+            "x",
+        ]
 
         # if 2D or 5D, axes can be assigned automatically
         assert validate_axes_names(2, axes=None, fmt=v03) == ["y", "x"]
         assert validate_axes_names(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
 
         # for v0.1 or v0.2, axes should be None
+        assert validate_axes_names(2, axes=["y", "x"], fmt=FormatV01()) is None
         assert validate_axes_names(2, axes=["y", "x"], fmt=FormatV02()) is None
 
         # check that write_image is checking axes

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -91,9 +91,9 @@ class TestWriter:
             validate_axes_names(3, axes="yx", fmt=v03)
 
         # axes must be ordered tczyx
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             validate_axes_names(3, axes="yxt", fmt=v03)
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             validate_axes_names(2, axes=["x", "y"], fmt=v03)
 
         validate_axes_names(2, axes=["y", "x"], fmt=v03)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -95,6 +95,8 @@ class TestWriter:
             _validate_axes_names(3, axes="yxt", fmt=v03)
         with pytest.raises(ValueError):
             _validate_axes_names(2, axes=["x", "y"], fmt=v03)
+        with pytest.raises(ValueError):
+            _validate_axes_names(5, axes="xyzct", fmt=v03)
 
         # valid axes - no change, converted to list
         assert _validate_axes_names(2, axes=["y", "x"], fmt=v03) == ["y", "x"]


### PR DESCRIPTION
Fixes #122

This uses @constantinpape code from https://github.com/ome/ome-ngff-prototypes/blob/05b55d2516941e2eaf8fa82b722cad4371f99b5f/single_image/prototypes/v03.py#L19 to validate axes.

Also adds the required dimension order to the docstring for `write_image()` and `write_multiscale()`

cc @k-dominik 

To test, try the code sample below: https://github.com/ome/ome-zarr-py/pull/123#issuecomment-949691217 as it is, and with various shapes and valid/invalid axes. (invalid axes are not in the `tczyx` order, e.g. `xyz`. This should throw an `AssertionError`).
NB: This previously failed to scale with unhelpful error message (since the sizeX is 1), but error should now be improved.