### PR TITLE
Update write_image signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.0 (Mar 2022)
+
+- Add API for writing data according to the `image-label` spec: `write_labels`, `write_multiscale_labels` & `write_label_metadata` ([#178](https://github.com/ome/ome-zarr-py/pull/178), [#184](https://github.com/ome/ome-zarr-py/pull/184))
+- Remove `byte_order` from `write_image` signature ([#184](https://github.com/ome/ome-zarr-py/pull/184))
+- Deprecate `chunks` argument in favor of `storage_options` ([#184](https://github.com/ome/ome-zarr-py/pull/184))
+
 # 0.3.0 (Feb 2022)
 
 ## Specification changes

--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -35,7 +35,7 @@ The following code creates a 3D Image in OME-Zarr with labels::
     # write the image data
     store = parse_url(path, mode="w").store
     root = zarr.group(store=store)
-    write_image(image=data, group=root, chunks=(1, size_xy, size_xy), axes="zyx")
+    write_image(image=data, group=root, iaxes="zyx", storage_options=dict(chunks=(1, size_xy, size_xy)))
     # optional rendering settings
     root.attrs["omero"] = {
         "channels": [{

--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -135,7 +135,8 @@ def create_zarr(
             if zct + 2 < len(chunks):
                 chunks[zct] = 1
 
-    write_multiscale(pyramid, grp, chunks=tuple(chunks), axes=axes)
+    storage_options = dict(chunks=tuple(chunks))
+    write_multiscale(pyramid, grp, axes=axes, storage_options=storage_options)
 
     if size_c == 1:
         image_data = {

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -363,7 +363,6 @@ def write_image(
     image: np.ndarray,
     group: zarr.Group,
     chunks: Union[Tuple[Any, ...], int] = None,
-    byte_order: Union[str, List[str]] = "tczyx",
     scaler: Scaler = Scaler(),
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
@@ -382,9 +381,6 @@ def write_image(
       the group within the zarr store to store the data in
     chunks: int or tuple of ints,
       size of the saved chunks to store the image
-    byte_order: str or list of str, default "tczyx"
-      combination of the letters defining the order
-      in which the dimensions are saved
     scaler: Scaler
       Scaler implementation for downsampling the image argument. If None,
       no downsampling will be performed.

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -414,31 +414,7 @@ def write_image(
       the number of datasets in a multiresolution pyramid. One can provide
       different chunk size for each level of a pyramind using this option.
     """
-
-    if image.ndim > 5:
-        raise ValueError("Only images of 5D or less are supported")
-
-    if fmt.version in ("0.1", "0.2"):
-        # v0.1 and v0.2 are strictly 5D
-        shape_5d: Tuple[Any, ...] = (*(1,) * (5 - image.ndim), *image.shape)
-        image = image.reshape(shape_5d)
-        # and we don't need axes
-        axes = None
-
-    # check axes before trying to scale
-    _get_valid_axes(image.ndim, axes, fmt)
-
-    if scaler is not None:
-        if image.shape[-1] == 1 or image.shape[-2] == 1:
-            raise ValueError(
-                "Can't downsample if size of x or y dimension is 1. "
-                "Shape: %s" % (image.shape,)
-            )
-        mip = scaler.nearest(image)
-    else:
-        LOGGER.debug("disabling pyramid")
-        mip = [image]
-
+    mip = _create_mip(image, fmt, scaler, axes)
     write_multiscale(
         mip,
         group,
@@ -553,6 +529,129 @@ def write_multiscale_labels(
     write_label_metadata(
         group["labels"], name, **({} if label_metadata is None else label_metadata)
     )
+
+
+def write_labels(
+    labels: np.ndarray,
+    group: zarr.Group,
+    name: str,
+    scaler: Scaler = Scaler(),
+    chunks: Union[Tuple[Any, ...], int] = None,
+    fmt: Format = CurrentFormat(),
+    axes: Union[str, List[str], List[Dict[str, str]]] = None,
+    coordinate_transformations: List[List[Dict[str, Any]]] = None,
+    storage_options: Union[JSONDict, List[JSONDict]] = None,
+    label_metadata: JSONDict = None,
+    **metadata: JSONDict,
+) -> None:
+    """
+    Write image label data to disk.
+
+    Including the multiscales and image-label metadata.
+    Creates the label data in the sub-group "labels/{name}"
+
+    labels: np.ndarray
+      the label data to save. A downsampling of the data will be computed
+      if the scaler argument is non-None.
+      Label array MUST be up to 5-dimensional with dimensions
+      ordered (t, c, z, y, x)
+    group: zarr.Group
+      the group within the zarr store to store the data in
+    name: str
+      the name of this labale data
+    scaler: Scaler
+      Scaler implementation for downsampling the image argument. If None,
+      no downsampling will be performed.
+    chunks: int or tuple of ints,
+      Size of the saved chunks to store the image.
+      This argument is deprecated and will be removed in a future version.
+      Use storage_options instead.
+    fmt: Format
+      The format of the ome_zarr data which should be used.
+      Defaults to the most current.
+    axes: str or list of str or list of dict
+      List of axes dicts, or names. Not needed for v0.1 or v0.2
+      or if 2D. Otherwise this must be provided
+    coordinate_transformations: 2Dlist of dict
+      For each path, we have a List of transformation Dicts.
+      Each list of dicts are added to each datasets in order
+      and must include a 'scale' transform.
+    storage_options: dict or list of dict
+      Options to be passed on to the storage backend. A list would need to match
+      the number of datasets in a multiresolution pyramid. One can provide
+      different chunk size for each level of a pyramind using this option.
+    label_metadata: JSONDict
+      image label metadata. See 'write_label_metadata' for details
+    """
+    if labels.ndim > 5:
+        raise ValueError("Only labelss of 5D or less are supported")
+
+    if fmt.version in ("0.1", "0.2"):
+        # v0.1 and v0.2 are strictly 5D
+        shape_5d: Tuple[Any, ...] = (*(1,) * (5 - labels.ndim), *labels.shape)
+        labels = labels.reshape(shape_5d)
+        # and we don't need axes
+        axes = None
+
+    # check axes before trying to scale
+    _get_valid_axes(labels.ndim, axes, fmt)
+
+    if scaler is not None:
+        if labels.shape[-1] == 1 or labels.shape[-2] == 1:
+            raise ValueError(
+                "Can't downsample if size of x or y dimension is 1. "
+                "Shape: %s" % (labels.shape,)
+            )
+        mip = scaler.nearest(labels)
+    else:
+        LOGGER.debug("disabling pyramid")
+        mip = [labels]
+
+    mip = _create_mip(labels, fmt, scaler, axes)
+    write_multiscale_labels(
+        mip,
+        group,
+        name=name,
+        chunks=chunks,
+        fmt=fmt,
+        axes=axes,
+        coordinate_transformations=coordinate_transformations,
+        storage_options=storage_options,
+        label_metadata=label_metadata,
+        **metadata,
+    )
+
+
+def _create_mip(
+    image: np.ndarray,
+    fmt: Format,
+    scaler: Scaler,
+    axes: Union[str, List[str], List[Dict[str, str]]],
+) -> List[np.ndarray]:
+    if image.ndim > 5:
+        raise ValueError("Only images of 5D or less are supported")
+
+    if fmt.version in ("0.1", "0.2"):
+        # v0.1 and v0.2 are strictly 5D
+        shape_5d: Tuple[Any, ...] = (*(1,) * (5 - image.ndim), *image.shape)
+        image = image.reshape(shape_5d)
+        # and we don't need axes
+        axes = None
+
+    # check axes before trying to scale
+    _get_valid_axes(image.ndim, axes, fmt)
+
+    if scaler is not None:
+        if image.shape[-1] == 1 or image.shape[-2] == 1:
+            raise ValueError(
+                "Can't downsample if size of x or y dimension is 1. "
+                "Shape: %s" % (image.shape,)
+            )
+        mip = scaler.nearest(image)
+    else:
+        LOGGER.debug("disabling pyramid")
+        mip = [image]
+    return mip
 
 
 def _retuple(

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -3,7 +3,7 @@
 """
 import logging
 import warnings
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import zarr
@@ -626,8 +626,8 @@ def _create_mip(
     image: np.ndarray,
     fmt: Format,
     scaler: Scaler,
-    axes: Union[str, List[str], List[Dict[str, str]]],
-) -> Tuple[List[np.ndarray], Union[str, List[str], List[Dict[str, str]]]]:
+    axes: Optional[Union[str, List[str], List[Dict[str, str]]]],
+) -> Tuple[List[np.ndarray], Optional[Union[str, List[str], List[Dict[str, str]]]]]:
     if image.ndim > 5:
         raise ValueError("Only images of 5D or less are supported")
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -414,7 +414,7 @@ def write_image(
       the number of datasets in a multiresolution pyramid. One can provide
       different chunk size for each level of a pyramind using this option.
     """
-    mip = _create_mip(image, fmt, scaler, axes)
+    mip, axes = _create_mip(image, fmt, scaler, axes)
     write_multiscale(
         mip,
         group,
@@ -607,7 +607,7 @@ def write_labels(
         LOGGER.debug("disabling pyramid")
         mip = [labels]
 
-    mip = _create_mip(labels, fmt, scaler, axes)
+    mip, axes = _create_mip(labels, fmt, scaler, axes)
     write_multiscale_labels(
         mip,
         group,
@@ -627,7 +627,7 @@ def _create_mip(
     fmt: Format,
     scaler: Scaler,
     axes: Union[str, List[str], List[Dict[str, str]]],
-) -> List[np.ndarray]:
+) -> Tuple[List[np.ndarray], Union[str, List[str], List[Dict[str, str]]]]:
     if image.ndim > 5:
         raise ValueError("Only images of 5D or less are supported")
 
@@ -651,7 +651,7 @@ def _create_mip(
     else:
         LOGGER.debug("disabling pyramid")
         mip = [image]
-    return mip
+    return mip, axes
 
 
 def _retuple(

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -495,6 +495,7 @@ def write_multiscale_labels(
     pyramid: List,
     group: zarr.Group,
     name: str,
+    chunks: Union[Tuple[Any, ...], int] = None,
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
     coordinate_transformations: List[List[Dict[str, Any]]] = None,
@@ -516,6 +517,10 @@ def write_multiscale_labels(
       the group within the zarr store to store the data in
     name: str
       the name of this labale data
+    chunks: int or tuple of ints,
+      Size of the saved chunks to store the image.
+      This argument is deprecated and will be removed in a future version.
+      Use storage_options instead.
     fmt: Format
       The format of the ome_zarr data which should be used.
       Defaults to the most current.
@@ -537,6 +542,7 @@ def write_multiscale_labels(
     write_multiscale(
         pyramid,
         sub_group,
+        chunks=chunks,
         fmt=fmt,
         axes=axes,
         coordinate_transformations=coordinate_transformations,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -583,30 +583,6 @@ def write_labels(
     label_metadata: JSONDict
       image label metadata. See 'write_label_metadata' for details
     """
-    if labels.ndim > 5:
-        raise ValueError("Only labelss of 5D or less are supported")
-
-    if fmt.version in ("0.1", "0.2"):
-        # v0.1 and v0.2 are strictly 5D
-        shape_5d: Tuple[Any, ...] = (*(1,) * (5 - labels.ndim), *labels.shape)
-        labels = labels.reshape(shape_5d)
-        # and we don't need axes
-        axes = None
-
-    # check axes before trying to scale
-    _get_valid_axes(labels.ndim, axes, fmt)
-
-    if scaler is not None:
-        if labels.shape[-1] == 1 or labels.shape[-2] == 1:
-            raise ValueError(
-                "Can't downsample if size of x or y dimension is 1. "
-                "Shape: %s" % (labels.shape,)
-            )
-        mip = scaler.nearest(labels)
-    else:
-        LOGGER.debug("disabling pyramid")
-        mip = [labels]
-
     mip, axes = _create_mip(labels, fmt, scaler, axes)
     write_multiscale_labels(
         mip,

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -83,11 +83,11 @@ class TestWriter:
         write_image(
             image=data,
             group=self.group,
-            chunks=(128, 128),
             scaler=scaler,
             fmt=version,
             axes=axes,
             coordinate_transformations=transformations,
+            storage_options=dict(chunks=(128, 128)),
         )
 
         # Verify
@@ -839,11 +839,11 @@ class TestLabelWriter:
         write_image(
             image=data,
             group=self.root,
-            chunks=(128, 128),
             scaler=scaler,
             fmt=version,
             axes=axes,
             coordinate_transformations=transformations,
+            storage_options=dict(chunks=(128, 128)),
         )
 
     @pytest.fixture(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -865,7 +865,9 @@ class TestLabelWriter:
         else:
             return None
 
-    def verify_label_data(self, label_name, label_data, version, shape, transformations):
+    def verify_label_data(
+        self, label_name, label_data, version, shape, transformations
+    ):
         # Verify image data
         reader = Reader(parse_url(f"{self.path}/labels/{label_name}"))
         node = list(reader())[0]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -12,6 +12,7 @@ from ome_zarr.scale import Scaler
 from ome_zarr.writer import (
     _get_valid_axes,
     write_image,
+    write_labels,
     write_multiscale_labels,
     write_multiscales_metadata,
     write_plate_metadata,
@@ -864,6 +865,37 @@ class TestLabelWriter:
         else:
             return None
 
+    def verify_label_data(self, label_name, label_data, version, shape, transformations):
+        # Verify image data
+        reader = Reader(parse_url(f"{self.path}/labels/{label_name}"))
+        node = list(reader())[0]
+        assert Multiscales.matches(node.zarr)
+        if version.version in ("0.1", "0.2"):
+            # v0.1 and v0.2 MUST be 5D
+            assert node.data[0].ndim == 5
+        else:
+            assert node.data[0].shape == shape
+
+        if version.version not in ("0.1", "0.2", "0.3"):
+            for transf, expected in zip(
+                node.metadata["coordinateTransformations"], transformations
+            ):
+                assert transf == expected
+            assert len(node.metadata["coordinateTransformations"]) == len(node.data)
+        assert np.allclose(label_data, node.data[0][...].compute())
+
+        # Verify label metadata
+        label_root = zarr.open(f"{self.path}/labels", "r")
+        assert "labels" in label_root.attrs
+        assert label_name in label_root.attrs["labels"]
+
+        label_group = zarr.open(f"{self.path}/labels/{label_name}", "r")
+        assert "image-label" in label_group.attrs
+
+        # Verify multiscale metadata
+        name = label_group.attrs["multiscales"][0].get("name", "")
+        assert label_name == name
+
     @pytest.mark.parametrize(
         "format_version",
         (
@@ -873,8 +905,52 @@ class TestLabelWriter:
             pytest.param(FormatV04, id="V04"),
         ),
     )
-    def test_multiscale_label_writer(self, shape, scaler, format_version):
+    def test_write_labels(self, shape, scaler, format_version):
+        version = format_version()
+        axes = "tczyx"[-len(shape) :]
+        transformations = []
+        for dataset_transfs in TRANSFORMATIONS:
+            transf = dataset_transfs[0]
+            # e.g. slice [1, 1, z, x, y] -> [z, x, y] for 3D
+            transformations.append(
+                [{"type": "scale", "scale": transf["scale"][-len(shape) :]}]
+            )
+            if scaler is None:
+                break
 
+        # create the actual label data
+        label_data = np.random.randint(0, 1000, size=shape)
+        if version.version in ("0.1", "0.2"):
+            # v0.1 and v0.2 require 5d
+            expand_dims = (np.s_[None],) * (5 - len(shape))
+            label_data = label_data[expand_dims]
+            assert label_data.ndim == 5
+        label_name = "my-labels"
+
+        # create the root level image data
+        self.create_image_data(shape, scaler, version, axes, transformations)
+
+        write_labels(
+            label_data,
+            self.root,
+            scaler=scaler,
+            name=label_name,
+            fmt=version,
+            axes=axes,
+            coordinate_transformations=transformations,
+        )
+        self.verify_label_data(label_name, label_data, version, shape, transformations)
+
+    @pytest.mark.parametrize(
+        "format_version",
+        (
+            pytest.param(FormatV01, id="V01"),
+            pytest.param(FormatV02, id="V02"),
+            pytest.param(FormatV03, id="V03"),
+            pytest.param(FormatV04, id="V04"),
+        ),
+    )
+    def test_write_multiscale_labels(self, shape, scaler, format_version):
         version = format_version()
         axes = "tczyx"[-len(shape) :]
         transformations = []
@@ -910,36 +986,7 @@ class TestLabelWriter:
             axes=axes,
             coordinate_transformations=transformations,
         )
-
-        # Verify image data
-        reader = Reader(parse_url(f"{self.path}/labels/{label_name}"))
-        node = list(reader())[0]
-        assert Multiscales.matches(node.zarr)
-        if version.version in ("0.1", "0.2"):
-            # v0.1 and v0.2 MUST be 5D
-            assert node.data[0].ndim == 5
-        else:
-            assert node.data[0].shape == shape
-
-        if version.version not in ("0.1", "0.2", "0.3"):
-            for transf, expected in zip(
-                node.metadata["coordinateTransformations"], transformations
-            ):
-                assert transf == expected
-            assert len(node.metadata["coordinateTransformations"]) == len(node.data)
-        assert np.allclose(label_data, node.data[0][...].compute())
-
-        # Verify label metadata
-        label_root = zarr.open(f"{self.path}/labels", "r")
-        assert "labels" in label_root.attrs
-        assert label_name in label_root.attrs["labels"]
-
-        label_group = zarr.open(f"{self.path}/labels/{label_name}", "r")
-        assert "image-label" in label_group.attrs
-
-        # Verify multiscale metadata
-        name = label_group.attrs["multiscales"][0].get("name", "")
-        assert label_name == name
+        self.verify_label_data(label_name, label_data, version, shape, transformations)
 
     def test_two_label_images(self):
         axes = "tczyx"
@@ -951,11 +998,12 @@ class TestLabelWriter:
         # create the root level image data
         shape = (1, 2, 1, 256, 256)
         scaler = Scaler()
+        version = FormatV04()
         self.create_image_data(
             shape,
             scaler,
             axes=axes,
-            version=FormatV04(),
+            version=version,
             transformations=transformations,
         )
 
@@ -971,11 +1019,9 @@ class TestLabelWriter:
                 axes=axes,
                 coordinate_transformations=transformations,
             )
-
-            label_group = zarr.open(f"{self.path}/labels/{label_name}", "r")
-            assert "image-label" in label_group.attrs
-            name = label_group.attrs["multiscales"][0].get("name", "")
-            assert label_name == name
+            self.verify_label_data(
+                label_name, label_data, version, shape, transformations
+            )
 
         # Verify label metadata
         label_root = zarr.open(f"{self.path}/labels", "r")


### PR DESCRIPTION
This PR updates the signatures of `write_image`, `write_multiscale` and `write_multiscale_labels`:
- Removes `byte_order` from `write_image`: this was not used at all
- Removes `chunks` from all of them to avoid duplication with `storage_options`. 
- Moves `retuple` from `write_image` to `write_multiscale`, which is where the "actual" writing of data happens.

If we agree on these changes I will also add `write_labels` here (corresponding to `write_image`, but for image label data).

cc @will-moore @sbesson @joshmoore  