### PR TITLE
write_multiscales_metadata no_transformations

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -2,7 +2,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from zarr.storage import FSStore
 
@@ -84,6 +84,14 @@ class Format(ABC):
     ) -> None:  # pragma: no cover
         raise NotImplementedError()
 
+    @abstractmethod
+    def validate_coordinate_transformations(
+        self,
+        shapes: List[tuple],
+        coordinateTransformations: List[List[Dict[str, Any]]] = None,
+    ) -> Optional[List[List[Dict[str, Any]]]]:  # pragma: no cover
+        raise NotImplementedError()
+
 
 class FormatV01(Format):
     """
@@ -121,6 +129,13 @@ class FormatV01(Format):
                 raise ValueError(f"{well} must contain a {key} key of type {key_type}")
             if not isinstance(well[key], key_type):
                 raise ValueError(f"{well} path must be of {key_type} type")
+
+    def validate_coordinate_transformations(
+        self,
+        shapes: List[tuple],
+        coordinateTransformations: List[List[Dict[str, Any]]] = None,
+    ) -> Optional[List[List[Dict[str, Any]]]]:
+        return None
 
 
 class FormatV02(FormatV01):
@@ -214,6 +229,55 @@ class FormatV04(FormatV03):
             raise ValueError(f"{column} is not defined in the plate columns")
         if well["columnIndex"] != columns.index(column):
             raise ValueError(f"Mismatching column index for {well}")
+
+    def validate_coordinate_transformations(
+        self,
+        shapes: List[tuple],
+        coordinateTransformations: List[List[Dict[str, Any]]] = None,
+    ) -> Optional[List[List[Dict[str, Any]]]]:
+        """
+        Validates that a list of dicts contains a 'scale' transformation
+
+        Raises ValueError if no 'scale' found or doesn't match ndim
+        """
+        data_shape = shapes[0]
+        trans: List[List[Dict[str, Any]]] = []
+        if coordinateTransformations is None:
+            # calculate minimal 'scale' transform based on pyramid dims
+            for shape in shapes:
+                assert len(shape) == len(data_shape)
+                scale = [full / level for full, level in zip(data_shape, shape)]
+                trans.append([{"type": "scale", "scale": scale}])
+            coordinateTransformations = trans
+        else:
+            ct_count = len(coordinateTransformations)
+            if ct_count != len(shapes):
+                raise ValueError(
+                    "coordinateTransformations count: %s must match datasets %s"
+                    % (ct_count, len(shapes))
+                )
+            for shape, transform in zip(shapes, coordinateTransformations):
+                self.validate_dataset_transformations(transform, len(shape))
+        return coordinateTransformations
+
+    def validate_dataset_transformations(
+        self, transformations: List[Dict[str, Any]], ndim: int = None
+    ) -> None:
+        assert isinstance(transformations, list)
+        scale_transfs = [trans for trans in transformations if trans["type"] == "scale"]
+        if len(scale_transfs) == 0:
+            raise ValueError("No scale items in coordinateTransforms")
+        for trans in scale_transfs:
+            scale = trans["scale"]
+            if ndim is not None:
+                if len(scale) != ndim:
+                    raise ValueError(
+                        "'scale' list %s must match number of image dimensions: %s"
+                        % (scale, ndim)
+                    )
+            for value in scale:
+                if not isinstance(value, (float, int)):
+                    raise ValueError("'scale' values must all be numbers: %s" % scale)
 
 
 CurrentFormat = FormatV04

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -93,7 +93,8 @@ class Format(ABC):
     @abstractmethod
     def validate_coordinate_transformations(
         self,
-        ndims: List[int],
+        ndim: int,
+        nlevels: int,
         coordinate_transformations: List[List[Dict[str, Any]]] = None,
     ) -> Optional[List[List[Dict[str, Any]]]]:  # pragma: no cover
         raise NotImplementedError()
@@ -143,7 +144,8 @@ class FormatV01(Format):
 
     def validate_coordinate_transformations(
         self,
-        ndims: List[int],
+        ndim: int,
+        nlevels: int,
         coordinate_transformations: List[List[Dict[str, Any]]] = None,
     ) -> None:
         return None
@@ -257,25 +259,26 @@ class FormatV04(FormatV03):
 
     def validate_coordinate_transformations(
         self,
-        ndims: List[int],
+        ndim: int,
+        nlevels: int,
         coordinate_transformations: List[List[Dict[str, Any]]] = None,
     ) -> None:
         """
         Validates that a list of dicts contains a 'scale' transformation
 
         Raises ValueError if no 'scale' found or doesn't match ndim
-        @param ndims:       List with number of dims for each dataset
+        @param ndim:       Number of image dimensions
         """
 
         if coordinate_transformations is None:
             raise ValueError("coordinate_transformations must be provided")
         ct_count = len(coordinate_transformations)
-        if ct_count != len(ndims):
+        if ct_count != nlevels:
             raise ValueError(
                 "coordinate_transformations count: %s must match datasets %s"
-                % (ct_count, len(ndims))
+                % (ct_count, nlevels)
             )
-        for ndim, transformations in zip(ndims, coordinate_transformations):
+        for transformations in coordinate_transformations:
             assert isinstance(transformations, list)
             # validate scales...
             scale_transfs = [

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -280,8 +280,10 @@ class FormatV04(FormatV03):
             scale_transfs = [
                 trans for trans in transformations if trans["type"] == "scale"
             ]
-            if len(scale_transfs) == 0:
-                raise ValueError("No scale items in coordinate_transformations")
+            if len(scale_transfs) != 1:
+                raise ValueError(
+                    "Must supply 1 'scale' item in coordinate_transformations"
+                )
             for trans in scale_transfs:
                 scale = trans["scale"]
                 if ndim is not None:
@@ -292,9 +294,7 @@ class FormatV04(FormatV03):
                         )
                 for value in scale:
                     if not isinstance(value, (float, int)):
-                        raise ValueError(
-                            "'scale' values must all be numbers: %s" % scale
-                        )
+                        raise ValueError(f"'scale' values must all be numbers: {scale}")
 
 
 CurrentFormat = FormatV04

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -178,7 +178,7 @@ class FormatV03(FormatV02):  # inherits from V02 to avoid code duplication
 class FormatV04(FormatV03):
     """
     Changelog: axes is list of dicts,
-    introduce transformations in multiscales (Nov 2021)
+    introduce coordinateTransformations in multiscales (Nov 2021)
     """
 
     REQUIRED_PLATE_WELL_KEYS = {"path": str, "rowIndex": int, "columnIndex": int}

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -290,9 +290,9 @@ class Multiscales(Spec):
             node.metadata["axes"] = axes_obj.to_list()
             paths = [d["path"] for d in datasets]
             self.datasets: List[str] = paths
-            transformations = [d.get("transformations") for d in datasets]
+            transformations = [d.get("coordinateTransformations") for d in datasets]
             if any(trans is not None for trans in transformations):
-                node.metadata["transformations"] = transformations
+                node.metadata["coordinateTransformations"] = transformations
             LOGGER.info("datasets %s", datasets)
         except Exception as e:
             LOGGER.error(f"failed to parse multiscale metadata: {e}")

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -168,7 +168,7 @@ def write_multiscale(
     chunks: Union[Tuple[Any, ...], int] = None,
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
-    transformations: List[List[Dict[str, Any]]] = None,
+    coordinateTransformations: List[List[Dict[str, Any]]] = None,
 ) -> None:
     """
     Write a pyramid with multiscale metadata to disk.
@@ -189,7 +189,7 @@ def write_multiscale(
     axes: str or list of str or list of dict
       List of axes dicts, or names. Not needed for v0.1 or v0.2
       or if 2D. Otherwise this must be provided
-    transformations: 2Dlist of dict
+    coordinateTransformations: 2Dlist of dict
       For each path, we have a List of transformation Dicts (not validated).
       Each list of dicts are added to each datasets in order.
     """
@@ -203,9 +203,9 @@ def write_multiscale(
         group.create_dataset(str(path), data=dataset, chunks=chunks)
         datasets.append({"path": str(path)})
 
-    if transformations is not None:
-        for dataset, transform in zip(datasets, transformations):
-            dataset["transformations"] = transform
+    if coordinateTransformations is not None:
+        for dataset, transform in zip(datasets, coordinateTransformations):
+            dataset["coordinateTransformations"] = transform
 
     write_multiscales_metadata(group, datasets, fmt, axes)
 
@@ -335,7 +335,7 @@ def write_image(
     scaler: Scaler = Scaler(),
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
-    transformations: List[List[Dict[str, Any]]] = None,
+    coordinateTransformations: List[List[Dict[str, Any]]] = None,
     **metadata: JSONDict,
 ) -> None:
     """Writes an image to the zarr store according to ome-zarr specification
@@ -363,7 +363,7 @@ def write_image(
     axes: str or list of str or list of dict
       List of axes dicts, or names. Not needed for v0.1 or v0.2
       or if 2D. Otherwise this must be provided
-    transformations: 2Dlist of dict
+    coordinateTransformations: 2Dlist of dict
       For each resolution, we have a List of transformation Dicts (not validated).
       Each list of dicts are added to each datasets in order.
     """
@@ -396,7 +396,12 @@ def write_image(
         image = [image]
 
     write_multiscale(
-        image, group, chunks=chunks, fmt=fmt, axes=axes, transformations=transformations
+        image,
+        group,
+        chunks=chunks,
+        fmt=fmt,
+        axes=axes,
+        coordinateTransformations=coordinateTransformations,
     )
     group.attrs.update(metadata)
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -213,9 +213,11 @@ def write_multiscale(
         group.create_dataset(str(path), data=data, chunks=chunks)
         datasets.append({"path": str(path)})
 
-    shapes = [data.shape for data in pyramid]
     if coordinate_transformations is None:
+        shapes = [data.shape for data in pyramid]
         coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
+
+    # we validate again later, but this catches length mismatch before zip(datasets...)
     fmt.validate_coordinate_transformations(
         dims, len(pyramid), coordinate_transformations
     )

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -205,9 +205,10 @@ def write_multiscale(
         datasets.append({"path": str(path)})
 
     shapes = [data.shape for data in pyramid]
+    ndims = [len(shape) for shape in shapes]
     if coordinate_transformations is None:
         coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
-    fmt.validate_coordinate_transformations(shapes, coordinate_transformations)
+    fmt.validate_coordinate_transformations(ndims, coordinate_transformations)
     if coordinate_transformations is not None:
         for dataset, transform in zip(datasets, coordinate_transformations):
             dataset["coordinateTransformations"] = transform

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -168,7 +168,7 @@ def write_multiscale(
     chunks: Union[Tuple[Any, ...], int] = None,
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
-    coordinateTransformations: List[List[Dict[str, Any]]] = None,
+    coordinate_transformations: List[List[Dict[str, Any]]] = None,
 ) -> None:
     """
     Write a pyramid with multiscale metadata to disk.
@@ -189,7 +189,7 @@ def write_multiscale(
     axes: str or list of str or list of dict
       List of axes dicts, or names. Not needed for v0.1 or v0.2
       or if 2D. Otherwise this must be provided
-    coordinateTransformations: 2Dlist of dict
+    coordinate_transformations: 2Dlist of dict
       For each path, we have a List of transformation Dicts.
       Each list of dicts are added to each datasets in order
       and must include a 'scale' transform.
@@ -205,9 +205,11 @@ def write_multiscale(
         datasets.append({"path": str(path)})
 
     shapes = [data.shape for data in pyramid]
-    transf = fmt.validate_coordinate_transformations(shapes, coordinateTransformations)
-    if transf is not None:
-        for dataset, transform in zip(datasets, transf):
+    if coordinate_transformations is None:
+        coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
+    fmt.validate_coordinate_transformations(shapes, coordinate_transformations)
+    if coordinate_transformations is not None:
+        for dataset, transform in zip(datasets, coordinate_transformations):
             dataset["coordinateTransformations"] = transform
 
     write_multiscales_metadata(group, datasets, fmt, axes)
@@ -339,7 +341,7 @@ def write_image(
     scaler: Scaler = Scaler(),
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
-    coordinateTransformations: List[List[Dict[str, Any]]] = None,
+    coordinate_transformations: List[List[Dict[str, Any]]] = None,
     **metadata: JSONDict,
 ) -> None:
     """Writes an image to the zarr store according to ome-zarr specification
@@ -367,7 +369,7 @@ def write_image(
     axes: str or list of str or list of dict
       List of axes dicts, or names. Not needed for v0.1 or v0.2
       or if 2D. Otherwise this must be provided
-    coordinateTransformations: 2Dlist of dict
+    coordinate_transformations: 2Dlist of dict
       For each resolution, we have a List of transformation Dicts (not validated).
       Each list of dicts are added to each datasets in order.
     """
@@ -405,7 +407,7 @@ def write_image(
         chunks=chunks,
         fmt=fmt,
         axes=axes,
-        coordinateTransformations=coordinateTransformations,
+        coordinate_transformations=coordinate_transformations,
     )
     group.attrs.update(metadata)
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -122,6 +122,33 @@ class TestWriter:
             for value in transfs[0]["scale"]:
                 assert value >= 1
 
+    def test_validate_coordinate_transforms(self):
+
+        shapes = [(256, 256), (128, 128)]
+        fmt = FormatV04()
+
+        transformations = [
+            [{"type": "scale", "scale": (1, 1)}],
+            [{"type": "scale", "scale": (0.5, 0.5)}],
+        ]
+        fmt.validate_coordinate_transformations(shapes, transformations)
+
+        with pytest.raises(ValueError):
+            # transformations different length than shapes
+            fmt.validate_coordinate_transformations([(512, 512)], transformations)
+
+        with pytest.raises(ValueError):
+            transf = [[{"type": "scale", "scale": ("1", 1)}]]
+            fmt.validate_coordinate_transformations([(512, 512)], transf)
+
+        with pytest.raises(ValueError):
+            transf = [[{"type": "foo", "scale": (1, 1)}]]
+            fmt.validate_coordinate_transformations([(512, 512)], transf)
+
+        with pytest.raises(ValueError):
+            transf = [[{"type": "scale", "scale": (1, 1)}]]
+            fmt.validate_coordinate_transformations([(64, 64, 64)], transf)
+
     def test_dim_names(self):
 
         v03 = FormatV03()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -86,7 +86,7 @@ class TestWriter:
             scaler=scaler,
             fmt=version,
             axes=axes,
-            coordinateTransformations=transformations,
+            coordinate_transformations=transformations,
         )
 
         # Verify

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -134,7 +134,7 @@ class TestWriter:
         fmt.validate_coordinate_transformations(ndims, transformations)
 
         with pytest.raises(ValueError):
-            # transformations different length than shapes
+            # transformations different length than levels
             fmt.validate_coordinate_transformations([2], transformations)
 
         with pytest.raises(ValueError):
@@ -146,8 +146,25 @@ class TestWriter:
             fmt.validate_coordinate_transformations([2], transf)
 
         with pytest.raises(ValueError):
+            # scale list of floats different length from 3
             transf = [[{"type": "scale", "scale": (1, 1)}]]
             fmt.validate_coordinate_transformations([3], transf)
+
+        translate = [{"type": "translation", "translation": (1, 1)}]
+        scale_then_trans = [transf + translate for transf in transformations]
+        print("scale_then_trans", scale_then_trans)
+
+        fmt.validate_coordinate_transformations(ndims, scale_then_trans)
+
+        trans_then_scale = [translate + transf for transf in transformations]
+        with pytest.raises(ValueError):
+            # scale must come first
+            fmt.validate_coordinate_transformations(ndims, trans_then_scale)
+
+        with pytest.raises(ValueError):
+            scale_then_trans2 = [transf + translate for transf in scale_then_trans]
+            # more than 1 transformation
+            fmt.validate_coordinate_transformations(ndims, scale_then_trans2)
 
     def test_dim_names(self):
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -124,30 +124,30 @@ class TestWriter:
 
     def test_validate_coordinate_transforms(self):
 
-        shapes = [(256, 256), (128, 128)]
+        ndims = [2, 2]
         fmt = FormatV04()
 
         transformations = [
             [{"type": "scale", "scale": (1, 1)}],
             [{"type": "scale", "scale": (0.5, 0.5)}],
         ]
-        fmt.validate_coordinate_transformations(shapes, transformations)
+        fmt.validate_coordinate_transformations(ndims, transformations)
 
         with pytest.raises(ValueError):
             # transformations different length than shapes
-            fmt.validate_coordinate_transformations([(512, 512)], transformations)
+            fmt.validate_coordinate_transformations([2], transformations)
 
         with pytest.raises(ValueError):
             transf = [[{"type": "scale", "scale": ("1", 1)}]]
-            fmt.validate_coordinate_transformations([(512, 512)], transf)
+            fmt.validate_coordinate_transformations([2], transf)
 
         with pytest.raises(ValueError):
             transf = [[{"type": "foo", "scale": (1, 1)}]]
-            fmt.validate_coordinate_transformations([(512, 512)], transf)
+            fmt.validate_coordinate_transformations([2], transf)
 
         with pytest.raises(ValueError):
             transf = [[{"type": "scale", "scale": (1, 1)}]]
-            fmt.validate_coordinate_transformations([(64, 64, 64)], transf)
+            fmt.validate_coordinate_transformations([3], transf)
 
     def test_dim_names(self):
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -18,9 +18,9 @@ from ome_zarr.writer import (
 )
 
 TRANSFORMATIONS = [
-    {"axisIndices": [1, 2, 3], "scale": [0.50, 0.36, 0.36], "type": "scale"},
-    {"axisIndices": [1, 2, 3], "scale": [0.50, 0.72, 0.72], "type": "scale"},
-    {"axisIndices": [1, 2, 3], "scale": [0.50, 1.44, 1.44], "type": "scale"},
+    {"scale": [0.50, 0.36, 0.36], "type": "scale"},
+    {"scale": [0.50, 0.72, 0.72], "type": "scale"},
+    {"scale": [0.50, 1.44, 1.44], "type": "scale"},
 ]
 
 
@@ -75,7 +75,7 @@ class TestWriter:
             scaler=scaler,
             fmt=version,
             axes=axes,
-            transformations=TRANSFORMATIONS,
+            coordinateTransformations=TRANSFORMATIONS,
         )
 
         # Verify
@@ -88,9 +88,11 @@ class TestWriter:
         else:
             assert node.data[0].shape == shape
         print("node.metadata", node.metadata)
-        for transf, expected in zip(node.metadata["transformations"], TRANSFORMATIONS):
+        for transf, expected in zip(
+            node.metadata["coordinateTransformations"], TRANSFORMATIONS
+        ):
             assert transf == expected
-        assert len(node.metadata["transformations"]) == len(node.data)
+        assert len(node.metadata["coordinateTransformations"]) == len(node.data)
         assert np.allclose(data, node.data[0][...].compute())
 
     def test_dim_names(self):
@@ -235,7 +237,7 @@ class TestMultiscalesMetadata:
     def test_multi_levels_transformations(self):
         datasets = []
         for level, transf in enumerate(TRANSFORMATIONS):
-            datasets.append({"path": str(level), "transformation": transf})
+            datasets.append({"path": str(level), "coordinateTransformations": transf})
         write_multiscales_metadata(self.root, datasets)
         assert "multiscales" in self.root.attrs
         assert "version" in self.root.attrs["multiscales"][0]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -232,6 +232,15 @@ class TestMultiscalesMetadata:
             {"path": "2"},
         ]
 
+    def test_multi_levels_transformations(self):
+        datasets = []
+        for level, transf in enumerate(TRANSFORMATIONS):
+            datasets.append({"path": str(level), "transformation": transf})
+        write_multiscales_metadata(self.root, datasets)
+        assert "multiscales" in self.root.attrs
+        assert "version" in self.root.attrs["multiscales"][0]
+        assert self.root.attrs["multiscales"][0]["datasets"] == datasets
+
     @pytest.mark.parametrize("fmt", (FormatV01(), FormatV02(), FormatV03()))
     def test_version(self, fmt):
         write_multiscales_metadata(self.root, ["0"], fmt=fmt)


### PR DESCRIPTION
As discussed at https://github.com/ome/omero-cli-zarr/pull/93#discussion_r791685798
this allows the 'paths` argument of `write_multiscales_metadata()` to take a list of `datasets` dicts.

EDIT: Also updated to validate latest 0.4 spec with `coordinateTransformations` of `scale` and `translation`.