### PR TITLE
Convert `ome_zarr.writer.write_multiscale` to use docstrings markup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
           # Conflicts with black: E203 whitespace before ':'
           # Does not recognize deprecated directive in docstrings
           "--ignore=E203,RST303",
-          "--rst-roles=class,func,ref,mod,const",
+          "--rst-roles=class,func,ref,mod,meth,const",
         ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,8 @@ repos:
           "--max-line-length=88",
           # Conflicts with black: E203 whitespace before ':'
           "--ignore=E203",
+          # Does not recognize deprecated directive in docstrings
+          "--ignore=RST303",
           "--rst-roles=class,func,ref,mod,const",
         ]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,9 +58,8 @@ repos:
           # default black line length is 88
           "--max-line-length=88",
           # Conflicts with black: E203 whitespace before ':'
-          "--ignore=E203",
           # Does not recognize deprecated directive in docstrings
-          "--ignore=RST303",
+          "--ignore=E203,RST303",
           "--rst-roles=class,func,ref,mod,const",
         ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,6 +8,7 @@ sys.path.insert(0, pathlib.Path(__file__).parents[2].resolve().as_posix())
 extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
 ]
 
 # use index.rst instead of contents.rst
@@ -18,3 +19,11 @@ master_doc = "index"
 project = "ome-zarr-py"
 copyright = "Open Microscopy Environment"  # noqa: A001
 author = "Open Microscopy Environment"
+
+# Example configuration for intersphinx: refer to the Python standard library.
+# use in refs e.g:
+# :ref:`comparison manual <python:comparisons>`
+intersphinx_mapping = {
+    'python':('https://docs.python.org/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'zarr': ('https://zarr.readthedocs.io/en/stable/', None)}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,7 @@ author = "Open Microscopy Environment"
 # use in refs e.g:
 # :ref:`comparison manual <python:comparisons>`
 intersphinx_mapping = {
-    'python':('https://docs.python.org/', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
-    'zarr': ('https://zarr.readthedocs.io/en/stable/', None)}
+    "python": ("https://docs.python.org/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "zarr": ("https://zarr.readthedocs.io/en/stable/", None),
+}

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -181,30 +181,37 @@ def write_multiscale(
     """
     Write a pyramid with multiscale metadata to disk.
 
-    pyramid: List of np.ndarray
-      the image data to save. Largest level first
-      All image arrays MUST be up to 5-dimensional with dimensions
-      ordered (t, c, z, y, x)
-    group: zarr.Group
-      the group within the zarr store to store the data in
-    chunks: int or tuple of ints,
-      Size of the saved chunks to store the image.
-      This argument is deprecated and will be removed in a future version.
-      Use storage_options instead.
-    fmt: Format
-      The format of the ome_zarr data which should be used.
-      Defaults to the most current.
-    axes: str or list of str or list of dict
-      List of axes dicts, or names. Not needed for v0.1 or v0.2
-      or if 2D. Otherwise this must be provided
-    coordinate_transformations: 2Dlist of dict
-      For each path, we have a List of transformation Dicts.
-      Each list of dicts are added to each datasets in order
-      and must include a 'scale' transform.
-    storage_options: dict or list of dict
-      Options to be passed on to the storage backend. A list would need to match
-      the number of datasets in a multiresolution pyramid. One can provide
-      different chunk size for each level of a pyramind using this option.
+    :type pyramid: list of np.ndarray
+    :param pyramid:
+        The image data to save. Largest level first. All image arrays MUST be up to
+        5-dimensional with dimensions ordered (t, c, z, y, x)
+    :type group: :class:`zarr.Group`
+    :param group: The group within the zarr store to store the data in
+    :type chunks: int or tuple of ints, optional
+    :param chunks: The size of the saved chunks to store the image.
+
+        .. deprecated:: 0.4.0
+            This argument is deprecated and will be removed in a future version.
+            Use storage_options instead.
+    :type fmt: class:`ome_zarr.format.Format`, optional
+    :param fmt:
+        The format of the ome_zarr data which should be used.
+        Defaults to the most current.
+    :type axes: str list of str or list of dict, optional
+    :param axes:
+        List of axes dicts, or names. Not needed for v0.1 or v0.2 or if 2D. Otherwise
+        this must be provided
+    :type coordinate_transformations: 2Dlist of dict, optional
+    :param coordinate_transformations:
+        List of transformations for each path.
+        Each list of dicts are added to each datasets in order and must include a
+        'scale' transform.
+    :type storage_options: dict or list of dict, optional
+    :param storage_options:
+        Options to be passed on to the storage backend.
+        A list would need to match the number of datasets in a multiresolution pyramid.
+        One can provide different chunk size for each level of a pyramind using this
+        option.
     """
 
     dims = len(pyramid[0].shape)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -185,7 +185,7 @@ def write_multiscale(
     :param pyramid:
         The image data to save. Largest level first. All image arrays MUST be up to
         5-dimensional with dimensions ordered (t, c, z, y, x)
-    :type group: :class:`zarr.Group`
+    :type group: :class:`zarr.hierarchy.Group`
     :param group: The group within the zarr store to store the data in
     :type chunks: int or tuple of ints, optional
     :param chunks:
@@ -268,17 +268,20 @@ def write_multiscales_metadata(
     """
     Write the multiscales metadata in the group.
 
-    group: zarr.Group
-      the group within the zarr store to write the metadata in.
-    datasets: list of dicts
+    :type group: :class:`zarr.hierarchy.Group`
+    :param group: The group within the zarr store to write the metadata in.
+    :type datasets: list of dicts
+    :param datasets:
       The list of datasets (dicts) for this multiscale image.
       Each dict must include 'path' and a 'coordinateTransformations'
       list for version 0.4 or later that must include a 'scale' transform.
-    fmt: Format
+    :type fmt: :class:`ome_zarr.format.Format`, optional
+    :param fmt:
       The format of the ome_zarr data which should be used.
       Defaults to the most current.
-    axes: list of str or list of dicts
-      the names of the axes. e.g. ["t", "c", "z", "y", "x"].
+    :type axes: list of str or list of dicts, optional
+    :param axes:
+      The names of the axes. e.g. ["t", "c", "z", "y", "x"].
       Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
     """
 
@@ -321,23 +324,24 @@ def write_plate_metadata(
     """
     Write the plate metadata in the group.
 
-    group: zarr.Group
-      the group within the zarr store to write the metadata in.
-    rows: list of str
-      The list of names for the plate rows
-    columns: list of str
-      The list of names for the plate columns
-    wells: list of str or dict
-      The list of paths for the well groups
-    fmt: Format
+    :type group: :class:`zarr.hierarchy.Group`
+    :param group: The group within the zarr store to write the metadata in.
+    :type rows: list of str
+    :param rows: The list of names for the plate rows.
+    :type columns: list of str
+    :param columns: The list of names for the plate columns.
+    :type wells: list of str or dict
+    :param wells: The list of paths for the well groups.
+    :type fmt: :class:`ome_zarr.format.Format`, optional
+    :param fmt:
       The format of the ome_zarr data which should be used.
       Defaults to the most current.
-    name: str
-      The plate name
-    field_count: int
-      The maximum number of fields per view across wells
-    acquisitions: list of dict
-      A list of the various plate acquisitions
+    :type acquisitions: list of dict, optional
+    :param acquisitions: A list of the various plate acquisitions.
+    :type name: str, optional
+    :param name: The plate name.
+    :type field_count: int, optional
+    :param field_count: The maximum number of fields per view across wells.
     """
 
     plate: Dict[str, Union[str, int, List[Dict]]] = {
@@ -363,13 +367,12 @@ def write_well_metadata(
     """
     Write the well metadata in the group.
 
-    group: zarr.Group
-      the group within the zarr store to write the metadata in.
-    image_paths: list of str or dict
-      The list of paths for the well images
-    image_acquisitions: list of int
-      The list of acquisitions for the well images
-    fmt: Format
+    :type group: :class:`zarr.hierarchy.Group`
+    :param group: The group within the zarr store to write the metadata in.
+    :type images: list of dict
+    :param images: The list of dictionaries for all fields of views.
+    :type fmt: :class:`ome_zarr.format.Format`, optional
+    :param fmt:
       The format of the ome_zarr data which should be used.
       Defaults to the most current.
     """
@@ -394,33 +397,43 @@ def write_image(
 ) -> None:
     """Writes an image to the zarr store according to ome-zarr specification
 
-    image: np.ndarray
-      the image data to save. A downsampling of the data will be computed
+    :type image: :class:`np.ndarray`
+    :param image:
+      The image data to save. A downsampling of the data will be computed
       if the scaler argument is non-None.
       Image array MUST be up to 5-dimensional with dimensions
       ordered (t, c, z, y, x)
-    group: zarr.Group
-      the group within the zarr store to store the data in
-    scaler: Scaler
+    :type group: :class:`zarr.hierarchy.Group`
+    :param group: The group within the zarr store to write the metadata in.
+    :type scaler: :class:`ome_zarr.scale.Scaler`
+    :param scaler:
       Scaler implementation for downsampling the image argument. If None,
       no downsampling will be performed.
-    chunks: int or tuple of ints,
-      Size of the saved chunks to store the image.
-      This argument is deprecated and will be removed in a future version.
-      Use storage_options instead.
-    fmt: Format
+    :type chunks: int or tuple of ints, optional
+    :param chunks:
+        The size of the saved chunks to store the image.
+
+        .. deprecated:: 0.4.0
+            This argument is deprecated and will be removed in a future version.
+            Use ``storage_options`` instead.
+    :type fmt: :class:`ome_zarr.format.Format`, optional
+    :param fmt:
       The format of the ome_zarr data which should be used.
       Defaults to the most current.
-    axes: str or list of str or list of dict
-      List of axes dicts, or names. Not needed for v0.1 or v0.2
-      or if 2D. Otherwise this must be provided
-    coordinate_transformations: 2Dlist of dict
+    :type axes: list of str or list of dicts, optional
+    :param axes:
+      The names of the axes. e.g. ["t", "c", "z", "y", "x"].
+      Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
+    :type coordinate_transformations: list of dict
+    :param coordinate_transformations:
       For each resolution, we have a List of transformation Dicts (not validated).
       Each list of dicts are added to each datasets in order.
-    storage_options: dict or list of dict
-      Options to be passed on to the storage backend. A list would need to match
-      the number of datasets in a multiresolution pyramid. One can provide
-      different chunk size for each level of a pyramind using this option.
+    :type storage_options: dict or list of dict, optional
+    :param storage_options:
+        Options to be passed on to the storage backend.
+        A list would need to match the number of datasets in a multiresolution pyramid.
+        One can provide different chunk size for each level of a pyramid using this
+        option.
     """
     mip, axes = _create_mip(image, fmt, scaler, axes)
     write_multiscale(
@@ -448,15 +461,17 @@ def write_label_metadata(
     The label data must have been written to a sub-group,
     with the same name as the second argument.
 
-    group: zarr.Group
-      the top-level label group within the zarr store
-    name: str
-      the name of the label sub-group
-    colors: list of JSONDict
+    :type group: :class:`zarr.hierarchy.Group`
+    :param group: The group within the zarr store to write the metadata in.
+    :type name: str
+    :param name: The name of the label sub-group.
+    :type colors: list of JSONDict, optional
+    :param colors:
       Fixed colors for (a subset of) the label values.
       Each dict specifies the color for one label and must contain the fields
       "label-value" and "rgba".
-    properties: list of JSONDict
+    :type properties: list of JSONDict, optional
+    :param properties:
       Additional properties for (a subset of) the label values.
       Each dict specifies additional properties for one label.
       It must contain the field "label-value"
@@ -493,34 +508,43 @@ def write_multiscale_labels(
     Including the multiscales and image-label metadata.
     Creates the label data in the sub-group "labels/{name}"
 
-    pyramid: List of np.ndarray
+    :type pyramid: list of :class:`np.ndarray`
+    :param pyramid:
       the image label data to save. Largest level first
       All image arrays MUST be up to 5-dimensional with dimensions
       ordered (t, c, z, y, x)
-    group: zarr.Group
-      the group within the zarr store to store the data in
-    name: str
-      the name of this labale data
-    chunks: int or tuple of ints,
-      Size of the saved chunks to store the image.
-      This argument is deprecated and will be removed in a future version.
-      Use storage_options instead.
-    fmt: Format
+    :type group: :class:`zarr.hierarchy.Group`
+    :param group: The group within the zarr store to write the metadata in.
+    :type name: str, optional
+    :param name: The name of this labels data.
+    :type chunks: int or tuple of ints, optional
+    :param chunks:
+        The size of the saved chunks to store the image.
+
+        .. deprecated:: 0.4.0
+            This argument is deprecated and will be removed in a future version.
+            Use ``storage_options`` instead.
+    :type fmt: :class:`ome_zarr.format.Format`, optional
+    :param fmt:
       The format of the ome_zarr data which should be used.
       Defaults to the most current.
-    axes: str or list of str or list of dict
-      List of axes dicts, or names. Not needed for v0.1 or v0.2
-      or if 2D. Otherwise this must be provided
-    coordinate_transformations: 2Dlist of dict
-      For each path, we have a List of transformation Dicts.
-      Each list of dicts are added to each datasets in order
-      and must include a 'scale' transform.
-    storage_options: dict or list of dict
-      Options to be passed on to the storage backend. A list would need to match
-      the number of datasets in a multiresolution pyramid. One can provide
-      different chunk size for each level of a pyramind using this option.
-    label_metadata: JSONDict
-      image label metadata. See 'write_label_metadata' for details
+    :type axes: list of str or list of dicts, optional
+    :param axes:
+      The names of the axes. e.g. ["t", "c", "z", "y", "x"].
+      Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
+    :type coordinate_transformations: list of dict
+    :param coordinate_transformations:
+      For each resolution, we have a List of transformation Dicts (not validated).
+      Each list of dicts are added to each datasets in order.
+    :type storage_options: dict or list of dict, optional
+    :param storage_options:
+        Options to be passed on to the storage backend.
+        A list would need to match the number of datasets in a multiresolution pyramid.
+        One can provide different chunk size for each level of a pyramid using this
+        option.
+    :type label_metadata: dict, optional
+    :param label_metadata:
+      Image label metadata. See :meth:`write_label_metadata` for details
     """
     sub_group = group.require_group(f"labels/{name}")
     write_multiscale(
@@ -558,38 +582,48 @@ def write_labels(
     Including the multiscales and image-label metadata.
     Creates the label data in the sub-group "labels/{name}"
 
-    labels: np.ndarray
-      the label data to save. A downsampling of the data will be computed
+    :type labels: :class:`np.ndarray`
+    :param labels:
+      The label data to save. A downsampling of the data will be computed
       if the scaler argument is non-None.
       Label array MUST be up to 5-dimensional with dimensions
       ordered (t, c, z, y, x)
-    group: zarr.Group
-      the group within the zarr store to store the data in
-    name: str
-      the name of this labale data
-    scaler: Scaler
+    :type group: :class:`zarr.hierarchy.Group`
+    :param group: The group within the zarr store to write the metadata in.
+    :type name: str, optional
+    :param name: The name of this labels data.
+    :type scaler: :class:`ome_zarr.scale.Scaler`
+    :param scaler:
       Scaler implementation for downsampling the image argument. If None,
       no downsampling will be performed.
-    chunks: int or tuple of ints,
-      Size of the saved chunks to store the image.
-      This argument is deprecated and will be removed in a future version.
-      Use storage_options instead.
-    fmt: Format
+    :type chunks: int or tuple of ints, optional
+    :param chunks:
+        The size of the saved chunks to store the image.
+
+        .. deprecated:: 0.4.0
+            This argument is deprecated and will be removed in a future version.
+            Use ``storage_options`` instead.
+    :type fmt: :class:`ome_zarr.format.Format`, optional
+    :param fmt:
       The format of the ome_zarr data which should be used.
       Defaults to the most current.
-    axes: str or list of str or list of dict
-      List of axes dicts, or names. Not needed for v0.1 or v0.2
-      or if 2D. Otherwise this must be provided
-    coordinate_transformations: 2Dlist of dict
-      For each path, we have a List of transformation Dicts.
-      Each list of dicts are added to each datasets in order
-      and must include a 'scale' transform.
-    storage_options: dict or list of dict
-      Options to be passed on to the storage backend. A list would need to match
-      the number of datasets in a multiresolution pyramid. One can provide
-      different chunk size for each level of a pyramind using this option.
-    label_metadata: JSONDict
-      image label metadata. See 'write_label_metadata' for details
+    :type axes: list of str or list of dicts, optional
+    :param axes:
+      The names of the axes. e.g. ["t", "c", "z", "y", "x"].
+      Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
+    :type coordinate_transformations: list of dict
+    :param coordinate_transformations:
+      For each resolution, we have a List of transformation Dicts (not validated).
+      Each list of dicts are added to each datasets in order.
+    :type storage_options: dict or list of dict, optional
+    :param storage_options:
+        Options to be passed on to the storage backend.
+        A list would need to match the number of datasets in a multiresolution pyramid.
+        One can provide different chunk size for each level of a pyramid using this
+        option.
+    :type label_metadata: dict, optional
+    :param label_metadata:
+      Image label metadata. See :meth:`write_label_metadata` for details
     """
     mip, axes = _create_mip(labels, fmt, scaler, axes)
     write_multiscale_labels(

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -193,7 +193,7 @@ def write_multiscale(
 
         .. deprecated:: 0.4.0
             This argument is deprecated and will be removed in a future version.
-            Use ``storage_options`` instead.
+            Use :attr:`storage_options` instead.
     :type fmt: :class:`ome_zarr.format.Format`, optional
     :param fmt:
         The format of the ome_zarr data which should be used.
@@ -415,7 +415,7 @@ def write_image(
 
         .. deprecated:: 0.4.0
             This argument is deprecated and will be removed in a future version.
-            Use ``storage_options`` instead.
+            Use :attr:`storage_options` instead.
     :type fmt: :class:`ome_zarr.format.Format`, optional
     :param fmt:
       The format of the ome_zarr data which should be used.
@@ -523,7 +523,7 @@ def write_multiscale_labels(
 
         .. deprecated:: 0.4.0
             This argument is deprecated and will be removed in a future version.
-            Use ``storage_options`` instead.
+            Use :attr:`storage_options` instead.
     :type fmt: :class:`ome_zarr.format.Format`, optional
     :param fmt:
       The format of the ome_zarr data which should be used.
@@ -602,7 +602,7 @@ def write_labels(
 
         .. deprecated:: 0.4.0
             This argument is deprecated and will be removed in a future version.
-            Use ``storage_options`` instead.
+            Use :attr:`storage_options` instead.
     :type fmt: :class:`ome_zarr.format.Format`, optional
     :param fmt:
       The format of the ome_zarr data which should be used.

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -181,7 +181,7 @@ def write_multiscale(
     """
     Write a pyramid with multiscale metadata to disk.
 
-    :type pyramid: list of :class:`np.ndarray`
+    :type pyramid: list of :class:`numpy.ndarray`
     :param pyramid:
         The image data to save. Largest level first. All image arrays MUST be up to
         5-dimensional with dimensions ordered (t, c, z, y, x)
@@ -397,7 +397,7 @@ def write_image(
 ) -> None:
     """Writes an image to the zarr store according to ome-zarr specification
 
-    :type image: :class:`np.ndarray`
+    :type image: :class:`numpy.ndarray`
     :param image:
       The image data to save. A downsampling of the data will be computed
       if the scaler argument is non-None.
@@ -508,7 +508,7 @@ def write_multiscale_labels(
     Including the multiscales and image-label metadata.
     Creates the label data in the sub-group "labels/{name}"
 
-    :type pyramid: list of :class:`np.ndarray`
+    :type pyramid: list of :class:`numpy.ndarray`
     :param pyramid:
       the image label data to save. Largest level first
       All image arrays MUST be up to 5-dimensional with dimensions
@@ -582,7 +582,7 @@ def write_labels(
     Including the multiscales and image-label metadata.
     Creates the label data in the sub-group "labels/{name}"
 
-    :type labels: :class:`np.ndarray`
+    :type labels: :class:`numpy.ndarray`
     :param labels:
       The label data to save. A downsampling of the data will be computed
       if the scaler argument is non-None.

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -181,19 +181,20 @@ def write_multiscale(
     """
     Write a pyramid with multiscale metadata to disk.
 
-    :type pyramid: list of np.ndarray
+    :type pyramid: list of :class:`np.ndarray`
     :param pyramid:
         The image data to save. Largest level first. All image arrays MUST be up to
         5-dimensional with dimensions ordered (t, c, z, y, x)
     :type group: :class:`zarr.Group`
     :param group: The group within the zarr store to store the data in
     :type chunks: int or tuple of ints, optional
-    :param chunks: The size of the saved chunks to store the image.
+    :param chunks:
+        The size of the saved chunks to store the image.
 
         .. deprecated:: 0.4.0
             This argument is deprecated and will be removed in a future version.
-            Use storage_options instead.
-    :type fmt: class:`ome_zarr.format.Format`, optional
+            Use ``storage_options`` instead.
+    :type fmt: :class:`ome_zarr.format.Format`, optional
     :param fmt:
         The format of the ome_zarr data which should be used.
         Defaults to the most current.
@@ -210,7 +211,7 @@ def write_multiscale(
     :param storage_options:
         Options to be passed on to the storage backend.
         A list would need to match the number of datasets in a multiresolution pyramid.
-        One can provide different chunk size for each level of a pyramind using this
+        One can provide different chunk size for each level of a pyramid using this
         option.
     """
 


### PR DESCRIPTION
This proposes to use the standard docstring markup (`param`, `type`) to unify the rendering in the published documentation. Also includes the `deprecated` markup for deprecated options.

Initially applied to `write_multiscales` for a first round of review, the other docstrings in the `writer` module can be unified if we all agree with this strategy.

Proposed tag:  this is no a blocker for the imminent release of `0.4.0`  and should be releasable as a `0.4.1`
