### PR TITLE
Validate axes types v0.4

### DIFF
--- a/ome_zarr/axes.py
+++ b/ome_zarr/axes.py
@@ -13,10 +13,15 @@ class Axes:
         axes: Union[List[str], List[Dict[str, str]]],
         fmt: Format = CurrentFormat(),
     ) -> None:
+        """
+        Constructor, transforms axes and validates
 
+        Raises ValueError if not valid
+        """
         if axes is not None:
             self.axes = self._axes_to_dicts(axes)
         self.fmt = fmt
+        self.validate()
 
     def validate(self) -> None:
         """Raises ValueError if not valid"""

--- a/ome_zarr/axes.py
+++ b/ome_zarr/axes.py
@@ -1,0 +1,100 @@
+"""Axes class for validating and transforming axes
+"""
+from typing import Any, Dict, List, Union
+
+from .format import Format
+
+KNOWN_AXES = {"x": "space", "y": "space", "z": "space", "c": "channel", "t": "time"}
+
+
+class Axes:
+    def __init__(self, axes: Union[List[str], List[Dict[str, str]]]) -> None:
+        self.axes = self._axes_to_dicts(axes)
+
+    def validate(self, fmt: Format) -> None:
+
+        # check names (only enforced for version 0.3)
+        if fmt.version == "0.3":
+            self._validate_axes_03()
+            return
+
+        self._validate_axes_types()
+
+    def get_axes(self, fmt: Format) -> Union[List[str], List[Dict[str, str]]]:
+        if fmt.version == "0.3":
+            return self._get_names()
+        return self.axes
+
+    @staticmethod
+    def _axes_to_dicts(
+        axes: Union[List[str], List[Dict[str, str]]]
+    ) -> List[Dict[str, str]]:
+        """Returns a list of axis dicts with name and type"""
+        axes_dicts = []
+        for axis in axes:
+            if isinstance(axis, str):
+                axis_dict = {"name": axis}
+                if axis in KNOWN_AXES:
+                    axis_dict["type"] = KNOWN_AXES[axis]
+                axes_dicts.append(axis_dict)
+            else:
+                axes_dicts.append(axis)
+        return axes_dicts
+
+    def _validate_axes_types(self) -> None:
+        """
+        Validate the axes types according to the spec, version 0.4+
+        """
+        axes_types = [axis.get("type") for axis in self.axes]
+        known_types = list(KNOWN_AXES.values())
+        unknown_types = [atype for atype in axes_types if atype not in known_types]
+        if len(unknown_types) > 1:
+            raise ValueError(
+                "Too many unknown axes types. 1 allowed, found: %s" % unknown_types
+            )
+
+        def _last_index(item: str, item_list: List[Any]) -> int:
+            return max(loc for loc, val in enumerate(item_list) if val == item)
+
+        if "time" in axes_types and _last_index("time", axes_types) > 0:
+            raise ValueError("'time' axis must be first dimension only")
+
+        if axes_types.count("channel") > 1:
+            raise ValueError("Only 1 axis can be type 'channel'")
+
+        if "channel" in axes_types and _last_index(
+            "channel", axes_types
+        ) > axes_types.index("space"):
+            raise ValueError("'space' axes must come after 'channel'")
+
+    def _get_names(self) -> List[str]:
+        """Returns a list of axis names"""
+        axes_names = []
+        for axis in self.axes:
+            if "name" not in axis:
+                raise ValueError("Axis Dict %s has no 'name'" % axis)
+            axes_names.append(axis["name"])
+        return axes_names
+
+    def _validate_axes_03(self) -> None:
+
+        val_axes = tuple(self._get_names())
+        if len(val_axes) == 2:
+            if val_axes != ("y", "x"):
+                raise ValueError(f"2D data must have axes ('y', 'x') {val_axes}")
+        elif len(val_axes) == 3:
+            if val_axes not in [("z", "y", "x"), ("c", "y", "x"), ("t", "y", "x")]:
+                raise ValueError(
+                    "3D data must have axes ('z', 'y', 'x') or ('c', 'y', 'x')"
+                    " or ('t', 'y', 'x'), not %s" % (val_axes,)
+                )
+        elif len(val_axes) == 4:
+            if val_axes not in [
+                ("t", "z", "y", "x"),
+                ("c", "z", "y", "x"),
+                ("t", "c", "y", "x"),
+            ]:
+                raise ValueError("4D data must have axes tzyx or czyx or tcyx")
+        else:
+            if val_axes != ("t", "c", "z", "y", "x"):
+                raise ValueError("5D data must have axes ('t', 'c', 'z', 'y', 'x')")

--- a/ome_zarr/axes.py
+++ b/ome_zarr/axes.py
@@ -2,20 +2,30 @@
 """
 from typing import Any, Dict, List, Union
 
-from .format import Format
+from .format import CurrentFormat, Format
 
 KNOWN_AXES = {"x": "space", "y": "space", "z": "space", "c": "channel", "t": "time"}
 
 
 class Axes:
-    def __init__(self, axes: Union[List[str], List[Dict[str, str]]]) -> None:
-        self.axes = self._axes_to_dicts(axes)
+    def __init__(
+        self,
+        axes: Union[List[str], List[Dict[str, str]]],
+        fmt: Format = CurrentFormat(),
+    ) -> None:
 
-    def validate(self, fmt: Format) -> None:
+        if axes is not None:
+            self.axes = self._axes_to_dicts(axes)
+        self.fmt = fmt
+
+    def validate(self) -> None:
+        """Raises ValueError if not valid"""
+        if self.fmt.version in ("0.1", "0.2"):
+            return
 
         # check names (only enforced for version 0.3)
-        if fmt.version == "0.3":
-            self._validate_axes_03()
+        if self.fmt.version == "0.3":
+            self._validate_03()
             return
 
         self._validate_axes_types()
@@ -76,7 +86,7 @@ class Axes:
             axes_names.append(axis["name"])
         return axes_names
 
-    def _validate_axes_03(self) -> None:
+    def _validate_03(self) -> None:
 
         val_axes = tuple(self._get_names())
         if len(val_axes) == 2:

--- a/ome_zarr/axes.py
+++ b/ome_zarr/axes.py
@@ -30,7 +30,7 @@ class Axes:
 
         self._validate_axes_types()
 
-    def get_axes(self, fmt: Format) -> Union[List[str], List[Dict[str, str]]]:
+    def to_list(self, fmt: Format) -> Union[List[str], List[Dict[str, str]]]:
         if fmt.version == "0.3":
             return self._get_names()
         return self.axes

--- a/ome_zarr/axes.py
+++ b/ome_zarr/axes.py
@@ -20,6 +20,9 @@ class Axes:
         """
         if axes is not None:
             self.axes = self._axes_to_dicts(axes)
+        elif fmt.version in ("0.1", "0.2"):
+            # strictly 5D
+            self.axes = self._axes_to_dicts(["t", "c", "z", "y", "x"])
         self.fmt = fmt
         self.validate()
 
@@ -35,7 +38,9 @@ class Axes:
 
         self._validate_axes_types()
 
-    def to_list(self, fmt: Format) -> Union[List[str], List[Dict[str, str]]]:
+    def to_list(
+        self, fmt: Format = CurrentFormat()
+    ) -> Union[List[str], List[Dict[str, str]]]:
         if fmt.version == "0.3":
             return self._get_names()
         return self.axes

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -9,10 +9,19 @@ from zarr.storage import FSStore
 LOGGER = logging.getLogger("ome_zarr.format")
 
 
+def format_from_version(version: str) -> "Format":
+
+    for fmt in format_implementations():
+        if fmt.version == version:
+            return fmt
+    raise ValueError(f"Version {version} not recognized")
+
+
 def format_implementations() -> Iterator["Format"]:
     """
     Return an instance of each format implementation, newest to oldest.
     """
+    yield FormatV04()
     yield FormatV03()
     yield FormatV02()
     yield FormatV01()

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -136,4 +136,15 @@ class FormatV03(FormatV02):  # inherits from V02 to avoid code duplication
         return "0.3"
 
 
-CurrentFormat = FormatV03
+class FormatV04(FormatV03):
+    """
+    Changelog: axes is list of dicts,
+    introduce transformations in multiscales (Nov 2021)
+    """
+
+    @property
+    def version(self) -> str:
+        return "0.4"
+
+
+CurrentFormat = FormatV04

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -282,8 +282,7 @@ class Multiscales(Spec):
                 "version", "0.1"
             )  # should this be matched with Format.version?
             datasets = multiscales[0]["datasets"]
-            # axes field was introduced in 0.3, before all data was 5d
-            axes = tuple(multiscales[0].get("axes", ["t", "c", "z", "y", "x"]))
+            axes = multiscales[0].get("axes")
             if len(set(axes) - axes_values) > 0:
                 raise RuntimeError(f"Invalid axes names: {set(axes) - axes_values}")
             node.metadata["axes"] = axes
@@ -301,6 +300,8 @@ class Multiscales(Spec):
                 for c in data.chunks
             ]
             LOGGER.info("resolution: %s", resolution)
+            if axes is not None:
+                axes = tuple(str(axis) for axis in axes)
             LOGGER.info(" - shape %s = %s", axes, data.shape)
             LOGGER.info(" - chunks =  %s", chunk_sizes)
             LOGGER.info(" - dtype = %s", data.dtype)

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -301,9 +301,10 @@ class Multiscales(Spec):
                 for c in data.chunks
             ]
             LOGGER.info("resolution: %s", resolution)
+            axes_names = None
             if axes is not None:
-                axes = tuple(str(axis) for axis in axes)
-            LOGGER.info(" - shape %s = %s", axes, data.shape)
+                axes_names = tuple(axis["name"] for axis in axes)
+            LOGGER.info(" - shape %s = %s", axes_names, data.shape)
             LOGGER.info(" - chunks =  %s", chunk_sizes)
             LOGGER.info(" - dtype = %s", data.dtype)
             node.data.append(data)

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -303,7 +303,9 @@ class Multiscales(Spec):
             LOGGER.info("resolution: %s", resolution)
             axes_names = None
             if axes is not None:
-                axes_names = tuple(axis["name"] for axis in axes)
+                axes_names = tuple(
+                    axis if isinstance(axis, str) else axis["name"] for axis in axes
+                )
             LOGGER.info(" - shape %s = %s", axes_names, data.shape)
             LOGGER.info(" - chunks =  %s", chunk_sizes)
             LOGGER.info(" - dtype = %s", data.dtype)

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -283,7 +283,8 @@ class Multiscales(Spec):
             )  # should this be matched with Format.version?
             datasets = multiscales[0]["datasets"]
             axes = multiscales[0].get("axes")
-            if len(set(axes) - axes_values) > 0:
+            if version == "0.3" and len(set(axes) - axes_values) > 0:
+                # TODO: validate axis for > V0.3 ?
                 raise RuntimeError(f"Invalid axes names: {set(axes) - axes_values}")
             node.metadata["axes"] = axes
             datasets = [d["path"] for d in datasets]

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -286,7 +286,7 @@ class Multiscales(Spec):
             axes = multiscales[0].get("axes")
             fmt = format_from_version(version)
             # Raises ValueError if not valid
-            Axes(axes, fmt).validate()
+            Axes(axes, fmt)
             node.metadata["axes"] = axes
             datasets = [d["path"] for d in datasets]
             self.datasets: List[str] = datasets

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -286,8 +286,8 @@ class Multiscales(Spec):
             axes = multiscales[0].get("axes")
             fmt = format_from_version(version)
             # Raises ValueError if not valid
-            Axes(axes, fmt)
-            node.metadata["axes"] = axes
+            axes_obj = Axes(axes, fmt)
+            node.metadata["axes"] = axes_obj.to_list()
             paths = [d["path"] for d in datasets]
             self.datasets: List[str] = paths
             transformations = [d.get("transformations") for d in datasets]

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -9,10 +9,10 @@ import dask.array as da
 import numpy as np
 from dask import delayed
 
+from .axes import Axes
 from .format import format_from_version
 from .io import ZarrLocation
 from .types import JSONDict
-from .writer import validate_axes
 
 LOGGER = logging.getLogger("ome_zarr.reader")
 
@@ -286,7 +286,7 @@ class Multiscales(Spec):
             axes = multiscales[0].get("axes")
             fmt = format_from_version(version)
             # Raises ValueError if not valid
-            validate_axes(None, axes, fmt)
+            Axes(axes, fmt).validate()
             node.metadata["axes"] = axes
             datasets = [d["path"] for d in datasets]
             self.datasets: List[str] = datasets

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -288,8 +288,11 @@ class Multiscales(Spec):
             # Raises ValueError if not valid
             Axes(axes, fmt)
             node.metadata["axes"] = axes
-            datasets = [d["path"] for d in datasets]
-            self.datasets: List[str] = datasets
+            paths = [d["path"] for d in datasets]
+            self.datasets: List[str] = paths
+            transformations = [d.get("transformations") for d in datasets]
+            if any(trans is not None for trans in transformations):
+                node.metadata["transformations"] = transformations
             LOGGER.info("datasets %s", datasets)
         except Exception as e:
             LOGGER.error(f"failed to parse multiscale metadata: {e}")

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -49,8 +49,8 @@ def _get_valid_axes(
             f"axes length ({len(axes)}) must match number of dimensions ({ndim})"
         )
 
+    # valiates on init
     axes_obj = Axes(axes, fmt)
-    axes_obj.validate()
 
     return axes_obj.to_list(fmt)
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -69,7 +69,7 @@ def _validate_axes_types(axes_dicts: List[Dict[str, str]]) -> None:
         raise ValueError("'space' axes must come after 'channel'")
 
 
-def _validate_axes(
+def validate_axes(
     ndim: int = None,
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
     fmt: Format = CurrentFormat(),
@@ -170,7 +170,7 @@ def write_multiscale(
     """
 
     dims = len(pyramid[0].shape)
-    axes = _validate_axes(dims, axes, fmt)
+    axes = validate_axes(dims, axes, fmt)
 
     paths = []
     for path, dataset in enumerate(pyramid):
@@ -213,7 +213,7 @@ def write_multiscales_metadata(
         if fmt.version in ("0.1", "0.2"):
             LOGGER.info("axes ignored for version 0.1 or 0.2")
         else:
-            axes = _validate_axes(axes=axes, fmt=fmt)
+            axes = validate_axes(axes=axes, fmt=fmt)
             if axes is not None:
                 multiscales[0]["axes"] = axes
     group.attrs["multiscales"] = multiscales
@@ -267,7 +267,7 @@ def write_image(
         axes = None
 
     # check axes before trying to scale
-    _validate_axes(image.ndim, axes, fmt)
+    validate_axes(image.ndim, axes, fmt)
 
     if chunks is not None:
         chunks = _retuple(chunks, image.shape)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -213,7 +213,9 @@ def write_multiscales_metadata(
         if fmt.version in ("0.1", "0.2"):
             LOGGER.info("axes ignored for version 0.1 or 0.2")
         else:
-            multiscales[0]["axes"] = _validate_axes(axes=axes, fmt=fmt)
+            axes = _validate_axes(axes=axes, fmt=fmt)
+            if axes is not None:
+                multiscales[0]["axes"] = axes
     group.attrs["multiscales"] = multiscales
 
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -15,7 +15,7 @@ from .types import JSONDict
 LOGGER = logging.getLogger("ome_zarr.writer")
 
 
-def validate_axes(
+def _get_valid_axes(
     ndim: int = None,
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
     fmt: Format = CurrentFormat(),
@@ -131,7 +131,7 @@ def write_multiscale(
     """
 
     dims = len(pyramid[0].shape)
-    axes = validate_axes(dims, axes, fmt)
+    axes = _get_valid_axes(dims, axes, fmt)
 
     paths = []
     for path, dataset in enumerate(pyramid):
@@ -174,7 +174,7 @@ def write_multiscales_metadata(
         if fmt.version in ("0.1", "0.2"):
             LOGGER.info("axes ignored for version 0.1 or 0.2")
         else:
-            axes = validate_axes(axes=axes, fmt=fmt)
+            axes = _get_valid_axes(axes=axes, fmt=fmt)
             if axes is not None:
                 multiscales[0]["axes"] = axes
     group.attrs["multiscales"] = multiscales
@@ -307,7 +307,7 @@ def write_image(
         axes = None
 
     # check axes before trying to scale
-    validate_axes(image.ndim, axes, fmt)
+    _get_valid_axes(image.ndim, axes, fmt)
 
     if chunks is not None:
         chunks = _retuple(chunks, image.shape)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -213,8 +213,7 @@ def write_multiscales_metadata(
         if fmt.version in ("0.1", "0.2"):
             LOGGER.info("axes ignored for version 0.1 or 0.2")
         else:
-            axes = _validate_axes(axes=axes, fmt=fmt)
-            multiscales[0]["axes"] = axes
+            multiscales[0]["axes"] = _validate_axes(axes=axes, fmt=fmt)
     group.attrs["multiscales"] = multiscales
 
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -49,8 +49,8 @@ def validate_axes(
             f"axes length ({len(axes)}) must match number of dimensions ({ndim})"
         )
 
-    axes_obj = Axes(axes)
-    axes_obj.validate(fmt)
+    axes_obj = Axes(axes, fmt)
+    axes_obj.validate()
 
     return axes_obj.get_axes(fmt)
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -52,7 +52,7 @@ def validate_axes(
     axes_obj = Axes(axes, fmt)
     axes_obj.validate()
 
-    return axes_obj.get_axes(fmt)
+    return axes_obj.to_list(fmt)
 
 
 def _validate_well_images(images: List, fmt: Format = CurrentFormat()) -> None:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -10,7 +10,7 @@ from ome_zarr.reader import Multiscales, Reader
 from ome_zarr.scale import Scaler
 from ome_zarr.writer import (
     KNOWN_AXES,
-    _validate_axes,
+    validate_axes,
     write_image,
     write_multiscales_metadata,
 )
@@ -90,23 +90,23 @@ class TestWriter:
 
         # v0.3 MUST specify axes for 3D or 4D data
         with pytest.raises(ValueError):
-            _validate_axes(3, axes=None, fmt=v03)
+            validate_axes(3, axes=None, fmt=v03)
 
         # ndims must match axes length
         with pytest.raises(ValueError):
-            _validate_axes(3, axes="yx", fmt=v03)
+            validate_axes(3, axes="yx", fmt=v03)
 
         # axes must be ordered tczyx
         with pytest.raises(ValueError):
-            _validate_axes(3, axes="yxt", fmt=v03)
+            validate_axes(3, axes="yxt", fmt=v03)
         with pytest.raises(ValueError):
-            _validate_axes(2, axes=["x", "y"], fmt=v03)
+            validate_axes(2, axes=["x", "y"], fmt=v03)
         with pytest.raises(ValueError):
-            _validate_axes(5, axes="xyzct", fmt=v03)
+            validate_axes(5, axes="xyzct", fmt=v03)
 
         # valid axes - no change, converted to list
-        assert _validate_axes(2, axes=["y", "x"], fmt=v03) == ["y", "x"]
-        assert _validate_axes(5, axes="tczyx", fmt=v03) == [
+        assert validate_axes(2, axes=["y", "x"], fmt=v03) == ["y", "x"]
+        assert validate_axes(5, axes="tczyx", fmt=v03) == [
             "t",
             "c",
             "z",
@@ -115,12 +115,12 @@ class TestWriter:
         ]
 
         # if 2D or 5D, axes can be assigned automatically
-        assert _validate_axes(2, axes=None, fmt=v03) == ["y", "x"]
-        assert _validate_axes(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
+        assert validate_axes(2, axes=None, fmt=v03) == ["y", "x"]
+        assert validate_axes(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
 
         # for v0.1 or v0.2, axes should be None
-        assert _validate_axes(2, axes=["y", "x"], fmt=FormatV01()) is None
-        assert _validate_axes(2, axes=["y", "x"], fmt=FormatV02()) is None
+        assert validate_axes(2, axes=["y", "x"], fmt=FormatV01()) is None
+        assert validate_axes(2, axes=["y", "x"], fmt=FormatV02()) is None
 
         # check that write_image is checking axes
         data = self.create_data((125, 125))
@@ -138,7 +138,7 @@ class TestWriter:
 
         # ALL axes must specify 'name'
         with pytest.raises(ValueError):
-            _validate_axes(2, axes=[{"name": "y"}, {}], fmt=v04)
+            validate_axes(2, axes=[{"name": "y"}, {}], fmt=v04)
 
         all_dims = [
             {"name": "t", "type": "time"},
@@ -149,28 +149,28 @@ class TestWriter:
         ]
 
         # auto axes for 2D, 5D, converted to dict for v0.4
-        assert _validate_axes(2, axes=None, fmt=v04) == all_dims[-2:]
-        assert _validate_axes(5, axes=None, fmt=v04) == all_dims
+        assert validate_axes(2, axes=None, fmt=v04) == all_dims[-2:]
+        assert validate_axes(5, axes=None, fmt=v04) == all_dims
 
         # convert from list or string
-        assert _validate_axes(3, axes=["z", "y", "x"], fmt=v04) == all_dims[-3:]
-        assert _validate_axes(4, axes="czyx", fmt=v04) == all_dims[-4:]
+        assert validate_axes(3, axes=["z", "y", "x"], fmt=v04) == all_dims[-3:]
+        assert validate_axes(4, axes="czyx", fmt=v04) == all_dims[-4:]
 
         # invalid based on ordering of types
         with pytest.raises(ValueError):
-            assert _validate_axes(3, axes=["y", "c", "x"], fmt=v04)
+            assert validate_axes(3, axes=["y", "c", "x"], fmt=v04)
         with pytest.raises(ValueError):
-            assert _validate_axes(4, axes="ctyx", fmt=v04)
+            assert validate_axes(4, axes="ctyx", fmt=v04)
 
         # custom types
-        assert _validate_axes(3, axes=["foo", "y", "x"], fmt=v04) == [
+        assert validate_axes(3, axes=["foo", "y", "x"], fmt=v04) == [
             {"name": "foo"},
             all_dims[-2],
             all_dims[-1],
         ]
 
         # space types can be in ANY order
-        assert _validate_axes(3, axes=["x", "z", "y"], fmt=v04) == [
+        assert validate_axes(3, axes=["x", "z", "y"], fmt=v04) == [
             all_dims[-1],
             all_dims[-3],
             all_dims[-2],
@@ -178,7 +178,7 @@ class TestWriter:
 
         # Not allowed multiple custom types
         with pytest.raises(ValueError):
-            _validate_axes(4, axes=["foo", "bar", "y", "x"], fmt=v04)
+            validate_axes(4, axes=["foo", "bar", "y", "x"], fmt=v04)
 
         # unconventional naming is allowed
         strange_axes = [
@@ -187,7 +187,7 @@ class TestWriter:
             {"name": "dz", "type": "space"},
             {"name": "WIDTH", "type": "space"},
         ]
-        assert _validate_axes(4, axes=strange_axes, fmt=v04) == strange_axes
+        assert validate_axes(4, axes=strange_axes, fmt=v04) == strange_axes
 
         # check that write_image is checking axes
         data = self.create_data((125, 125))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -4,16 +4,12 @@ import numpy as np
 import pytest
 import zarr
 
+from ome_zarr.axes import KNOWN_AXES
 from ome_zarr.format import FormatV01, FormatV02, FormatV03, FormatV04
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Multiscales, Reader
 from ome_zarr.scale import Scaler
-from ome_zarr.writer import (
-    KNOWN_AXES,
-    validate_axes,
-    write_image,
-    write_multiscales_metadata,
-)
+from ome_zarr.writer import validate_axes, write_image, write_multiscales_metadata
 
 
 class TestWriter:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -10,7 +10,7 @@ from ome_zarr.io import parse_url
 from ome_zarr.reader import Multiscales, Reader
 from ome_zarr.scale import Scaler
 from ome_zarr.writer import (
-    validate_axes,
+    _get_valid_axes,
     write_image,
     write_multiscales_metadata,
     write_plate_metadata,
@@ -92,23 +92,23 @@ class TestWriter:
 
         # v0.3 MUST specify axes for 3D or 4D data
         with pytest.raises(ValueError):
-            validate_axes(3, axes=None, fmt=v03)
+            _get_valid_axes(3, axes=None, fmt=v03)
 
         # ndims must match axes length
         with pytest.raises(ValueError):
-            validate_axes(3, axes="yx", fmt=v03)
+            _get_valid_axes(3, axes="yx", fmt=v03)
 
         # axes must be ordered tczyx
         with pytest.raises(ValueError):
-            validate_axes(3, axes="yxt", fmt=v03)
+            _get_valid_axes(3, axes="yxt", fmt=v03)
         with pytest.raises(ValueError):
-            validate_axes(2, axes=["x", "y"], fmt=v03)
+            _get_valid_axes(2, axes=["x", "y"], fmt=v03)
         with pytest.raises(ValueError):
-            validate_axes(5, axes="xyzct", fmt=v03)
+            _get_valid_axes(5, axes="xyzct", fmt=v03)
 
         # valid axes - no change, converted to list
-        assert validate_axes(2, axes=["y", "x"], fmt=v03) == ["y", "x"]
-        assert validate_axes(5, axes="tczyx", fmt=v03) == [
+        assert _get_valid_axes(2, axes=["y", "x"], fmt=v03) == ["y", "x"]
+        assert _get_valid_axes(5, axes="tczyx", fmt=v03) == [
             "t",
             "c",
             "z",
@@ -117,12 +117,12 @@ class TestWriter:
         ]
 
         # if 2D or 5D, axes can be assigned automatically
-        assert validate_axes(2, axes=None, fmt=v03) == ["y", "x"]
-        assert validate_axes(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
+        assert _get_valid_axes(2, axes=None, fmt=v03) == ["y", "x"]
+        assert _get_valid_axes(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
 
         # for v0.1 or v0.2, axes should be None
-        assert validate_axes(2, axes=["y", "x"], fmt=FormatV01()) is None
-        assert validate_axes(2, axes=["y", "x"], fmt=FormatV02()) is None
+        assert _get_valid_axes(2, axes=["y", "x"], fmt=FormatV01()) is None
+        assert _get_valid_axes(2, axes=["y", "x"], fmt=FormatV02()) is None
 
         # check that write_image is checking axes
         data = self.create_data((125, 125))
@@ -140,7 +140,7 @@ class TestWriter:
 
         # ALL axes must specify 'name'
         with pytest.raises(ValueError):
-            validate_axes(2, axes=[{"name": "y"}, {}], fmt=v04)
+            _get_valid_axes(2, axes=[{"name": "y"}, {}], fmt=v04)
 
         all_dims = [
             {"name": "t", "type": "time"},
@@ -151,28 +151,28 @@ class TestWriter:
         ]
 
         # auto axes for 2D, 5D, converted to dict for v0.4
-        assert validate_axes(2, axes=None, fmt=v04) == all_dims[-2:]
-        assert validate_axes(5, axes=None, fmt=v04) == all_dims
+        assert _get_valid_axes(2, axes=None, fmt=v04) == all_dims[-2:]
+        assert _get_valid_axes(5, axes=None, fmt=v04) == all_dims
 
         # convert from list or string
-        assert validate_axes(3, axes=["z", "y", "x"], fmt=v04) == all_dims[-3:]
-        assert validate_axes(4, axes="czyx", fmt=v04) == all_dims[-4:]
+        assert _get_valid_axes(3, axes=["z", "y", "x"], fmt=v04) == all_dims[-3:]
+        assert _get_valid_axes(4, axes="czyx", fmt=v04) == all_dims[-4:]
 
         # invalid based on ordering of types
         with pytest.raises(ValueError):
-            assert validate_axes(3, axes=["y", "c", "x"], fmt=v04)
+            assert _get_valid_axes(3, axes=["y", "c", "x"], fmt=v04)
         with pytest.raises(ValueError):
-            assert validate_axes(4, axes="ctyx", fmt=v04)
+            assert _get_valid_axes(4, axes="ctyx", fmt=v04)
 
         # custom types
-        assert validate_axes(3, axes=["foo", "y", "x"], fmt=v04) == [
+        assert _get_valid_axes(3, axes=["foo", "y", "x"], fmt=v04) == [
             {"name": "foo"},
             all_dims[-2],
             all_dims[-1],
         ]
 
         # space types can be in ANY order
-        assert validate_axes(3, axes=["x", "z", "y"], fmt=v04) == [
+        assert _get_valid_axes(3, axes=["x", "z", "y"], fmt=v04) == [
             all_dims[-1],
             all_dims[-3],
             all_dims[-2],
@@ -180,7 +180,7 @@ class TestWriter:
 
         # Not allowed multiple custom types
         with pytest.raises(ValueError):
-            validate_axes(4, axes=["foo", "bar", "y", "x"], fmt=v04)
+            _get_valid_axes(4, axes=["foo", "bar", "y", "x"], fmt=v04)
 
         # unconventional naming is allowed
         strange_axes = [
@@ -189,7 +189,7 @@ class TestWriter:
             {"name": "dz", "type": "space"},
             {"name": "WIDTH", "type": "space"},
         ]
-        assert validate_axes(4, axes=strange_axes, fmt=v04) == strange_axes
+        assert _get_valid_axes(4, axes=strange_axes, fmt=v04) == strange_axes
 
         # check that write_image is checking axes
         data = self.create_data((125, 125))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -4,12 +4,13 @@ import numpy as np
 import pytest
 import zarr
 
-from ome_zarr.format import FormatV01, FormatV02, FormatV03
+from ome_zarr.format import FormatV01, FormatV02, FormatV03, FormatV04
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Multiscales, Reader
 from ome_zarr.scale import Scaler
 from ome_zarr.writer import (
-    _validate_axes_names,
+    KNOWN_AXES,
+    _validate_axes,
     write_image,
     write_multiscales_metadata,
 )
@@ -55,6 +56,7 @@ class TestWriter:
             ),
             pytest.param(FormatV02, id="V02"),
             pytest.param(FormatV03, id="V03"),
+            pytest.param(FormatV04, id="V04"),
         ),
     )
     def test_writer(self, shape, scaler, format_version):
@@ -75,11 +77,11 @@ class TestWriter:
         reader = Reader(parse_url(f"{self.path}/test"))
         node = list(reader())[0]
         assert Multiscales.matches(node.zarr)
-        if version.version not in ("0.1", "0.2"):
+        if version.version in ("0.1", "0.2"):
             # v0.1 and v0.2 MUST be 5D
-            assert node.data[0].shape == shape
-        else:
             assert node.data[0].ndim == 5
+        else:
+            assert node.data[0].shape == shape
         assert np.allclose(data, node.data[0][...].compute())
 
     def test_dim_names(self):
@@ -88,23 +90,23 @@ class TestWriter:
 
         # v0.3 MUST specify axes for 3D or 4D data
         with pytest.raises(ValueError):
-            _validate_axes_names(3, axes=None, fmt=v03)
+            _validate_axes(3, axes=None, fmt=v03)
 
         # ndims must match axes length
         with pytest.raises(ValueError):
-            _validate_axes_names(3, axes="yx", fmt=v03)
+            _validate_axes(3, axes="yx", fmt=v03)
 
         # axes must be ordered tczyx
         with pytest.raises(ValueError):
-            _validate_axes_names(3, axes="yxt", fmt=v03)
+            _validate_axes(3, axes="yxt", fmt=v03)
         with pytest.raises(ValueError):
-            _validate_axes_names(2, axes=["x", "y"], fmt=v03)
+            _validate_axes(2, axes=["x", "y"], fmt=v03)
         with pytest.raises(ValueError):
-            _validate_axes_names(5, axes="xyzct", fmt=v03)
+            _validate_axes(5, axes="xyzct", fmt=v03)
 
         # valid axes - no change, converted to list
-        assert _validate_axes_names(2, axes=["y", "x"], fmt=v03) == ["y", "x"]
-        assert _validate_axes_names(5, axes="tczyx", fmt=v03) == [
+        assert _validate_axes(2, axes=["y", "x"], fmt=v03) == ["y", "x"]
+        assert _validate_axes(5, axes="tczyx", fmt=v03) == [
             "t",
             "c",
             "z",
@@ -113,12 +115,12 @@ class TestWriter:
         ]
 
         # if 2D or 5D, axes can be assigned automatically
-        assert _validate_axes_names(2, axes=None, fmt=v03) == ["y", "x"]
-        assert _validate_axes_names(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
+        assert _validate_axes(2, axes=None, fmt=v03) == ["y", "x"]
+        assert _validate_axes(5, axes=None, fmt=v03) == ["t", "c", "z", "y", "x"]
 
         # for v0.1 or v0.2, axes should be None
-        assert _validate_axes_names(2, axes=["y", "x"], fmt=FormatV01()) is None
-        assert _validate_axes_names(2, axes=["y", "x"], fmt=FormatV02()) is None
+        assert _validate_axes(2, axes=["y", "x"], fmt=FormatV01()) is None
+        assert _validate_axes(2, axes=["y", "x"], fmt=FormatV02()) is None
 
         # check that write_image is checking axes
         data = self.create_data((125, 125))
@@ -128,6 +130,73 @@ class TestWriter:
                 group=self.group,
                 fmt=v03,
                 axes="xyz",
+            )
+
+    def test_axes_dicts(self):
+
+        v04 = FormatV04()
+
+        # ALL axes must specify 'name'
+        with pytest.raises(ValueError):
+            _validate_axes(2, axes=[{"name": "y"}, {}], fmt=v04)
+
+        all_dims = [
+            {"name": "t", "type": "time"},
+            {"name": "c", "type": "channel"},
+            {"name": "z", "type": "space"},
+            {"name": "y", "type": "space"},
+            {"name": "x", "type": "space"},
+        ]
+
+        # auto axes for 2D, 5D, converted to dict for v0.4
+        assert _validate_axes(2, axes=None, fmt=v04) == all_dims[-2:]
+        assert _validate_axes(5, axes=None, fmt=v04) == all_dims
+
+        # convert from list or string
+        assert _validate_axes(3, axes=["z", "y", "x"], fmt=v04) == all_dims[-3:]
+        assert _validate_axes(4, axes="czyx", fmt=v04) == all_dims[-4:]
+
+        # invalid based on ordering of types
+        with pytest.raises(ValueError):
+            assert _validate_axes(3, axes=["y", "c", "x"], fmt=v04)
+        with pytest.raises(ValueError):
+            assert _validate_axes(4, axes="ctyx", fmt=v04)
+
+        # custom types
+        assert _validate_axes(3, axes=["foo", "y", "x"], fmt=v04) == [
+            {"name": "foo"},
+            all_dims[-2],
+            all_dims[-1],
+        ]
+
+        # space types can be in ANY order
+        assert _validate_axes(3, axes=["x", "z", "y"], fmt=v04) == [
+            all_dims[-1],
+            all_dims[-3],
+            all_dims[-2],
+        ]
+
+        # Not allowed multiple custom types
+        with pytest.raises(ValueError):
+            _validate_axes(4, axes=["foo", "bar", "y", "x"], fmt=v04)
+
+        # unconventional naming is allowed
+        strange_axes = [
+            {"name": "duration", "type": "time"},
+            {"name": "rotation", "type": "angle"},
+            {"name": "dz", "type": "space"},
+            {"name": "WIDTH", "type": "space"},
+        ]
+        assert _validate_axes(4, axes=strange_axes, fmt=v04) == strange_axes
+
+        # check that write_image is checking axes
+        data = self.create_data((125, 125))
+        with pytest.raises(ValueError):
+            write_image(
+                image=data,
+                group=self.group,
+                fmt=v04,
+                axes="xt",
             )
 
 
@@ -177,6 +246,7 @@ class TestMultiscalesMetadata:
     def test_axes(self, axes):
         write_multiscales_metadata(self.root, ["0"], axes=axes)
         assert "multiscales" in self.root.attrs
+        axes = [{"name": name, "type": KNOWN_AXES[name]} for name in axes]
         assert self.root.attrs["multiscales"][0]["axes"] == axes
 
     @pytest.mark.parametrize("fmt", (FormatV01(), FormatV02()))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -17,6 +17,12 @@ from ome_zarr.writer import (
     write_well_metadata,
 )
 
+TRANSFORMATIONS = [
+    {"axisIndices": [1, 2, 3], "scale": [0.50, 0.36, 0.36], "type": "scale"},
+    {"axisIndices": [1, 2, 3], "scale": [0.50, 0.72, 0.72], "type": "scale"},
+    {"axisIndices": [1, 2, 3], "scale": [0.50, 1.44, 1.44], "type": "scale"},
+]
+
 
 class TestWriter:
     @pytest.fixture(autouse=True)
@@ -73,6 +79,7 @@ class TestWriter:
             scaler=scaler,
             fmt=version,
             axes=axes,
+            transformations=TRANSFORMATIONS,
         )
 
         # Verify
@@ -84,6 +91,10 @@ class TestWriter:
             assert node.data[0].ndim == 5
         else:
             assert node.data[0].shape == shape
+        print("node.metadata", node.metadata)
+        for transf, expected in zip(node.metadata["transformations"], TRANSFORMATIONS):
+            assert transf == expected
+        assert len(node.metadata["transformations"]) == len(node.data)
         assert np.allclose(data, node.data[0][...].compute())
 
     def test_dim_names(self):


### PR DESCRIPTION
This builds on top of #123 to add validation of new axes dicts, based on the axes types.

Based on spec at https://github.com/ome/ngff/pull/57 (not merged yet).

There is a fair bit of validation code here cc @glyg 

Breaking changes:
 - reader `axes` now returns a list of dicts instead of list of str
 - OME-Zarr data is written as v0.4

But the writing API isn't breaking. Anything that was valid for v0.3 is also valid for v0.4, since we automatically add `type` info for `tczyx` dimensions.