### PR TITLE
Plate pyramids and version

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -64,14 +64,21 @@ class Format(ABC):
     def init_channels(self) -> None:  # pragma: no cover
         raise NotImplementedError()
 
-    def _get_multiscale_version(self, metadata: dict) -> Optional[str]:
+    def _get_metadata_version(self, metadata: dict) -> Optional[str]:
+        """
+        Checks the metadata dict for a version
+
+        Returns the version of the first object found in the metadata,
+        checking for 'multiscales', 'plate', 'well' etc
+        """
         multiscales = metadata.get("multiscales", [])
         if multiscales:
             dataset = multiscales[0]
             return dataset.get("version", None)
-        plate = metadata.get("plate", [])
-        if plate:
-            return plate.get("version", None)
+        for name in ["plate", "well", "image-label"]:
+            obj = metadata.get(name, None)
+            if obj:
+                return obj.get("version", None)
         return None
 
     def __repr__(self) -> str:
@@ -120,7 +127,7 @@ class FormatV01(Format):
         return "0.1"
 
     def matches(self, metadata: dict) -> bool:
-        version = self._get_multiscale_version(metadata)
+        version = self._get_metadata_version(metadata)
         LOGGER.debug(f"{self.version} matches {version}?")
         return version == self.version
 

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -121,7 +121,7 @@ class FormatV01(Format):
 
     def matches(self, metadata: dict) -> bool:
         version = self._get_multiscale_version(metadata)
-        LOGGER.debug(f"V01:{version} v. {self.version}")
+        LOGGER.debug(f"{self.version} matches {version}?")
         return version == self.version
 
     def init_store(self, path: str, mode: str = "r") -> FSStore:
@@ -167,11 +167,6 @@ class FormatV02(FormatV01):
     @property
     def version(self) -> str:
         return "0.2"
-
-    def matches(self, metadata: dict) -> bool:
-        version = self._get_multiscale_version(metadata)
-        LOGGER.debug(f"{self.version} matches {version}?")
-        return version == self.version
 
     def init_store(self, path: str, mode: str = "r") -> FSStore:
         """

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -69,6 +69,9 @@ class Format(ABC):
         if multiscales:
             dataset = multiscales[0]
             return dataset.get("version", None)
+        plate = metadata.get("plate", [])
+        if plate:
+            return plate.get("version", None)
         return None
 
     def __repr__(self) -> str:

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -31,6 +31,7 @@ class ZarrLocation:
         self, path: Union[Path, str], mode: str = "r", fmt: Format = CurrentFormat()
     ) -> None:
 
+        LOGGER.debug(f"ZarrLocation.__init__ path:{path}, fmt:{fmt.version}")
         self.__fmt = fmt
         self.__mode = mode
         if isinstance(path, Path):
@@ -47,6 +48,7 @@ class ZarrLocation:
 
         self.__init_metadata()
         detected = detect_format(self.__metadata, loader)
+        LOGGER.debug(f"ZarrLocation.__init__ {path} detected:{detected}")
         if detected != fmt:
             LOGGER.warning(f"version mismatch: detected:{detected}, requested:{fmt}")
             self.__fmt = detected

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -497,33 +497,10 @@ class Plate(Spec):
         LOGGER.debug(f"img_pyramid_shapes: {well_spec.img_pyramid_shapes}")
 
         self.axes = well_spec.img_metadata["axes"]
-        size_y = well_spec.img_shape[len(self.axes) - 2]
-        size_x = well_spec.img_shape[len(self.axes) - 1]
 
-        # FIXME - if only returning a single stiched plate (not a pyramid)
-        # need to decide optimal size. E.g. longest side < 1500
-        TARGET_SIZE = 1500
-        plate_width = self.column_count * size_x
-        plate_height = self.row_count * size_y
-        longest_side = max(plate_width, plate_height)
-        target_level = 0
-        for level, shape in enumerate(well_spec.img_pyramid_shapes):
-            plate_width = self.column_count * shape[-1]
-            plate_height = self.row_count * shape[-2]
-            longest_side = max(plate_width, plate_height)
-            target_level = level
-            if longest_side <= TARGET_SIZE:
-                break
-
-        LOGGER.debug(f"target_level: {target_level}")
-
+        # Create a dask pyramid for the plate
         pyramid = []
-
-        # This should create a pyramid of levels, but causes seg faults!
-        # for level in range(5):
-        for level in [target_level]:
-
-            tile_shape = well_spec.img_pyramid_shapes[level]
+        for level, tile_shape in enumerate(well_spec.img_pyramid_shapes):
             lazy_plate = self.get_stitched_grid(level, tile_shape)
             pyramid.append(lazy_plate)
 

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -464,6 +464,7 @@ class Plate(Spec):
 
     def __init__(self, node: Node) -> None:
         super().__init__(node)
+        LOGGER.debug(f"Plate created with ZarrLocation fmt:{ self.zarr.fmt}")
         self.get_pyramid_lazy(node)
 
     def get_pyramid_lazy(self, node: Node) -> None:


### PR DESCRIPTION
This fixes one bug with viewing older (v0.1) plates and resolves the long-standing limitation of only loading a single resolution level for plates. Now we load a dask pyramid.

- Bug-fix: When `Format` class checks for version, it only read the `multiscales` metadata and not the 'plate', so we defaulted to using the `CurrentFormat` for reading plates. This meant that the `dimension_separator` was `/` and so for `v0.1` plates which use `.` the data wasn't loaded. Also, the `matches()` check was duplicated in the `FormatV02` subclass that had different logging than the `FormatV01` subclass so that logging for a `plate` previously looked like this:

```
14:55:02 DEBUG 0.4 matches None?
14:55:02 DEBUG 0.3 matches None?
14:55:02 DEBUG 0.2 matches None?
14:55:02 DEBUG V01:None v. 0.1
```
This now looks like:
```
14:57:00 DEBUG 0.4 matches 0.1?
14:57:00 DEBUG 0.3 matches 0.1?
14:57:00 DEBUG 0.2 matches 0.1?
14:57:00 DEBUG 0.1 matches 0.1?
```

 - Plate pyramids, see https://github.com/ome/napari-ome-zarr/issues/45 That discussion prompted another go at loading a dask pyramid (instead of picking a single resolution). So now, you can zoom in to a region of a plate in `napari` and it loads higher resolution tiles!

To test:
This `v0.1` plate previously appeared as black in `napari`, but now it loads and when you zoom in you get higher resolution tiles (although they seem to be very aggressively loaded so it is quite slow!):

```
$ napari --plugin napari-ome-zarr https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/422.zarr -vvv
```

<img width="1090" alt="Screenshot 2022-05-04 at 14 34 17" src="https://user-images.githubusercontent.com/900055/166697878-9ab6d026-fa40-4284-976f-d9e49c21d475.png">


