### PR TITLE
Relax version detection

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -12,6 +12,11 @@ LOGGER = logging.getLogger("ome_zarr.format")
 def format_from_version(version: str) -> "Format":
 
     for fmt in format_implementations():
+
+        # Support floating-point versions like `0.2`
+        if isinstance(version, float):
+            version = str(version)
+
         if fmt.version == version:
             return fmt
     raise ValueError(f"Version {version} not recognized")


### PR DESCRIPTION
Some writers (like for the DANDI project) have stored
the versions as floating point values (e.g. `0.2`).
Though this won't be long-term sustainable, relaxing
the version identification at this point seems
unproblematic.

cc: @leekamentsky