### PR TITLE
Add spec metadata

### DIFF
--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -299,8 +299,7 @@ class Multiscales(Spec):
             return  # EARLY EXIT
 
         for resolution in self.datasets:
-            data: da.core.Array = self.array(
-                resolution, self.metadata["version"])
+            data: da.core.Array = self.array(resolution, self.metadata["version"])
             chunk_sizes = [
                 str(c[0]) + (" (+ %s)" % c[-1] if c[-1] != c[0] else "")
                 for c in data.chunks

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -190,7 +190,6 @@ class Labels(Spec):
     def __init__(self, node: Node) -> None:
         super().__init__(node)
         label_names = self.lookup("labels", [])
-        self.metadata["version"] = label_names.get("version", "")
         for name in label_names:
             child_zarr = self.zarr.create(name)
             if child_zarr.exists():

--- a/ome_zarr/utils.py
+++ b/ome_zarr/utils.py
@@ -36,6 +36,8 @@ def info(path: str, stats: bool = False) -> Iterator[Node]:
         print(" - metadata")
         for spec in node.specs:
             print(f"   - {spec.__class__.__name__}")
+            for key, value in spec.metadata.items():
+                print(f"     - {key}: {value}")
         print(" - data")
         for array in node.data:
             minmax = ""


### PR DESCRIPTION
While trying to audit the existing NGFF samples, I tried to extend the `ome_zarr info` command to start displaying additional information such as `version` or `axes`.

As it stands, the `ome_zarr.reader` module iterates through nodes, discovers specifications and register part of the metadata under the `Node.metadata` dictionary. My understanding is that the specification of this metadata dictionary has been primarily driven by the `napari` use case (as the napari plugin used to be part of this repository). The metadata is appending , sometimes as key/value pairs(https://github.com/ome/ome-zarr-py/blob/9a778774d11ecba5ad1d8c53242b6cc6888fd6fe/ome_zarr/reader.py#L289), sometimes as a nested dictionary (https://github.com/ome/ome-zarr-py/blob/9a778774d11ecba5ad1d8c53242b6cc6888fd6fe/ome_zarr/reader.py#L523), sometimes as a combination of both (https://github.com/ome/ome-zarr-py/blob/9a778774d11ecba5ad1d8c53242b6cc6888fd6fe/ome_zarr/reader.py#L254-L259) 

This dictionary cannot be used in its current form for a generic introspection of OME-Zarr dataset e.g. by `ome_zarr info` as the keys are not defined and the relationship to the specification is lost.

857f4fb32ebf90960c22b5ea6bf516fb350b5a5c proposes one approach to solve this problem i.e. defining metadata at the `Spec` level rather than at the `Node` level. Together with 857f4fb32ebf90960c22b5ea6bf516fb350b5a5c, a proof of concept can be run against the existing samples:

```
(base) sbesson@ls30630:ome-zarr-py (spec_metadata) $ venv/bin/ome_zarr info https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836842.zarr
WARNING:ome_zarr.io:version mismatch: detected:FormatV01, requested:FormatV03
WARNING:ome_zarr.io:version mismatch: detected:FormatV03, requested:FormatV01
https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836842.zarr/ [zgroup]
 - metadata
   - Multiscales
     - version: 0.1
     - axes: ('t', 'c', 'z', 'y', 'x')
   - OMERO
     - version: 0.1
 - data
   - (1, 4, 1, 1920, 1920)
   - (1, 4, 1, 960, 960)
   - (1, 4, 1, 480, 480)
   - (1, 4, 1, 240, 240)
```

An alternative approach would be to keep using the `Node.metadata` dictionary with a self-describing structure e.g.

```
>>> metadata
{'multiscales': {'version': '0.1', 'axes': "('t', 'c', 'z', 'y', 'x')"}, 'omero': {'version': '0.1'}}
```
  
Independently of the chosen solution, I think we want to ensure some consistent metadata storage and migrate the logic of translating this metadata into the structure expected by `napari` into the `napari-ome-zarr` plugin.