### PR TITLE
Update CHANGELOG in preparation of 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
-# 0.3.0a1 (Jan 2022)
+# 0.3.0 (Feb 2022)
 
-## Breaking/specification changes
+## Specification changes
 
-- Add support for 0.4 OME-NGFF specification (axes [#124](https://github.com/ome/ome-zarr-py/pull/124)), HCS [#159](https://github.com/ome/ome-zarr-py/pull/159))
+- Add support for [OME-NGFF 0.4](https://ngff.openmicroscopy.org/0.4/) specification ([#124](https://github.com/ome/ome-zarr-py/pull/124), [#159](https://github.com/ome/ome-zarr-py/pull/159), [#162](https://github.com/ome/ome-zarr-py/pull/162))
 
 ## API additions
 
+- Add support for passing storage options (compression, chunks..) to the writer API, thanks to @satra ([#161](https://github.com/ome/ome-zarr-py/pull/161))
 - Add API for writing plate & well metadata ([#153](https://github.com/ome/ome-zarr-py/pull/153), [#157](https://github.com/ome/ome-zarr-py/pull/157))
-- Add API for writing multiscales metadata ([#149](https://github.com/ome/ome-zarr-py/pull/149))
+- Add API for writing multiscales metadata ([#149](https://github.com/ome/ome-zarr-py/pull/149), [#165](https://github.com/ome/ome-zarr-py/pull/165))
 
 ## Bug fix
 
+- Fix remaining HCS assumptions that images are 5D ([#148](https://github.com/ome/ome-zarr-py/pull/148))
 - Cap aiohttp to version 3.x ([#127](https://github.com/ome/ome-zarr-py/pull/127))
 
 # 0.2.0 (Oct 2021)


### PR DESCRIPTION
Following a discussion raised during today's OME meeting, this proposes to move towards the full release of `ome-zarr 0.3.0` with OME-NGFF 0.4 support.