### PR TITLE
Add support for passing wells as List[dict] in write_plate_metadata

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -104,8 +104,7 @@ def _validate_plate_acquisitions(
         "starttime",
         "endtime",
     ]
-    if acquisitions is None:
-        return
+
     for acquisition in acquisitions:
         if not isinstance(acquisition, dict):
             raise ValueError(f"{acquisition} must be a dictionary")

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -126,7 +126,7 @@ def _validate_plate_wells(wells: List, fmt: Format = CurrentFormat()) -> List[di
         "path",
     ]
     validated_wells = []
-    if wells is None:
+    if wells is None or len(wells) == 0:
         raise ValueError("Empty wells list")
     for well in wells:
         if isinstance(well, str):
@@ -138,7 +138,7 @@ def _validate_plate_wells(wells: List, fmt: Format = CurrentFormat()) -> List[di
                 raise ValueError(f"{well} must contain an path key")
             if not isinstance(well["path"], str):
                 raise ValueError(f"{well} path must be of str type")
-            validated_wells.append({"path": str(well)})
+            validated_wells.append(well)
         else:
             raise ValueError(f"Unrecognized type for {well}")
     return validated_wells

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -139,7 +139,7 @@ def _validate_plate_wells(
             if any(e not in VALID_KEYS for e in well.keys()):
                 LOGGER.debug("f{well} contains unspecified keys")
             if "path" not in well:
-                raise ValueError(f"{well} must contain an path key")
+                raise ValueError(f"{well} must contain a path key")
             if not isinstance(well["path"], str):
                 raise ValueError(f"{well} path must be of str type")
             validated_wells.append(well)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -70,7 +70,9 @@ def _validate_axes(axes: List[str], fmt: Format = CurrentFormat()) -> None:
             raise ValueError("5D data must have axes ('t', 'c', 'z', 'y', 'x')")
 
 
-def _validate_well_images(images: List, fmt: Format = CurrentFormat()) -> List[dict]:
+def _validate_well_images(
+    images: List[Union[str, dict]], fmt: Format = CurrentFormat()
+) -> List[dict]:
 
     VALID_KEYS = [
         "acquisition",
@@ -120,7 +122,9 @@ def _validate_plate_acquisitions(
     return acquisitions
 
 
-def _validate_plate_wells(wells: List, fmt: Format = CurrentFormat()) -> List[dict]:
+def _validate_plate_wells(
+    wells: List[Union[str, dict]], fmt: Format = CurrentFormat()
+) -> List[dict]:
 
     VALID_KEYS = [
         "path",
@@ -225,7 +229,7 @@ def write_plate_metadata(
     group: zarr.Group,
     rows: List[str],
     columns: List[str],
-    wells: Union[List[str], List[dict]],
+    wells: List[Union[str, dict]],
     fmt: Format = CurrentFormat(),
     acquisitions: List[dict] = None,
     field_count: int = None,
@@ -242,7 +246,7 @@ def write_plate_metadata(
       The list of names for the plate rows
     columns: list of str
       The list of names for the plate columns
-    wells: list of str or list of dict
+    wells: list of str or dict
       The list of paths for the well groups
     fmt: Format
       The format of the ome_zarr data which should be used.
@@ -272,7 +276,7 @@ def write_plate_metadata(
 
 def write_well_metadata(
     group: zarr.Group,
-    images: Union[List[str], List[dict]],
+    images: List[Union[str, dict]],
     fmt: Format = CurrentFormat(),
 ) -> None:
     """
@@ -282,7 +286,7 @@ def write_well_metadata(
     ----------
     group: zarr.Group
       the group within the zarr store to write the metadata in.
-    image_paths: list of str
+    image_paths: list of str or dict
       The list of paths for the well images
     image_acquisitions: list of int
       The list of acquisitions for the well images

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -375,7 +375,6 @@ class TestPlateMetadata:
         ),
     )
     def test_invalid_well_keys(self, wells):
-        wells = [{"path": 0}]
         with pytest.raises(ValueError):
             write_plate_metadata(self.root, ["A"], ["1"], wells)
 


### PR DESCRIPTION
Follow-up of https://github.com/ome/ome-zarr-py/pull/153, this adds support for wells specified as lists of dictionaries rather than lists of string. The primary use case are:

1- support additional custom metadata e.g.

```
wells = [
    {"path": "A/1", "concentration": "1"},
    {"path": "A/2", "concentration": "2"},
    {"path": "B/1", "concentration": "5"},
]
write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
```

2- support the upcoming breaking changes proposed in https://github.com/ome/ngff/pull/24 i.e.

```
wells = [
    {"path": "A/1", "rowIndex": 0, "columnIndex": 0},
    {"path": "A/2", "rowIndex": 0, "columnIndex": 1},
    {"path": "B/1", "rowIndex": 1, "columnIndex": 0},
]
write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
```

Unit tests are updated accordingly to cover all variants. While working on the tests, I found that the usage of the list mutability by the `_validate*` API was creating unnecessary confusion when the input argument is re-used. 347da426df98db2a9653d9bdbf17e6b8bbc00377 updates the logic to create a copy of the input list when the content might be modified by the validation function.

Since this API will likely be released with 0.4 support and given the changes proposed in https://github.com/ome/ngff/pull/24, it is likely the former support for wells as `List[str]` will:
 1- either need to be removed as  a list of paths will not be sufficient to generate valid `wells`
 2- or be updated to include the assumptions that the wells are following the standard letter/number convention and auto-generate the underlying `rowIndex`/`columnIndex` indices.
I left this discussion outside the scope of this PR which only focuses on supporting the `List[dict]` form.

