### PR TITLE
bugfix in chunks when providing storage_options as dict

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -228,7 +228,7 @@ Please use the 'storage_options' argument instead."""
         options = {}
         if storage_options:
             options = (
-                storage_options
+                storage_options.copy()
                 if not isinstance(storage_options, list)
                 else storage_options[path]
             )


### PR DESCRIPTION
The current implementation breaks when providing a single dict for `storage_options`, because `options.pop("chunks",...)` on line 238 removes the key `chunks` from the original `storage_options` dict after the first iteration. This happens because `options` is an alias of `storage_options` instead of a deep copy. My change fixes this and provides the intended behavior (all pyramid levels follow the same chunking scheme if `storage_options` is provided as a dict.