### PR TITLE
Fix format warning duplication

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -27,10 +27,10 @@ def format_implementations() -> Iterator["Format"]:
     yield FormatV01()
 
 
-def detect_format(metadata: dict) -> "Format":
+def detect_format(metadata: dict, default: "Format") -> "Format":
     """
     Give each format implementation a chance to take ownership of the
-    given metadata. If none matches, a CurrentFormat is returned.
+    given metadata. If none matches, the default value will be returned.
     """
 
     if metadata:
@@ -38,7 +38,7 @@ def detect_format(metadata: dict) -> "Format":
             if fmt.matches(metadata):
                 return fmt
 
-    return CurrentFormat()
+    return default
 
 
 class Format(ABC):

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -46,7 +46,7 @@ class ZarrLocation:
         self.__store = loader.init_store(self.__path, mode)
 
         self.__init_metadata()
-        detected = detect_format(self.__metadata)
+        detected = detect_format(self.__metadata, loader)
         if detected != fmt:
             LOGGER.warning(f"version mismatch: detected:{detected}, requested:{fmt}")
             self.__fmt = detected


### PR DESCRIPTION
The call graph that led to duplicated WARNING messages of the form:

```
WARNING:ome_zarr.io:version mismatch: detected:FormatV02, requested:FormatV04
WARNING:ome_zarr.io:version mismatch: detected:FormatV04, requested:FormatV02
```
where caused by (roughly) this sequence of calls:
 * Multiscales created using the default CurrentFormat (V04)
 * Metadata of Multiscales is checked (V02) leading to the first warning
 * The call to `zarr.create("labels")` initializes a Labels object
 * It has no metadata and so defaults to the CurrentFormat (V04)
 * This then mismatches from the expected format (V02) leading to the second

We now simply require that a value is passed for when the object does not contain metadata.