### PR TITLE
Multiscales metadata API: only support datasets as lists of dictionaries

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -126,17 +126,13 @@ def _validate_datasets(
     datasets: List[dict], dims: int, fmt: Format = CurrentFormat()
 ) -> List[Dict]:
 
-    validated_datasets = []
     if datasets is None or len(datasets) == 0:
         raise ValueError("Empty datasets list")
     transformations = []
     for dataset in datasets:
-        if isinstance(dataset, str):
-            validated_datasets.append({"path": dataset})
-        elif isinstance(dataset, dict):
+        if isinstance(dataset, dict):
             if not dataset.get("path"):
                 raise ValueError("no 'path' in dataset")
-            validated_datasets.append(dataset)
             transformation = dataset.get("coordinateTransformations")
             # transformation may be None for < 0.4 - validated below
             if transformation is not None:
@@ -145,7 +141,7 @@ def _validate_datasets(
             raise ValueError(f"Unrecognized type for {dataset}")
 
     fmt.validate_coordinate_transformations(dims, len(datasets), transformations)
-    return validated_datasets
+    return datasets
 
 
 def _validate_plate_wells(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -355,6 +355,77 @@ class TestMultiscalesMetadata:
                 self.root, datasets, axes=["t", "c", "z", "y", "x"]
             )
 
+    @pytest.mark.parametrize(
+        "coordinateTransformations",
+        (
+            [{"type": "scale", "scale": [1, 1]}],
+            [
+                {"type": "scale", "scale": [1, 1]},
+                {"type": "translation", "translation": [0, 0]},
+            ],
+        ),
+    )
+    def test_valid_transformations(self, coordinateTransformations):
+        axes = [{"name": "y", "type": "space"}, {"name": "x", "type": "space"}]
+        datasets = [
+            {
+                "path": "0",
+                "coordinateTransformations": coordinateTransformations,
+            }
+        ]
+        write_multiscales_metadata(self.root, datasets, axes=axes)
+        assert "multiscales" in self.root.attrs
+        assert self.root.attrs["multiscales"][0]["axes"] == axes
+        assert self.root.attrs["multiscales"][0]["datasets"] == datasets
+
+    @pytest.mark.parametrize(
+        "coordinateTransformations",
+        (
+            [],
+            None,
+            [{"type": "scale"}],
+            [{"scale": [1, 1]}],
+            [{"type": "scale", "scale": ["1", 1]}],
+            [{"type": "scale", "scale": [1, 1, 1]}],
+            [{"type": "scale", "scale": [1, 1]}, {"type": "scale", "scale": [1, 1]}],
+            [
+                {"type": "scale", "scale": [1, 1]},
+                {"type": "translation", "translation": ["0", 0]},
+            ],
+            [
+                {"type": "translation", "translation": [0, 0]},
+            ],
+            [
+                {"type": "scale", "scale": [1, 1]},
+                {"type": "translation", "translation": [0, 0, 0]},
+            ],
+            [
+                {"type": "translation", "translation": [0, 0]},
+                {"type": "scale", "scale": [1, 1]},
+            ],
+            [
+                {"type": "scale", "scale": [1, 1]},
+                {"type": "translation", "translation": [0, 0]},
+                {"type": "translation", "translation": [1, 0]},
+            ],
+            [
+                {"type": "scale", "scale": [1, 1]},
+                {"translation": [0, 0]},
+            ],
+            [
+                {"type": "scale", "scale": [1, 1]},
+                {"type": "translation", "translate": [0, 0]},
+            ],
+        ),
+    )
+    def test_invalid_transformations(self, coordinateTransformations):
+        axes = [{"name": "y", "type": "space"}, {"name": "x", "type": "space"}]
+        datasets = [
+            {"path": "0", "coordinateTransformations": coordinateTransformations}
+        ]
+        with pytest.raises(ValueError):
+            write_multiscales_metadata(self.root, datasets, axes=axes)
+
 
 class TestPlateMetadata:
     @pytest.fixture(autouse=True)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -297,7 +297,7 @@ class TestMultiscalesMetadata:
 
     @pytest.mark.parametrize("fmt", (FormatV01(), FormatV02(), FormatV03()))
     def test_version(self, fmt):
-        write_multiscales_metadata(self.root, ["0"], fmt=fmt)
+        write_multiscales_metadata(self.root, [{"path": "0"}], fmt=fmt)
         assert "multiscales" in self.root.attrs
         assert self.root.attrs["multiscales"][0]["version"] == fmt.version
         assert self.root.attrs["multiscales"][0]["datasets"] == [{"path": "0"}]
@@ -315,8 +315,10 @@ class TestMultiscalesMetadata:
             ["t", "c", "z", "y", "x"],
         ),
     )
-    def test_axes(self, axes):
-        write_multiscales_metadata(self.root, ["0"], fmt=FormatV03(), axes=axes)
+    def test_axes_V03(self, axes):
+        write_multiscales_metadata(
+            self.root, [{"path": "0"}], fmt=FormatV03(), axes=axes
+        )
         assert "multiscales" in self.root.attrs
         # for v0.3, axes is a list of names
         assert self.root.attrs["multiscales"][0]["axes"] == axes
@@ -327,7 +329,7 @@ class TestMultiscalesMetadata:
     @pytest.mark.parametrize("fmt", (FormatV01(), FormatV02()))
     def test_axes_ignored(self, fmt):
         write_multiscales_metadata(
-            self.root, ["0"], fmt=fmt, axes=["t", "c", "z", "y", "x"]
+            self.root, [{"path": "0"}], fmt=fmt, axes=["t", "c", "z", "y", "x"]
         )
         assert "multiscales" in self.root.attrs
         assert "axes" not in self.root.attrs["multiscales"][0]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -348,6 +348,13 @@ class TestMultiscalesMetadata:
         with pytest.raises(ValueError):
             write_multiscales_metadata(self.root, ["0"], fmt=FormatV03(), axes=axes)
 
+    @pytest.mark.parametrize("datasets", ([], None, "0", ["0"], [{"key": 1}]))
+    def test_invalid_datasets(self, datasets):
+        with pytest.raises(ValueError):
+            write_multiscales_metadata(
+                self.root, datasets, axes=["t", "c", "z", "y", "x"]
+            )
+
 
 class TestPlateMetadata:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Follow-up of the discussion in #162, this PR primarily the `write_multiscales_metadata` API introduced in #149 to only work on `datasets` passed as list of dictionaries. The writer unit tests are all adjusted for different version of the OME-NGFF format.

Additional unit tests are also added testing various combinations of valid and invalid `coordinateTransformations`. The transformations validation method is updated to add a few extra checks on the presence of mandatory keys.