### PR TITLE
Fix the Zarr development GH workflow following branch renaming

### DIFF
--- a/.github/workflows/zarr-dev.yml
+++ b/.github/workflows/zarr-dev.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel pytest tox
           python -m pip install \
-          git+https://github.com/zarr-developers/zarr-python.git@main
+          git+https://github.com/zarr-developers/zarr-python.git
 
       - name: Run pytest
         shell: bash -l {0}

--- a/.github/workflows/zarr-dev.yml
+++ b/.github/workflows/zarr-dev.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel pytest tox
           python -m pip install \
-          git+https://github.com/zarr-developers/zarr-python.git@master
+          git+https://github.com/zarr-developers/zarr-python.git@main
 
       - name: Run pytest
         shell: bash -l {0}


### PR DESCRIPTION
The upstream master branch has been merged into main and removed - see https://github.com/zarr-developers/zarr-python/pull/1033