### PR TITLE
Add new API to write multiscales metadata

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -103,9 +103,39 @@ def write_multiscale(
     for path, dataset in enumerate(pyramid):
         # TODO: chunks here could be different per layer
         group.create_dataset(str(path), data=dataset, chunks=chunks)
-        paths.append({"path": str(path)})
+        paths.append(str(path))
+    write_multiscales_metadata(group, paths, fmt, axes)
 
-    multiscales = [{"version": fmt.version, "datasets": paths}]
+
+def write_multiscales_metadata(
+    group: zarr.Group,
+    paths: List[str],
+    fmt: Format = CurrentFormat(),
+    axes: Union[str, List[str]] = None,
+) -> None:
+    """
+    Write the multiscales metadata in the group metadata
+
+    Parameters
+    ----------
+    group: zarr.Group
+      the group within the zarr store to store the data in
+    paths: list of str,
+      The list of path to the datasets for this multiscale image
+    fmt: Format
+      The format of the ome_zarr data which should be used.
+      Defaults to the most current.
+    axes: str or list of str
+      the names of the axes. e.g. "tczyx". Not needed for v0.1 or v0.2
+      or for v0.3 if 2D or 5D. Otherwise this must be provided
+    """
+
+    multiscales = [
+        {
+            "version": fmt.version,
+            "datasets": [{"path": str(p)} for p in paths],
+        }
+    ]
     if axes is not None:
         multiscales[0]["axes"] = axes
     group.attrs["multiscales"] = multiscales

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -116,20 +116,20 @@ def write_multiscales_metadata(
     axes: List[str] = None,
 ) -> None:
     """
-    Write the multiscales metadata in the group metadata
+    Write the multiscales metadata in the group.
 
     Parameters
     ----------
     group: zarr.Group
-      the group within the zarr store to store the data in
-    paths: list of str,
-      The list of path to the datasets for this multiscale image
+      the group within the zarr store to write the metadata in.
+    paths: list of str
+      The list of paths to the datasets for this multiscale image.
     fmt: Format
       The format of the ome_zarr data which should be used.
       Defaults to the most current.
-    axes: str or list of str
-      the names of the axes. e.g. "tczyx". Not needed for v0.1 or v0.2
-      or for v0.3 if 2D or 5D. Otherwise this must be provided
+    axes: list of str
+      the names of the axes. e.g. ["t", "c", "z", "y", "x"].
+      Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
     """
 
     multiscales = [

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -40,32 +40,34 @@ def _validate_axes_names(
     if isinstance(axes, str):
         axes = list(axes)
 
-    if axes is not None:
-        if len(axes) != ndim:
-            raise ValueError("axes length must match number of dimensions")
-        # from https://github.com/constantinpape/ome-ngff-implementations/
-        val_axes = tuple(axes)
-        if ndim == 2:
-            if val_axes != ("y", "x"):
-                raise ValueError(f"2D data must have axes ('y', 'x') {val_axes}")
-        elif ndim == 3:
-            if val_axes not in [("z", "y", "x"), ("c", "y", "x"), ("t", "y", "x")]:
-                raise ValueError(
-                    "3D data must have axes ('z', 'y', 'x') or ('c', 'y', 'x')"
-                    " or ('t', 'y', 'x'), not %s" % (val_axes,)
-                )
-        elif ndim == 4:
-            if val_axes not in [
-                ("t", "z", "y", "x"),
-                ("c", "z", "y", "x"),
-                ("t", "c", "y", "x"),
-            ]:
-                raise ValueError("4D data must have axes tzyx or czyx or tcyx")
-        else:
-            if val_axes != ("t", "c", "z", "y", "x"):
-                raise ValueError("5D data must have axes ('t', 'c', 'z', 'y', 'x')")
-
+    if len(axes) != ndim:
+        raise ValueError("axes length must match number of dimensions")
+    _validate_axes(axes)
     return axes
+
+
+def _validate_axes(axes: List[str], fmt: Format = CurrentFormat()) -> None:
+
+    val_axes = tuple(axes)
+    if len(val_axes) == 2:
+        if val_axes != ("y", "x"):
+            raise ValueError(f"2D data must have axes ('y', 'x') {val_axes}")
+    elif len(val_axes) == 3:
+        if val_axes not in [("z", "y", "x"), ("c", "y", "x"), ("t", "y", "x")]:
+            raise ValueError(
+                "3D data must have axes ('z', 'y', 'x') or ('c', 'y', 'x')"
+                " or ('t', 'y', 'x'), not %s" % (val_axes,)
+            )
+    elif len(val_axes) == 4:
+        if val_axes not in [
+            ("t", "z", "y", "x"),
+            ("c", "z", "y", "x"),
+            ("t", "c", "y", "x"),
+        ]:
+            raise ValueError("4D data must have axes tzyx or czyx or tcyx")
+    else:
+        if val_axes != ("t", "c", "z", "y", "x"):
+            raise ValueError("5D data must have axes ('t', 'c', 'z', 'y', 'x')")
 
 
 def write_multiscale(
@@ -111,7 +113,7 @@ def write_multiscales_metadata(
     group: zarr.Group,
     paths: List[str],
     fmt: Format = CurrentFormat(),
-    axes: Union[str, List[str]] = None,
+    axes: List[str] = None,
 ) -> None:
     """
     Write the multiscales metadata in the group metadata
@@ -137,7 +139,11 @@ def write_multiscales_metadata(
         }
     ]
     if axes is not None:
-        multiscales[0]["axes"] = axes
+        if fmt.version in ("0.1", "0.2"):
+            LOGGER.info("axes ignored for version 0.1 or 0.2")
+        else:
+            _validate_axes(axes, fmt)
+            multiscales[0]["axes"] = axes
     group.attrs["multiscales"] = multiscales
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -178,3 +178,25 @@ class TestMultiscalesMetadata:
         write_multiscales_metadata(self.root, ["0"], axes=axes)
         assert "multiscales" in self.root.attrs
         assert self.root.attrs["multiscales"][0]["axes"] == axes
+
+    @pytest.mark.parametrize("fmt", (FormatV01(), FormatV02()))
+    def test_axes_ignored(self, fmt):
+        write_multiscales_metadata(
+            self.root, ["0"], fmt=fmt, axes=["t", "c", "z", "y", "x"]
+        )
+        assert "multiscales" in self.root.attrs
+        assert "axes" not in self.root.attrs["multiscales"][0]
+
+    @pytest.mark.parametrize(
+        "axes",
+        (
+            [],
+            ["i", "j"],
+            ["x", "y"],
+            ["y", "x", "c"],
+            ["x", "y", "z", "c", "t"],
+        ),
+    )
+    def test_invalid_0_3_axes(self, axes):
+        with pytest.raises(ValueError):
+            write_multiscales_metadata(self.root, ["0"], fmt=FormatV03(), axes=axes)


### PR DESCRIPTION
While investigating the testing requirements for https://github.com/ome/ome-zarr-py/pull/148, I found that my primary need are API helper methods allowing to write NGFF metadata e.g. `write_plate_metadata`, `write_well_metadata` and generate test data

As a first step towards these APIs, this PR refactors the existing multiscales generation code and extract the `multiscales` metadata addition logic into a separate API `write_multiscales_metadata`.
A direct application of this method is the scenario where a library would have its own implementation of the data writing but would still like to write the metadata using the core API. An example is `omero-cli-zarr` where https://github.com/ome/omero-cli-zarr/blob/7589cc47920b912480b3e6daa282c3d773c2bfdf/src/omero_zarr/raw_pixels.py#L276-L289 could be updated to consume this API.

In addition to the new API, the existing internal axes validation method is split into two, separating the validation of the axes against the array dimensions and the inference of axes values for 2D/5D cases from the strict validation of the axes using the allowed values.

A set of unit tests are also added to cover the different scenarios.