### PR TITLE
Add support for HCS 0.4 specification

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -117,8 +117,6 @@ class FormatV01(Format):
                 raise ValueError(f"{well} must contain a {key} key of type {key_type}")
             if not isinstance(well[key], key_type):
                 raise ValueError(f"{well} path must be of {key_type} type")
-        if len(well["path"].split("/")) != 2:
-            raise ValueError(f"{well} path must exactly be composed of 2 groups")
 
 
 class FormatV02(FormatV01):
@@ -196,6 +194,11 @@ class FormatV04(FormatV03):
             raise ValueError(f"{column} is not defined in the list of columns")
         columnIndex = columns.index(column)
         return {"path": str(well), "rowIndex": rowIndex, "columnIndex": columnIndex}
+
+    def validate_well_dict(self, well: dict) -> None:
+        super().validate_well_dict(well)
+        if len(well["path"].split("/")) != 2:
+            raise ValueError(f"{well} path must exactly be composed of 2 groups")
 
 
 CurrentFormat = FormatV04

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -79,7 +79,9 @@ class Format(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def validate_well_dict(self, well: dict) -> None:
+    def validate_well_dict(
+        self, well: dict, rows: List[str], columns: List[str]
+    ) -> None:
         raise NotImplementedError()
 
 
@@ -109,7 +111,9 @@ class FormatV01(Format):
     ) -> dict:
         return {"path": str(well)}
 
-    def validate_well_dict(self, well: dict) -> None:
+    def validate_well_dict(
+        self, well: dict, rows: List[str], columns: List[str]
+    ) -> None:
         if any(e not in self.REQUIRED_PLATE_WELL_KEYS for e in well.keys()):
             LOGGER.debug("f{well} contains unspecified keys")
         for key, key_type in self.REQUIRED_PLATE_WELL_KEYS.items():
@@ -195,8 +199,10 @@ class FormatV04(FormatV03):
         columnIndex = columns.index(column)
         return {"path": str(well), "rowIndex": rowIndex, "columnIndex": columnIndex}
 
-    def validate_well_dict(self, well: dict) -> None:
-        super().validate_well_dict(well)
+    def validate_well_dict(
+        self, well: dict, rows: List[str], columns: List[str]
+    ) -> None:
+        super().validate_well_dict(well, rows, columns)
         if len(well["path"].split("/")) != 2:
             raise ValueError(f"{well} path must exactly be composed of 2 groups")
 

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -208,8 +208,12 @@ class FormatV04(FormatV03):
         row, column = well["path"].split("/")
         if row not in rows:
             raise ValueError(f"{row} is not defined in the plate rows")
+        if well["rowIndex"] != rows.index(row):
+            raise ValueError(f"Mismatching row index for {well}")
         if column not in columns:
             raise ValueError(f"{column} is not defined in the plate columns")
+        if well["columnIndex"] != columns.index(column):
+            raise ValueError(f"Mismatching column index for {well}")
 
 
 CurrentFormat = FormatV04

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -179,7 +179,7 @@ class FormatV04(FormatV03):
     introduce transformations in multiscales (Nov 2021)
     """
 
-    REQUIRED_PLATE_WELL_KEYS = {"path": str, "rowIndex": int, "colIndex": int}
+    REQUIRED_PLATE_WELL_KEYS = {"path": str, "rowIndex": int, "columnIndex": int}
 
     @property
     def version(self) -> str:
@@ -193,9 +193,9 @@ class FormatV04(FormatV03):
             raise ValueError(f"{row} is not defined in the list of rows")
         rowIndex = rows.index(row)
         if column not in columns:
-            raise ValueError(f"{row} is not defined in the list of rows")
-        colIndex = columns.index(column)
-        return {"path": str(well), "rowIndex": rowIndex, "colIndex": colIndex}
+            raise ValueError(f"{column} is not defined in the list of columns")
+        columnIndex = columns.index(column)
+        return {"path": str(well), "rowIndex": rowIndex, "columnIndex": columnIndex}
 
 
 CurrentFormat = FormatV04

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -44,11 +44,11 @@ def detect_format(metadata: dict) -> "Format":
 class Format(ABC):
     @property
     @abstractmethod
-    def version(self) -> str:
+    def version(self) -> str:  # pragma: no cover
         raise NotImplementedError()
 
     @abstractmethod
-    def matches(self, metadata: dict) -> bool:
+    def matches(self, metadata: dict) -> bool:  # pragma: no cover
         raise NotImplementedError()
 
     @abstractmethod
@@ -56,7 +56,7 @@ class Format(ABC):
         raise NotImplementedError()
 
     # @abstractmethod
-    def init_channels(self) -> None:
+    def init_channels(self) -> None:  # pragma: no cover
         raise NotImplementedError()
 
     def _get_multiscale_version(self, metadata: dict) -> Optional[str]:
@@ -75,13 +75,13 @@ class Format(ABC):
     @abstractmethod
     def generate_well_dict(
         self, well: str, rows: List[str], columns: List[str]
-    ) -> dict:
+    ) -> dict:  # pragma: no cover
         raise NotImplementedError()
 
     @abstractmethod
     def validate_well_dict(
         self, well: dict, rows: List[str], columns: List[str]
-    ) -> None:
+    ) -> None:  # pragma: no cover
         raise NotImplementedError()
 
 

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -205,6 +205,11 @@ class FormatV04(FormatV03):
         super().validate_well_dict(well, rows, columns)
         if len(well["path"].split("/")) != 2:
             raise ValueError(f"{well} path must exactly be composed of 2 groups")
+        row, column = well["path"].split("/")
+        if row not in rows:
+            raise ValueError(f"{row} is not defined in the plate rows")
+        if column not in columns:
+            raise ValueError(f"{column} is not defined in the plate columns")
 
 
 CurrentFormat = FormatV04

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -117,6 +117,8 @@ class FormatV01(Format):
                 raise ValueError(f"{well} must contain a {key} key of type {key_type}")
             if not isinstance(well[key], key_type):
                 raise ValueError(f"{well} path must be of {key_type} type")
+        if len(well["path"].split("/")) != 2:
+            raise ValueError(f"{well} path must exactly be composed of 2 groups")
 
 
 class FormatV02(FormatV01):

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -135,10 +135,10 @@ def _validate_plate_wells(
     for well in wells:
         if isinstance(well, str):
             well_dict = fmt.generate_well_dict(well, rows, columns)
-            fmt.validate_well_dict(well_dict)
+            fmt.validate_well_dict(well_dict, rows, columns)
             validated_wells.append(well_dict)
         elif isinstance(well, dict):
-            fmt.validate_well_dict(well)
+            fmt.validate_well_dict(well, rows, columns)
             validated_wells.append(well)
         else:
             raise ValueError(f"Unrecognized type for {well}")

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -111,22 +111,14 @@ def _validate_plate_wells(
     wells: List[Union[str, dict]], fmt: Format = CurrentFormat()
 ) -> List[dict]:
 
-    VALID_KEYS = [
-        "path",
-    ]
     validated_wells = []
     if wells is None or len(wells) == 0:
         raise ValueError("Empty wells list")
     for well in wells:
         if isinstance(well, str):
-            validated_wells.append({"path": str(well)})
+            validated_wells.append(fmt.generate_well_dict(well))
         elif isinstance(well, dict):
-            if any(e not in VALID_KEYS for e in well.keys()):
-                LOGGER.debug("f{well} contains unspecified keys")
-            if "path" not in well:
-                raise ValueError(f"{well} must contain a path key")
-            if not isinstance(well["path"], str):
-                raise ValueError(f"{well} path must be of str type")
+            fmt.validate_well_dict(well)
             validated_wells.append(well)
         else:
             raise ValueError(f"Unrecognized type for {well}")

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -107,6 +107,21 @@ def _validate_plate_acquisitions(
     return acquisitions
 
 
+def _validate_plate_rows_columns(
+    rows_or_columns: List[str],
+    fmt: Format = CurrentFormat(),
+) -> List[dict]:
+
+    if len(set(rows_or_columns)) != len(rows_or_columns):
+        raise ValueError(f"{rows_or_columns} must contain unique elements")
+    validated_list = []
+    for element in rows_or_columns:
+        if not element.isalnum():
+            raise ValueError(f"{element} must contain alphanumeric characters")
+        validated_list.append({"name": str(element)})
+    return validated_list
+
+
 def _validate_plate_wells(
     wells: List[Union[str, dict]],
     rows: List[str],
@@ -256,8 +271,8 @@ def write_plate_metadata(
     """
 
     plate: Dict[str, Union[str, int, List[Dict]]] = {
-        "columns": [{"name": str(c)} for c in columns],
-        "rows": [{"name": str(r)} for r in rows],
+        "columns": _validate_plate_rows_columns(columns),
+        "rows": _validate_plate_rows_columns(rows),
         "wells": _validate_plate_wells(wells, rows, columns, fmt=fmt),
         "version": fmt.version,
     }

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -108,7 +108,10 @@ def _validate_plate_acquisitions(
 
 
 def _validate_plate_wells(
-    wells: List[Union[str, dict]], fmt: Format = CurrentFormat()
+    wells: List[Union[str, dict]],
+    rows: List[str],
+    columns: List[str],
+    fmt: Format = CurrentFormat(),
 ) -> List[dict]:
 
     validated_wells = []
@@ -116,7 +119,9 @@ def _validate_plate_wells(
         raise ValueError("Empty wells list")
     for well in wells:
         if isinstance(well, str):
-            validated_wells.append(fmt.generate_well_dict(well))
+            well_dict = fmt.generate_well_dict(well, rows, columns)
+            fmt.validate_well_dict(well_dict)
+            validated_wells.append(well_dict)
         elif isinstance(well, dict):
             fmt.validate_well_dict(well)
             validated_wells.append(well)
@@ -253,7 +258,7 @@ def write_plate_metadata(
     plate: Dict[str, Union[str, int, List[Dict]]] = {
         "columns": [{"name": str(c)} for c in columns],
         "rows": [{"name": str(r)} for r in rows],
-        "wells": _validate_plate_wells(wells),
+        "wells": _validate_plate_wells(wells, rows, columns, fmt=fmt),
         "version": fmt.version,
     }
     if name is not None:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,5 +1,3 @@
-import uuid
-
 import pytest
 import zarr
 from numpy import zeros
@@ -139,34 +137,6 @@ class TestHCSNode:
         assert isinstance(node.specs[0], Plate)
 
         node = Node(parse_url(str(self.path / "A" / "1")), list())
-        assert node.data
-        assert node.metadata
-        assert len(node.specs) == 1
-        assert isinstance(node.specs[0], Well)
-
-    def test_uuid_plate(self):
-        group1 = uuid.uuid4()
-        group2 = uuid.uuid4()
-        well = {"path": f"{group1}/{group2}", "rowIndex": 0, "columnIndex": 0}
-        write_plate_metadata(self.root, ["A"], ["1"], [well])
-        row_group = self.root.require_group(group1)
-        well = row_group.require_group(group2)
-        write_well_metadata(well, ["0"])
-        image = well.require_group("0")
-        write_image(zeros((1, 1, 1, 256, 256)), image)
-
-        node = Node(parse_url(str(self.path)), list())
-        assert node.data
-        assert node.metadata
-        assert len(node.specs) == 1
-        assert isinstance(node.specs[0], Plate)
-        assert node.specs[0].row_names == ["A"]
-        assert node.specs[0].col_names == ["1"]
-        assert node.specs[0].well_paths == [f"{group1}/{group2}"]
-        assert node.specs[0].row_count == 1
-        assert node.specs[0].column_count == 1
-
-        node = Node(parse_url(str(self.path / f"{group1}/{group2}")), list())
         assert node.data
         assert node.metadata
         assert len(node.specs) == 1

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -504,13 +504,15 @@ class TestPlateMetadata:
             [{"path": "plate/A/1", "rowIndex": 0, "columnIndex": 0}],
             [{"path": "plate/A1", "rowIndex": 0, "columnIndex": 0}],
             [{"path": "A/1/0", "rowIndex": 0, "columnIndex": 0}],
-            # Invalid indices
+            [{"path": "A1", "rowIndex": 0, "columnIndex": 0}],
+            [{"path": "0", "rowIndex": 0, "columnIndex": 0}],
+            # Invalid row/column indices
             [{"path": "A/1", "rowIndex": "0", "columnIndex": 0}],
             [{"path": "A/1", "rowIndex": 0, "columnIndex": "0"}],
-            [{"path": "A1", "rowIndex": 0, "columnIndex": 0}],
-            # Mismatching indices
+            # Undefined rows/columns
             [{"path": "C/1", "rowIndex": 2, "columnIndex": 0}],
             [{"path": "A/3", "rowIndex": 0, "columnIndex": 2}],
+            # Mismatching indices
             [{"path": "A/1", "rowIndex": 0, "columnIndex": 1}],
             [{"path": "A/1", "rowIndex": 1, "columnIndex": 0}],
         ),

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -499,6 +499,8 @@ class TestPlateMetadata:
             [{"path": "A/1", "colIndex": 0}],
             [{"path": "A/1", "rowIndex": "0", "colIndex": 0}],
             [{"path": "A/1", "rowIndex": 0, "colIndex": "0"}],
+            [{"path": "A1", "rowIndex": 0, "colIndex": "0"}],
+            [{"path": "plate/A/1", "rowIndex": 0, "colIndex": "0"}],
         ),
     )
     def test_invalid_well_keys(self, wells):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,5 @@
 import pathlib
+import uuid
 
 import numpy as np
 import pytest
@@ -572,6 +573,37 @@ class TestPlateMetadata:
     def test_invalid_columns(self, columns):
         with pytest.raises(ValueError):
             write_plate_metadata(self.root, ["A"], columns, ["A/1"])
+
+    def test_uuid_plate(self):
+        wells = [
+            {
+                "path": str(uuid.uuid4()) + "/" + str(uuid.uuid4()),
+                "rowIndex": 0,
+                "columnIndex": 0,
+            },
+            {
+                "path": str(uuid.uuid4()) + "/" + str(uuid.uuid4()),
+                "rowIndex": 0,
+                "columnIndex": 1,
+            },
+            {
+                "path": str(uuid.uuid4()) + "/" + str(uuid.uuid4()),
+                "rowIndex": 1,
+                "columnIndex": 0,
+            },
+            {
+                "path": str(uuid.uuid4()) + "/" + str(uuid.uuid4()),
+                "rowIndex": 0,
+                "columnIndex": 1,
+            },
+        ]
+        write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
+
+        assert "plate" in self.root.attrs
+        assert self.root.attrs["plate"]["columns"] == [{"name": "1"}, {"name": "2"}]
+        assert self.root.attrs["plate"]["rows"] == [{"name": "A"}, {"name": "B"}]
+        assert self.root.attrs["plate"]["version"] == CurrentFormat().version
+        assert self.root.attrs["plate"]["wells"] == wells
 
 
 class TestWellMetadata:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,5 +1,4 @@
 import pathlib
-import uuid
 
 import numpy as np
 import pytest
@@ -502,6 +501,8 @@ class TestPlateMetadata:
             [{"path": "A/1", "rowIndex": 0, "columnIndex": "0"}],
             [{"path": "A1", "rowIndex": 0, "columnIndex": "0"}],
             [{"path": "plate/A/1", "rowIndex": 0, "columnIndex": "0"}],
+            [{"path": "C/1", "rowIndex": 2, "columnIndex": 0}],
+            [{"path": "A/3", "rowIndex": 0, "columnIndex": 2}],
         ),
     )
     def test_invalid_well_keys(self, wells):
@@ -573,37 +574,6 @@ class TestPlateMetadata:
     def test_invalid_columns(self, columns):
         with pytest.raises(ValueError):
             write_plate_metadata(self.root, ["A"], columns, ["A/1"])
-
-    def test_uuid_plate(self):
-        wells = [
-            {
-                "path": str(uuid.uuid4()) + "/" + str(uuid.uuid4()),
-                "rowIndex": 0,
-                "columnIndex": 0,
-            },
-            {
-                "path": str(uuid.uuid4()) + "/" + str(uuid.uuid4()),
-                "rowIndex": 0,
-                "columnIndex": 1,
-            },
-            {
-                "path": str(uuid.uuid4()) + "/" + str(uuid.uuid4()),
-                "rowIndex": 1,
-                "columnIndex": 0,
-            },
-            {
-                "path": str(uuid.uuid4()) + "/" + str(uuid.uuid4()),
-                "rowIndex": 0,
-                "columnIndex": 1,
-            },
-        ]
-        write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
-
-        assert "plate" in self.root.attrs
-        assert self.root.attrs["plate"]["columns"] == [{"name": "1"}, {"name": "2"}]
-        assert self.root.attrs["plate"]["rows"] == [{"name": "A"}, {"name": "B"}]
-        assert self.root.attrs["plate"]["version"] == CurrentFormat().version
-        assert self.root.attrs["plate"]["wells"] == wells
 
 
 class TestWellMetadata:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -492,15 +492,23 @@ class TestPlateMetadata:
     @pytest.mark.parametrize(
         "wells",
         (
-            [{"path": 0}],
+            # Missing required keys
             [{"id": "test"}],
-            [{"path": "A/1"}, {"path": None}],
+            [{"path": "A/1"}],
             [{"path": "A/1", "rowIndex": 0}],
             [{"path": "A/1", "columnIndex": 0}],
+            [{"rowIndex": 0, "columnIndex": 0}],
+            # Invalid paths
+            [{"path": 0, "rowIndex": 0, "columnIndex": 0}],
+            [{"path": None, "rowIndex": 0, "columnIndex": 0}],
+            [{"path": "plate/A/1", "rowIndex": 0, "columnIndex": 0}],
+            [{"path": "plate/A1", "rowIndex": 0, "columnIndex": 0}],
+            [{"path": "A/1/0", "rowIndex": 0, "columnIndex": 0}],
+            # Invalid indices
             [{"path": "A/1", "rowIndex": "0", "columnIndex": 0}],
             [{"path": "A/1", "rowIndex": 0, "columnIndex": "0"}],
-            [{"path": "A1", "rowIndex": 0, "columnIndex": "0"}],
-            [{"path": "plate/A/1", "rowIndex": 0, "columnIndex": 0}],
+            [{"path": "A1", "rowIndex": 0, "columnIndex": 0}],
+            # Mismatching indices
             [{"path": "C/1", "rowIndex": 2, "columnIndex": 0}],
             [{"path": "A/3", "rowIndex": 0, "columnIndex": 2}],
             [{"path": "A/1", "rowIndex": 0, "columnIndex": 1}],

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -500,7 +500,7 @@ class TestPlateMetadata:
             [{"path": "A/1", "rowIndex": "0", "columnIndex": 0}],
             [{"path": "A/1", "rowIndex": 0, "columnIndex": "0"}],
             [{"path": "A1", "rowIndex": 0, "columnIndex": "0"}],
-            [{"path": "plate/A/1", "rowIndex": 0, "columnIndex": "0"}],
+            [{"path": "plate/A/1", "rowIndex": 0, "columnIndex": 0}],
             [{"path": "C/1", "rowIndex": 2, "columnIndex": 0}],
             [{"path": "A/3", "rowIndex": 0, "columnIndex": 2}],
             [{"path": "A/1", "rowIndex": 0, "columnIndex": 1}],

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -298,7 +298,9 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["columns"] == [{"name": "1"}]
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
-        assert self.root.attrs["plate"]["wells"] == [{"path": "A/1"}]
+        assert self.root.attrs["plate"]["wells"] == [
+            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+        ]
         assert "name" not in self.root.attrs["plate"]
         assert "field_count" not in self.root.attrs["plate"]
         assert "acquisitions" not in self.root.attrs["plate"]
@@ -335,25 +337,57 @@ class TestPlateMetadata:
         ]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
         assert self.root.attrs["plate"]["wells"] == [
-            {"path": "A/1"},
-            {"path": "A/2"},
-            {"path": "A/3"},
-            {"path": "B/1"},
-            {"path": "B/2"},
-            {"path": "B/3"},
-            {"path": "C/1"},
-            {"path": "C/2"},
-            {"path": "C/3"},
-            {"path": "D/1"},
-            {"path": "D/2"},
-            {"path": "D/3"},
+            {"path": "A/1", "rowIndex": 0, "colIndex": 0},
+            {"path": "A/2", "rowIndex": 0, "colIndex": 1},
+            {"path": "A/3", "rowIndex": 0, "colIndex": 2},
+            {"path": "B/1", "rowIndex": 1, "colIndex": 0},
+            {"path": "B/2", "rowIndex": 1, "colIndex": 1},
+            {"path": "B/3", "rowIndex": 1, "colIndex": 2},
+            {"path": "C/1", "rowIndex": 2, "colIndex": 0},
+            {"path": "C/2", "rowIndex": 2, "colIndex": 1},
+            {"path": "C/3", "rowIndex": 2, "colIndex": 2},
+            {"path": "D/1", "rowIndex": 3, "colIndex": 0},
+            {"path": "D/2", "rowIndex": 3, "colIndex": 1},
+            {"path": "D/3", "rowIndex": 3, "colIndex": 2},
+        ]
+        assert "name" not in self.root.attrs["plate"]
+        assert "field_count" not in self.root.attrs["plate"]
+        assert "acquisitions" not in self.root.attrs["plate"]
+
+    def test_sparse_plate(self):
+        rows = ["A", "B", "C", "D", "E"]
+        cols = ["1", "2", "3", "4", "5"]
+        wells = [
+            "B/2",
+            "E/5",
+        ]
+        write_plate_metadata(self.root, rows, cols, wells)
+        assert "plate" in self.root.attrs
+        assert self.root.attrs["plate"]["columns"] == [
+            {"name": "1"},
+            {"name": "2"},
+            {"name": "3"},
+            {"name": "4"},
+            {"name": "5"},
+        ]
+        assert self.root.attrs["plate"]["rows"] == [
+            {"name": "A"},
+            {"name": "B"},
+            {"name": "C"},
+            {"name": "D"},
+            {"name": "E"},
+        ]
+        assert self.root.attrs["plate"]["version"] == CurrentFormat().version
+        assert self.root.attrs["plate"]["wells"] == [
+            {"path": "B/2", "rowIndex": 1, "colIndex": 1},
+            {"path": "E/5", "rowIndex": 4, "colIndex": 4},
         ]
         assert "name" not in self.root.attrs["plate"]
         assert "field_count" not in self.root.attrs["plate"]
         assert "acquisitions" not in self.root.attrs["plate"]
 
     @pytest.mark.parametrize("fmt", (FormatV01(), FormatV02(), FormatV03()))
-    def test_plate_version(self, fmt):
+    def test_legacy_wells(self, fmt):
         write_plate_metadata(self.root, ["A"], ["1"], ["A/1"], fmt=fmt)
         assert "plate" in self.root.attrs
         assert self.root.attrs["plate"]["columns"] == [{"name": "1"}]
@@ -371,7 +405,9 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["name"] == "test"
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
-        assert self.root.attrs["plate"]["wells"] == [{"path": "A/1"}]
+        assert self.root.attrs["plate"]["wells"] == [
+            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+        ]
         assert "field_count" not in self.root.attrs["plate"]
         assert "acquisitions" not in self.root.attrs["plate"]
 
@@ -382,7 +418,9 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["field_count"] == 10
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
-        assert self.root.attrs["plate"]["wells"] == [{"path": "A/1"}]
+        assert self.root.attrs["plate"]["wells"] == [
+            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+        ]
         assert "name" not in self.root.attrs["plate"]
         assert "acquisitions" not in self.root.attrs["plate"]
 
@@ -394,7 +432,9 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["columns"] == [{"name": "1"}]
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
-        assert self.root.attrs["plate"]["wells"] == [{"path": "A/1"}]
+        assert self.root.attrs["plate"]["wells"] == [
+            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+        ]
         assert "name" not in self.root.attrs["plate"]
         assert "field_count" not in self.root.attrs["plate"]
 
@@ -415,7 +455,9 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["columns"] == [{"name": "1"}]
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
-        assert self.root.attrs["plate"]["wells"] == [{"path": "A/1"}]
+        assert self.root.attrs["plate"]["wells"] == [
+            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+        ]
         assert "name" not in self.root.attrs["plate"]
         assert "field_count" not in self.root.attrs["plate"]
 
@@ -453,17 +495,35 @@ class TestPlateMetadata:
             [{"path": 0}],
             [{"id": "test"}],
             [{"path": "A/1"}, {"path": None}],
+            [{"path": "A/1", "rowIndex": 0}],
+            [{"path": "A/1", "colIndex": 0}],
+            [{"path": "A/1", "rowIndex": "0", "colIndex": 0}],
+            [{"path": "A/1", "rowIndex": 0, "colIndex": "0"}],
         ),
     )
     def test_invalid_well_keys(self, wells):
         with pytest.raises(ValueError):
             write_plate_metadata(self.root, ["A"], ["1"], wells)
 
-    def test_unspecified_well_keys(self):
+    @pytest.mark.parametrize("fmt", (FormatV01(), FormatV02(), FormatV03()))
+    def test_legacy_unspecified_well_keys(self, fmt):
         wells = [
             {"path": "A/1", "unspecified_key": "alpha"},
             {"path": "A/2", "unspecified_key": "beta"},
             {"path": "B/1", "unspecified_key": "gamma"},
+        ]
+        write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells, fmt=fmt)
+        assert "plate" in self.root.attrs
+        assert self.root.attrs["plate"]["columns"] == [{"name": "1"}, {"name": "2"}]
+        assert self.root.attrs["plate"]["rows"] == [{"name": "A"}, {"name": "B"}]
+        assert self.root.attrs["plate"]["version"] == fmt.version
+        assert self.root.attrs["plate"]["wells"] == wells
+
+    def test_unspecified_well_keys(self):
+        wells = [
+            {"path": "A/1", "rowIndex": 0, "colIndex": 0, "unspecified_key": "alpha"},
+            {"path": "A/2", "rowIndex": 0, "colIndex": 1, "unspecified_key": "beta"},
+            {"path": "B/1", "rowIndex": 1, "colIndex": 0, "unspecified_key": "gamma"},
         ]
         write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
         assert "plate" in self.root.attrs
@@ -471,6 +531,25 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}, {"name": "B"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
         assert self.root.attrs["plate"]["wells"] == wells
+
+    def test_missing_well_keys(self):
+        wells = [
+            {"path": "A/1"},
+            {"path": "A/2"},
+            {"path": "B/1"},
+        ]
+        with pytest.raises(ValueError):
+            write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
+
+    def test_well_not_in_rows(self):
+        wells = ["A/1", "B/1", "C/1"]
+        with pytest.raises(ValueError):
+            write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
+
+    def test_well_not_in_columns(self):
+        wells = ["A/1", "A/2", "A/3"]
+        with pytest.raises(ValueError):
+            write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
 
 
 class TestWellMetadata:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -503,6 +503,8 @@ class TestPlateMetadata:
             [{"path": "plate/A/1", "rowIndex": 0, "columnIndex": "0"}],
             [{"path": "C/1", "rowIndex": 2, "columnIndex": 0}],
             [{"path": "A/3", "rowIndex": 0, "columnIndex": 2}],
+            [{"path": "A/1", "rowIndex": 0, "columnIndex": 1}],
+            [{"path": "A/1", "rowIndex": 1, "columnIndex": 0}],
         ),
     )
     def test_invalid_well_keys(self, wells):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -551,6 +551,16 @@ class TestPlateMetadata:
         with pytest.raises(ValueError):
             write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
 
+    @pytest.mark.parametrize("rows", (["A", "B", "B"], ["A", "&"]))
+    def test_invalid_rows(self, rows):
+        with pytest.raises(ValueError):
+            write_plate_metadata(self.root, rows, ["1"], ["A/1"])
+
+    @pytest.mark.parametrize("columns", (["1", "2", "2"], ["1", "&"]))
+    def test_invalid_columns(self, columns):
+        with pytest.raises(ValueError):
+            write_plate_metadata(self.root, ["A"], columns, ["A/1"])
+
 
 class TestWellMetadata:
     @pytest.fixture(autouse=True)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -299,7 +299,7 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
         assert self.root.attrs["plate"]["wells"] == [
-            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+            {"path": "A/1", "rowIndex": 0, "columnIndex": 0}
         ]
         assert "name" not in self.root.attrs["plate"]
         assert "field_count" not in self.root.attrs["plate"]
@@ -337,18 +337,18 @@ class TestPlateMetadata:
         ]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
         assert self.root.attrs["plate"]["wells"] == [
-            {"path": "A/1", "rowIndex": 0, "colIndex": 0},
-            {"path": "A/2", "rowIndex": 0, "colIndex": 1},
-            {"path": "A/3", "rowIndex": 0, "colIndex": 2},
-            {"path": "B/1", "rowIndex": 1, "colIndex": 0},
-            {"path": "B/2", "rowIndex": 1, "colIndex": 1},
-            {"path": "B/3", "rowIndex": 1, "colIndex": 2},
-            {"path": "C/1", "rowIndex": 2, "colIndex": 0},
-            {"path": "C/2", "rowIndex": 2, "colIndex": 1},
-            {"path": "C/3", "rowIndex": 2, "colIndex": 2},
-            {"path": "D/1", "rowIndex": 3, "colIndex": 0},
-            {"path": "D/2", "rowIndex": 3, "colIndex": 1},
-            {"path": "D/3", "rowIndex": 3, "colIndex": 2},
+            {"path": "A/1", "rowIndex": 0, "columnIndex": 0},
+            {"path": "A/2", "rowIndex": 0, "columnIndex": 1},
+            {"path": "A/3", "rowIndex": 0, "columnIndex": 2},
+            {"path": "B/1", "rowIndex": 1, "columnIndex": 0},
+            {"path": "B/2", "rowIndex": 1, "columnIndex": 1},
+            {"path": "B/3", "rowIndex": 1, "columnIndex": 2},
+            {"path": "C/1", "rowIndex": 2, "columnIndex": 0},
+            {"path": "C/2", "rowIndex": 2, "columnIndex": 1},
+            {"path": "C/3", "rowIndex": 2, "columnIndex": 2},
+            {"path": "D/1", "rowIndex": 3, "columnIndex": 0},
+            {"path": "D/2", "rowIndex": 3, "columnIndex": 1},
+            {"path": "D/3", "rowIndex": 3, "columnIndex": 2},
         ]
         assert "name" not in self.root.attrs["plate"]
         assert "field_count" not in self.root.attrs["plate"]
@@ -379,8 +379,8 @@ class TestPlateMetadata:
         ]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
         assert self.root.attrs["plate"]["wells"] == [
-            {"path": "B/2", "rowIndex": 1, "colIndex": 1},
-            {"path": "E/5", "rowIndex": 4, "colIndex": 4},
+            {"path": "B/2", "rowIndex": 1, "columnIndex": 1},
+            {"path": "E/5", "rowIndex": 4, "columnIndex": 4},
         ]
         assert "name" not in self.root.attrs["plate"]
         assert "field_count" not in self.root.attrs["plate"]
@@ -406,7 +406,7 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
         assert self.root.attrs["plate"]["wells"] == [
-            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+            {"path": "A/1", "rowIndex": 0, "columnIndex": 0}
         ]
         assert "field_count" not in self.root.attrs["plate"]
         assert "acquisitions" not in self.root.attrs["plate"]
@@ -419,7 +419,7 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
         assert self.root.attrs["plate"]["wells"] == [
-            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+            {"path": "A/1", "rowIndex": 0, "columnIndex": 0}
         ]
         assert "name" not in self.root.attrs["plate"]
         assert "acquisitions" not in self.root.attrs["plate"]
@@ -433,7 +433,7 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
         assert self.root.attrs["plate"]["wells"] == [
-            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+            {"path": "A/1", "rowIndex": 0, "columnIndex": 0}
         ]
         assert "name" not in self.root.attrs["plate"]
         assert "field_count" not in self.root.attrs["plate"]
@@ -456,7 +456,7 @@ class TestPlateMetadata:
         assert self.root.attrs["plate"]["rows"] == [{"name": "A"}]
         assert self.root.attrs["plate"]["version"] == CurrentFormat().version
         assert self.root.attrs["plate"]["wells"] == [
-            {"path": "A/1", "rowIndex": 0, "colIndex": 0}
+            {"path": "A/1", "rowIndex": 0, "columnIndex": 0}
         ]
         assert "name" not in self.root.attrs["plate"]
         assert "field_count" not in self.root.attrs["plate"]
@@ -496,11 +496,11 @@ class TestPlateMetadata:
             [{"id": "test"}],
             [{"path": "A/1"}, {"path": None}],
             [{"path": "A/1", "rowIndex": 0}],
-            [{"path": "A/1", "colIndex": 0}],
-            [{"path": "A/1", "rowIndex": "0", "colIndex": 0}],
-            [{"path": "A/1", "rowIndex": 0, "colIndex": "0"}],
-            [{"path": "A1", "rowIndex": 0, "colIndex": "0"}],
-            [{"path": "plate/A/1", "rowIndex": 0, "colIndex": "0"}],
+            [{"path": "A/1", "columnIndex": 0}],
+            [{"path": "A/1", "rowIndex": "0", "columnIndex": 0}],
+            [{"path": "A/1", "rowIndex": 0, "columnIndex": "0"}],
+            [{"path": "A1", "rowIndex": 0, "columnIndex": "0"}],
+            [{"path": "plate/A/1", "rowIndex": 0, "columnIndex": "0"}],
         ),
     )
     def test_invalid_well_keys(self, wells):
@@ -523,9 +523,19 @@ class TestPlateMetadata:
 
     def test_unspecified_well_keys(self):
         wells = [
-            {"path": "A/1", "rowIndex": 0, "colIndex": 0, "unspecified_key": "alpha"},
-            {"path": "A/2", "rowIndex": 0, "colIndex": 1, "unspecified_key": "beta"},
-            {"path": "B/1", "rowIndex": 1, "colIndex": 0, "unspecified_key": "gamma"},
+            {
+                "path": "A/1",
+                "rowIndex": 0,
+                "columnIndex": 0,
+                "unspecified_key": "alpha",
+            },
+            {"path": "A/2", "rowIndex": 0, "columnIndex": 1, "unspecified_key": "beta"},
+            {
+                "path": "B/1",
+                "rowIndex": 1,
+                "columnIndex": 0,
+                "unspecified_key": "gamma",
+            },
         ]
         write_plate_metadata(self.root, ["A", "B"], ["1", "2"], wells)
         assert "plate" in self.root.attrs


### PR DESCRIPTION
Implements the specification changes proposed in https://github.com/ome/ngff/pull/24

- `rows` and `columns` must have unique names and be alphanumerical
- `wells` elements must include `path` (composed of exactly 2 groups), `rowIndex` and `colIndex`

As discussed in #157, the internal logic is adjusted to support the simple case of passing wells as list of strings and compute the row/column indices assuming the paths match the `rows` and `columns` lists.

Unit tests are updated to cover both the new and the legacy behavior as well as various invalid cases. The reader is not adjusted to consume the new logic. I would propose to complete the work on #148 first.