### PR TITLE
add compressor option to write image

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = dask,numpy,pytest,scipy,setuptools,skimage,zarr
+known_third_party = dask,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -186,7 +186,9 @@ def write_multiscale(
     paths = []
     for path, dataset in enumerate(pyramid):
         # TODO: chunks here could be different per layer
-        group.create_dataset(str(path), data=dataset, chunks=chunks, compressor=compressor)
+        group.create_dataset(
+            str(path), data=dataset, chunks=chunks, compressor=compressor
+        )
         paths.append(str(path))
     write_multiscales_metadata(group, paths, fmt, axes, transformations)
 
@@ -388,12 +390,13 @@ def write_image(
         image = [image]
 
     write_multiscale(
-        image, group, 
-        chunks=chunks, 
-        fmt=fmt, 
-        axes=axes, 
-        transformations=transformations, 
-        compressor=compressor
+        image,
+        group,
+        chunks=chunks,
+        fmt=fmt,
+        axes=axes,
+        transformations=transformations,
+        compressor=compressor,
     )
     group.attrs.update(metadata)
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -214,13 +214,15 @@ def write_multiscale(
 
     datasets: List[dict] = []
     for path, data in enumerate(pyramid):
-        options = (
-            storage_options
-            if not isinstance(storage_options, list)
-            else storage_options[path]
-        )
-        if "chunks" not in options:
-            options["chunks"] = chunks
+        options = {}
+        if storage_options:
+            options = (
+                storage_options
+                if not isinstance(storage_options, list)
+                else storage_options[path]
+            )
+            if "chunks" not in options:
+                options["chunks"] = chunks
         group.create_dataset(str(path), data=data, **options)
         datasets.append({"path": str(path)})
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -152,6 +152,7 @@ def write_multiscale(
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
     transformations: List[List[Dict[str, Any]]] = None,
+    compressor: Any = None,
 ) -> None:
     """
     Write a pyramid with multiscale metadata to disk.
@@ -175,6 +176,8 @@ def write_multiscale(
     transformations: 2Dlist of dict
       For each path, we have a List of transformation Dicts (not validated).
       Each list of dicts are added to each datasets in order.
+    compressor: A compressor object
+      An optional compressor object to be passed on to zarr dataset creation
     """
 
     dims = len(pyramid[0].shape)
@@ -183,7 +186,7 @@ def write_multiscale(
     paths = []
     for path, dataset in enumerate(pyramid):
         # TODO: chunks here could be different per layer
-        group.create_dataset(str(path), data=dataset, chunks=chunks)
+        group.create_dataset(str(path), data=dataset, chunks=chunks, compressor=compressor)
         paths.append(str(path))
     write_multiscales_metadata(group, paths, fmt, axes, transformations)
 
@@ -322,6 +325,7 @@ def write_image(
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
     transformations: List[List[Dict[str, Any]]] = None,
+    compressor: Any = None,
     **metadata: JSONDict,
 ) -> None:
     """Writes an image to the zarr store according to ome-zarr specification
@@ -352,6 +356,8 @@ def write_image(
     transformations: 2Dlist of dict
       For each resolution, we have a List of transformation Dicts (not validated).
       Each list of dicts are added to each datasets in order.
+    compressor: A compressor object
+      An optional compressor object to be passed on to zarr dataset creation
     """
 
     if image.ndim > 5:
@@ -382,7 +388,12 @@ def write_image(
         image = [image]
 
     write_multiscale(
-        image, group, chunks=chunks, fmt=fmt, axes=axes, transformations=transformations
+        image, group, 
+        chunks=chunks, 
+        fmt=fmt, 
+        axes=axes, 
+        transformations=transformations, 
+        compressor=compressor
     )
     group.attrs.update(metadata)
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -204,8 +204,8 @@ def write_multiscale(
       Each list of dicts are added to each datasets in order
       and must include a 'scale' transform.
     storage_options: dict or list of dict
-      Options to be passed on to the storage backend. A list would need to match 
-      the number of datasets in a multiresolution pyramid. One can provide 
+      Options to be passed on to the storage backend. A list would need to match
+      the number of datasets in a multiresolution pyramid. One can provide
       different chunk size for each level of a pyramind using this option.
     """
 
@@ -214,12 +214,14 @@ def write_multiscale(
 
     datasets: List[dict] = []
     for path, data in enumerate(pyramid):
-        options = storage_options if not isinstance(storage_options, list) else storage_options[path]
+        options = (
+            storage_options
+            if not isinstance(storage_options, list)
+            else storage_options[path]
+        )
         if "chunks" not in options:
             options["chunks"] = chunks
-        group.create_dataset(
-             str(path), data=data, **options
-        )
+        group.create_dataset(str(path), data=data, **options)
         datasets.append({"path": str(path)})
 
     if coordinate_transformations is None:
@@ -402,8 +404,8 @@ def write_image(
       For each resolution, we have a List of transformation Dicts (not validated).
       Each list of dicts are added to each datasets in order.
     storage_options: dict or list of dict
-      Options to be passed on to the storage backend. A list would need to match 
-      the number of datasets in a multiresolution pyramid. One can provide 
+      Options to be passed on to the storage backend. A list would need to match
+      the number of datasets in a multiresolution pyramid. One can provide
       different chunk size for each level of a pyramind using this option.
     """
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -221,8 +221,8 @@ def write_multiscale(
                 if not isinstance(storage_options, list)
                 else storage_options[path]
             )
-            if "chunks" not in options:
-                options["chunks"] = chunks
+        if "chunks" not in options:
+            options["chunks"] = chunks
         group.create_dataset(str(path), data=data, **options)
         datasets.append({"path": str(path)})
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -127,7 +127,7 @@ class TestWriter:
         data = self.create_data(shape)
         compressor = Blosc(cname='zstd', clevel=5, shuffle=Blosc.SHUFFLE)
         write_image(data, self.group, axes="zyx", storage_options={"compressor": compressor})
-        group = zarr.open(f"{self.path}/test"))
+        group = zarr.open(f"{self.path}/test")
         assert group["0"].compressor.get_config() == {'id': 'blosc', 'cname': 'zstd', 'clevel': 5, 'shuffle': Blosc.SHUFFLE, 'blocksize': 0}
 
     def test_validate_coordinate_transforms(self):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -125,10 +125,18 @@ class TestWriter:
     def test_write_image_compressed(self):
         shape = (64, 64, 64)
         data = self.create_data(shape)
-        compressor = Blosc(cname='zstd', clevel=5, shuffle=Blosc.SHUFFLE)
-        write_image(data, self.group, axes="zyx", storage_options={"compressor": compressor})
+        compressor = Blosc(cname="zstd", clevel=5, shuffle=Blosc.SHUFFLE)
+        write_image(
+            data, self.group, axes="zyx", storage_options={"compressor": compressor}
+        )
         group = zarr.open(f"{self.path}/test")
-        assert group["0"].compressor.get_config() == {'id': 'blosc', 'cname': 'zstd', 'clevel': 5, 'shuffle': Blosc.SHUFFLE, 'blocksize': 0}
+        assert group["0"].compressor.get_config() == {
+            "id": "blosc",
+            "cname": "zstd",
+            "clevel": 5,
+            "shuffle": Blosc.SHUFFLE,
+            "blocksize": 0,
+        }
 
     def test_validate_coordinate_transforms(self):
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,5 +1,6 @@
 import pathlib
 
+from numcodecs import Blosc
 import numpy as np
 import pytest
 import zarr
@@ -120,6 +121,14 @@ class TestWriter:
             assert transfs[0]["scale"][0] == 1
             for value in transfs[0]["scale"]:
                 assert value >= 1
+
+    def test_write_image_compressed(self):
+        shape = (64, 64, 64)
+        data = self.create_data(shape)
+        compressor = Blosc(cname='zstd', clevel=5, shuffle=Blosc.SHUFFLE)
+        write_image(data, self.group, axes="zyx", storage_options={"compressor": compressor})
+        group = zarr.open(f"{self.path}/test"))
+        assert group["0"].compressor.get_config() == {'id': 'blosc', 'cname': 'zstd', 'clevel': 5, 'shuffle': Blosc.SHUFFLE, 'blocksize': 0}
 
     def test_validate_coordinate_transforms(self):
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,9 +1,9 @@
 import pathlib
 
-from numcodecs import Blosc
 import numpy as np
 import pytest
 import zarr
+from numcodecs import Blosc
 
 from ome_zarr.format import CurrentFormat, FormatV01, FormatV02, FormatV03, FormatV04
 from ome_zarr.io import parse_url


### PR DESCRIPTION
this proposes a change to the write_image api to allow compressors.  this is now more general to pass any options to the create dataset function and should handle multilevel options.

closes #160

- [x] Write some tests