### PR TITLE
Add image-label convenience functions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Test
         run: tox -e  'py37-coverage'
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           file: ./coverage.xml
           fail_ci_if_error: true

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -175,6 +175,7 @@ def write_multiscale(
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
     coordinate_transformations: List[List[Dict[str, Any]]] = None,
     storage_options: Union[JSONDict, List[JSONDict]] = None,
+    **metadata: JSONDict,
 ) -> None:
     """
     Write a pyramid with multiscale metadata to disk.
@@ -232,7 +233,7 @@ def write_multiscale(
         for dataset, transform in zip(datasets, coordinate_transformations):
             dataset["coordinateTransformations"] = transform
 
-    write_multiscales_metadata(group, datasets, fmt, axes)
+    write_multiscales_metadata(group, datasets, fmt, axes, **metadata)
 
 
 def write_multiscales_metadata(
@@ -240,6 +241,7 @@ def write_multiscales_metadata(
     datasets: List[dict],
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
+    **metadata: JSONDict,
 ) -> None:
     """
     Write the multiscales metadata in the group.
@@ -272,6 +274,7 @@ def write_multiscales_metadata(
         {
             "version": fmt.version,
             "datasets": _validate_datasets(datasets, ndim, fmt),
+            **metadata
         }
     ]
     if axes is not None:
@@ -432,8 +435,8 @@ def write_image(
         axes=axes,
         coordinate_transformations=coordinate_transformations,
         storage_options=storage_options,
+        **metadata
     )
-    group.attrs.update(metadata)
 
 
 def _retuple(

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -175,7 +175,7 @@ def write_multiscale(
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
     coordinate_transformations: List[List[Dict[str, Any]]] = None,
     storage_options: Union[JSONDict, List[JSONDict]] = None,
-    **metadata: JSONDict,
+    **metadata: Union[str, JSONDict, List[JSONDict]],
 ) -> None:
     """
     Write a pyramid with multiscale metadata to disk.
@@ -241,7 +241,7 @@ def write_multiscales_metadata(
     datasets: List[dict],
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
-    **metadata: JSONDict,
+    **metadata: Union[str, JSONDict, List[JSONDict]],
 ) -> None:
     """
     Write the multiscales metadata in the group.
@@ -369,7 +369,7 @@ def write_image(
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
     coordinate_transformations: List[List[Dict[str, Any]]] = None,
     storage_options: Union[JSONDict, List[JSONDict]] = None,
-    **metadata: JSONDict,
+    **metadata: Union[str, JSONDict, List[JSONDict]],
 ) -> None:
     """Writes an image to the zarr store according to ome-zarr specification
 
@@ -425,13 +425,13 @@ def write_image(
                 "Can't downsample if size of x or y dimension is 1. "
                 "Shape: %s" % (image.shape,)
             )
-        image = scaler.nearest(image)
+        mip = scaler.nearest(image)
     else:
         LOGGER.debug("disabling pyramid")
-        image = [image]
+        mip = [image]
 
     write_multiscale(
-        image,
+        mip,
         group,
         chunks=chunks,
         fmt=fmt,
@@ -449,7 +449,7 @@ def write_label_metadata(
     name: str,
     colors: List[JSONDict] = None,
     properties: List[JSONDict] = None,
-    **metadata: JSONDict,
+    **metadata: Union[List[JSONDict], JSONDict, str],
 ):
     """
     Write image-label metadata to the group.

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -442,8 +442,6 @@ def write_image(
     )
 
 
-# how do we actually validate this?
-# do we have a schema for the image-label metadata already?
 def write_label_metadata(
     group: zarr.Group,
     name: str,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -270,12 +270,11 @@ def write_multiscales_metadata(
             if axes is not None:
                 ndim = len(axes)
 
+    # note: we construct the multiscale metadata via 'dict(...)' rather than `{...}` in order
+    # to avoid duplication of protected keys like 'version' in **metadata
+    # (for {} this would silently over-write it, with dict() it explicitly fails)
     multiscales = [
-        {
-            "version": fmt.version,
-            "datasets": _validate_datasets(datasets, ndim, fmt),
-            **metadata
-        }
+        dict(version=fmt.version, datasets=_validate_datasets(datasets, ndim, fmt), **metadata)
     ]
     if axes is not None:
         multiscales[0]["axes"] = axes

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -274,7 +274,11 @@ def write_multiscales_metadata(
     # to avoid duplication of protected keys like 'version' in **metadata
     # (for {} this would silently over-write it, with dict() it explicitly fails)
     multiscales = [
-        dict(version=fmt.version, datasets=_validate_datasets(datasets, ndim, fmt), **metadata)
+        dict(
+            version=fmt.version,
+            datasets=_validate_datasets(datasets, ndim, fmt),
+            **metadata,
+        )
     ]
     if axes is not None:
         multiscales[0]["axes"] = axes
@@ -445,7 +449,7 @@ def write_label_metadata(
     name: str,
     colors: List[JSONDict] = None,
     properties: List[JSONDict] = None,
-    **metadata: JSONDict
+    **metadata: JSONDict,
 ):
     """
     Write image-label metadata to the group.
@@ -534,7 +538,9 @@ def write_multiscale_labels(
         name=name,
         **metadata,
     )
-    write_label_metadata(group["labels"], name, **({} if label_metadata is None else label_metadata))
+    write_label_metadata(
+        group["labels"], name, **({} if label_metadata is None else label_metadata)
+    )
 
 
 def _retuple(

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -270,7 +270,7 @@ def write_multiscales_metadata(
             if axes is not None:
                 ndim = len(axes)
 
-    # note: we construct the multiscale metadata via 'dict(...)' rather than `{...}` in order
+    # note: we construct the multiscale metadata via dict(), rather than {}
     # to avoid duplication of protected keys like 'version' in **metadata
     # (for {} this would silently over-write it, with dict() it explicitly fails)
     multiscales = [
@@ -450,11 +450,12 @@ def write_label_metadata(
     colors: List[JSONDict] = None,
     properties: List[JSONDict] = None,
     **metadata: Union[List[JSONDict], JSONDict, str],
-):
+) -> None:
     """
     Write image-label metadata to the group.
 
-    The label data must have been written to a sub-group with the same name as the second argument.
+    The label data must have been written to a sub-group,
+    with the same name as the second argument.
 
     group: zarr.Group
       the top-level label group within the zarr store
@@ -467,7 +468,8 @@ def write_label_metadata(
     properties: list of JSONDict
       Additional properties for (a subset of) the label values.
       Each dict specifies additional properties for one label.
-      It must contain the field "label-value" and may contain arbitrary additional properties.
+      It must contain the field "label-value"
+      and may contain arbitrary additional properties.
     """
     label_group = group[name]
     image_label_metadata = {**metadata}
@@ -495,8 +497,9 @@ def write_multiscale_labels(
     **metadata: JSONDict,
 ) -> None:
     """
-    Write image labels in pyramidal format with multiscale and image-label metadata to disk.
+    Write pyramidal image labels to disk.
 
+    Including the multiscales and image-label metadata.
     Creates the label data in the sub-group "labels/{name}"
 
     pyramid: List of np.ndarray

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -946,15 +946,17 @@ class TestLabelWriter:
         transformations = []
         for dataset_transfs in TRANSFORMATIONS:
             transf = dataset_transfs[0]
-            transformations.append(
-                [{"type": "scale", "scale": transf["scale"]}]
-            )
+            transformations.append([{"type": "scale", "scale": transf["scale"]}])
 
         # create the root level image data
         shape = (1, 2, 1, 256, 256)
         scaler = Scaler()
         self.create_image_data(
-            shape, scaler, axes=axes, version=FormatV04(), transformations=transformations
+            shape,
+            scaler,
+            axes=axes,
+            version=FormatV04(),
+            transformations=transformations,
         )
 
         label_names = ("first_labels", "second_labels")
@@ -979,4 +981,6 @@ class TestLabelWriter:
         label_root = zarr.open(f"{self.path}/labels", "r")
         assert "labels" in label_root.attrs
         assert len(label_root.attrs["labels"]) == len(label_names)
-        assert all(label_name in label_root.attrs["labels"] for label_name in label_names)
+        assert all(
+            label_name in label_root.attrs["labels"] for label_name in label_names
+        )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -12,6 +12,7 @@ from ome_zarr.scale import Scaler
 from ome_zarr.writer import (
     _get_valid_axes,
     write_image,
+    write_multiscale_labels,
     write_multiscales_metadata,
     write_plate_metadata,
     write_well_metadata,
@@ -823,3 +824,115 @@ class TestWellMetadata:
         assert "well" in self.root.attrs
         assert self.root.attrs["well"]["images"] == images
         assert self.root.attrs["well"]["version"] == CurrentFormat().version
+
+
+class TestLabelWriter:
+    @pytest.fixture(autouse=True)
+    def initdir(self, tmpdir):
+        self.path = pathlib.Path(tmpdir.mkdir("data.ome.zarr"))
+        self.store = parse_url(self.path, mode="w").store
+        self.root = zarr.group(store=self.store)
+
+    def create_image_data(self, shape, scaler, version, axes, transformations):
+        rng = np.random.default_rng(0)
+        data = rng.poisson(10, size=shape).astype(np.uint8)
+        write_image(
+            image=data,
+            group=self.root,
+            chunks=(128, 128),
+            scaler=scaler,
+            fmt=version,
+            axes=axes,
+            coordinate_transformations=transformations,
+        )
+
+    @pytest.fixture(
+        params=(
+            (1, 2, 1, 256, 256),
+            (3, 512, 512),
+            (256, 256),
+        ),
+        ids=["5D", "3D", "2D"],
+    )
+    def shape(self, request):
+        return request.param
+
+    @pytest.fixture(params=[True, False], ids=["scale", "noop"])
+    def scaler(self, request):
+        if request.param:
+            return Scaler()
+        else:
+            return None
+
+    @pytest.mark.parametrize(
+        "format_version",
+        (
+            pytest.param(FormatV01, id="V01"),
+            pytest.param(FormatV02, id="V02"),
+            pytest.param(FormatV03, id="V03"),
+            pytest.param(FormatV04, id="V04"),
+        ),
+    )
+    def test_multiscale_label_writer(self, shape, scaler, format_version):
+
+        version = format_version()
+        axes = "tczyx"[-len(shape) :]
+        transformations = []
+        for dataset_transfs in TRANSFORMATIONS:
+            transf = dataset_transfs[0]
+            # e.g. slice [1, 1, z, x, y] -> [z, x, y] for 3D
+            transformations.append(
+                [{"type": "scale", "scale": transf["scale"][-len(shape) :]}]
+            )
+
+        # create the actual label data
+        label_data = np.random.randint(0, 1000, size=shape)
+        if version.version in ("0.1", "0.2"):
+            # v0.1 and v0.2 require 5d
+            expand_dims = (np.s_[None],) * (5 - len(shape))
+            label_data = label_data[expand_dims]
+            assert label_data.ndim == 5
+        label_name = "my-labels"
+        if scaler is None:
+            transformations = [transformations[0]]
+            labels_mip = [label_data]
+        else:
+            labels_mip = scaler.nearest(label_data)
+
+        # create the root level image data
+        self.create_image_data(shape, scaler, version, axes, transformations)
+
+        write_multiscale_labels(
+            labels_mip,
+            self.root,
+            name=label_name,
+            fmt=version,
+            axes=axes,
+            coordinate_transformations=transformations,
+        )
+
+        # Verify image data
+        reader = Reader(parse_url(f"{self.path}/labels/{label_name}"))
+        node = list(reader())[0]
+        assert Multiscales.matches(node.zarr)
+        if version.version in ("0.1", "0.2"):
+            # v0.1 and v0.2 MUST be 5D
+            assert node.data[0].ndim == 5
+        else:
+            assert node.data[0].shape == shape
+        print("node.metadata", node.metadata)
+        if version.version not in ("0.1", "0.2", "0.3"):
+            for transf, expected in zip(
+                node.metadata["coordinateTransformations"], transformations
+            ):
+                assert transf == expected
+            assert len(node.metadata["coordinateTransformations"]) == len(node.data)
+        assert np.allclose(label_data, node.data[0][...].compute())
+
+        # Verify label metadata
+        label_root = zarr.open(f"{self.path}/labels", "r")
+        assert "labels" in label_root.attrs
+        assert label_name in label_root.attrs["labels"]
+
+        label_group = zarr.open(f"{self.path}/labels/{label_name}", "r")
+        assert "image-label" in label_group.attrs


### PR DESCRIPTION
Fixes #176 and #171

This PR:
- unifies `**metadata` across `write_image`, `write_multiscale` and `write_multiscales_metadata`
- introduces new convenience function `write_multiscale_image_labels` to create `image-label` data. 

For a usage example see https://github.com/ome/ome-ngff-prototypes/blob/update-ome-zarr-py/workflows/spatial-transcriptomics-example/convert_transcriptomics_data_to_ngff.py.

Still TODO:
- [x] ~~Add `write_image_labels` (analogue to `write_image`) that uses `write_multiscale_image_labels` internally~~ (leave this for a follow-up todo and also clean up `write_image` ...)
- [ ] Add tests

I will address the TODOs if we decide to go forward with these changes.
Side-note: some confusing / unclear things I noticed in the `image-labels` spec while working on this.