### PR TITLE
Fix remaining assumptions on 5D dimensions

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -106,7 +106,7 @@ class FormatV02(Format):
 
         kwargs = {
             "dimension_separator": "/",
-            "normalize_keys": True,
+            "normalize_keys": False,
         }
 
         mkdir = True

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -543,8 +543,9 @@ class Plate(Spec):
 
             try:
                 data = self.zarr.load(path)
-            except ValueError:
+            except ValueError as e:
                 LOGGER.error(f"Failed to load {path}")
+                LOGGER.debug(f"{e}")
                 data = np.zeros(tile_shape, dtype=self.numpy_type)
             return data
 

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -580,8 +580,8 @@ class PlateLabels(Plate):
         if "c" in self.axes:
             c_index = self.axes.index("c")
             idx = [slice(None)] * len(self.axes)
-            idx[c_index] = slice(0)
-            node.data[0] = node.data[0][c_index]
+            idx[c_index] = slice(0, 1)
+            node.data[0] = node.data[0][tuple(idx)]
         # remove image metadata
         node.metadata = {}
 

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -577,7 +577,7 @@ class Plate(Spec):
 
 
 class PlateLabels(Plate):
-    def get_tile_path(self, level: int, row: int, col: int) -> str:
+    def get_tile_path(self, level: int, row: int, col: int) -> str:  # pragma: no cover
         """251.zarr/A/1/0/labels/0/3/"""
         path = (
             f"{self.row_names[row]}/{self.col_names[col]}/"
@@ -585,7 +585,7 @@ class PlateLabels(Plate):
         )
         return path
 
-    def get_pyramid_lazy(self, node: Node) -> None:
+    def get_pyramid_lazy(self, node: Node) -> None:  # pragma: no cover
         super().get_pyramid_lazy(node)
         # pyramid data may be multi-channel, but we only have 1 labels channel
         if "c" in self.axes:
@@ -612,7 +612,7 @@ class PlateLabels(Plate):
                         del properties[label_val]["label-value"]
         node.metadata["properties"] = properties
 
-    def get_numpy_type(self, image_node: Node) -> np.dtype:
+    def get_numpy_type(self, image_node: Node) -> np.dtype:  # pragma: no cover
         # FIXME - don't assume Well A1 is valid
         path = self.get_tile_path(0, 0, 0)
         label_zarr = self.zarr.load(path)

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -576,8 +576,8 @@ class PlateLabels(Plate):
     def get_pyramid_lazy(self, node: Node) -> None:
         super().get_pyramid_lazy(node)
         # pyramid data may be multi-channel, but we only have 1 labels channel
-        if 'c' in self.axes:
-            c_index = self.axes.index('c')
+        if "c" in self.axes:
+            c_index = self.axes.index("c")
             idx = [slice(None)] * len(self.axes)
             idx[c_index] = 0
             node.data[0] = node.data[0][c_index]

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -579,7 +579,7 @@ class PlateLabels(Plate):
         if "c" in self.axes:
             c_index = self.axes.index("c")
             idx = [slice(None)] * len(self.axes)
-            idx[c_index] = 0
+            idx[c_index] = slice(0)
             node.data[0] = node.data[0][c_index]
         # remove image metadata
         node.metadata = {}

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -588,6 +588,8 @@ class PlateLabels(Plate):
     def get_pyramid_lazy(self, node: Node) -> None:  # pragma: no cover
         super().get_pyramid_lazy(node)
         # pyramid data may be multi-channel, but we only have 1 labels channel
+        # TODO: when PlateLabels are re-enabled, update the logic to handle
+        # 0.4 axes (list of dictionaries)
         if "c" in self.axes:
             c_index = self.axes.index("c")
             idx = [slice(None)] * len(self.axes)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -109,7 +109,6 @@ class TestHCSNode:
         for wp in empty_wells:
             assert parse_url(str(self.path / wp)) is None
 
-    @pytest.mark.xfail(reason="https://github.com/ome/ome-zarr-py/issues/145")
     @pytest.mark.parametrize(
         "axes, dims",
         (


### PR DESCRIPTION
Fixes #145 

A few specifications especially in the HCS domain still rely on the expectation that the underlying image will be 5D. As this constraint has been lifted with v0.3, these changes update various places in the code to dynamically identify the x, y and c axis before performing array manipulation.


Without this PR, both `ome_zarr info` and `napari` should fail to read https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0094A/7751.zarr is a suitable example for testing this change (plate with XY dimensions). With this PR included, both commands should work successfully.

The last commits also disable `PlateLabels` to fix the HCS display in `napari`.  #177 as well as https://github.com/ome/ome-zarr-py/issues/65#issuecomment-1010074621 might be fixed by this PR