### PR TITLE
Write version attribute to image-label specification

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -453,6 +453,7 @@ def write_label_metadata(
     name: str,
     colors: List[JSONDict] = None,
     properties: List[JSONDict] = None,
+    fmt: Format = CurrentFormat(),
     **metadata: Union[List[JSONDict], JSONDict, str],
 ) -> None:
     """
@@ -476,6 +477,10 @@ def write_label_metadata(
       Each dict specifies additional properties for one label.
       It must contain the field "label-value"
       and may contain arbitrary additional properties.
+    :type fmt: :class:`ome_zarr.format.Format`, optional
+    :param fmt:
+      The format of the ome_zarr data which should be used.
+      Defaults to the most current.
     """
     label_group = group[name]
     image_label_metadata = {**metadata}
@@ -483,6 +488,7 @@ def write_label_metadata(
         image_label_metadata["colors"] = colors
     if properties is not None:
         image_label_metadata["properties"] = properties
+    image_label_metadata["version"] = fmt.version
     label_group.attrs["image-label"] = image_label_metadata
 
     label_list = group.attrs.get("labels", [])
@@ -559,7 +565,10 @@ def write_multiscale_labels(
         **metadata,
     )
     write_label_metadata(
-        group["labels"], name, **({} if label_metadata is None else label_metadata)
+        group["labels"],
+        name,
+        fmt=fmt,
+        **({} if label_metadata is None else label_metadata),
     )
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -834,14 +834,14 @@ class TestLabelWriter:
         self.store = parse_url(self.path, mode="w").store
         self.root = zarr.group(store=self.store)
 
-    def create_image_data(self, shape, scaler, version, axes, transformations):
+    def create_image_data(self, shape, scaler, fmt, axes, transformations):
         rng = np.random.default_rng(0)
         data = rng.poisson(10, size=shape).astype(np.uint8)
         write_image(
             image=data,
             group=self.root,
             scaler=scaler,
-            fmt=version,
+            fmt=fmt,
             axes=axes,
             coordinate_transformations=transformations,
             storage_options=dict(chunks=(128, 128)),
@@ -865,20 +865,18 @@ class TestLabelWriter:
         else:
             return None
 
-    def verify_label_data(
-        self, label_name, label_data, version, shape, transformations
-    ):
+    def verify_label_data(self, label_name, label_data, fmt, shape, transformations):
         # Verify image data
         reader = Reader(parse_url(f"{self.path}/labels/{label_name}"))
         node = list(reader())[0]
         assert Multiscales.matches(node.zarr)
-        if version.version in ("0.1", "0.2"):
+        if fmt.version in ("0.1", "0.2"):
             # v0.1 and v0.2 MUST be 5D
             assert node.data[0].ndim == 5
         else:
             assert node.data[0].shape == shape
 
-        if version.version not in ("0.1", "0.2", "0.3"):
+        if fmt.version not in ("0.1", "0.2", "0.3"):
             for transf, expected in zip(
                 node.metadata["coordinateTransformations"], transformations
             ):
@@ -893,6 +891,7 @@ class TestLabelWriter:
 
         label_group = zarr.open(f"{self.path}/labels/{label_name}", "r")
         assert "image-label" in label_group.attrs
+        assert label_group.attrs["image-label"]["version"] == fmt.version
 
         # Verify multiscale metadata
         name = label_group.attrs["multiscales"][0].get("name", "")
@@ -908,7 +907,7 @@ class TestLabelWriter:
         ),
     )
     def test_write_labels(self, shape, scaler, format_version):
-        version = format_version()
+        fmt = format_version()
         axes = "tczyx"[-len(shape) :]
         transformations = []
         for dataset_transfs in TRANSFORMATIONS:
@@ -922,7 +921,7 @@ class TestLabelWriter:
 
         # create the actual label data
         label_data = np.random.randint(0, 1000, size=shape)
-        if version.version in ("0.1", "0.2"):
+        if fmt.version in ("0.1", "0.2"):
             # v0.1 and v0.2 require 5d
             expand_dims = (np.s_[None],) * (5 - len(shape))
             label_data = label_data[expand_dims]
@@ -930,18 +929,18 @@ class TestLabelWriter:
         label_name = "my-labels"
 
         # create the root level image data
-        self.create_image_data(shape, scaler, version, axes, transformations)
+        self.create_image_data(shape, scaler, fmt, axes, transformations)
 
         write_labels(
             label_data,
             self.root,
             scaler=scaler,
             name=label_name,
-            fmt=version,
+            fmt=fmt,
             axes=axes,
             coordinate_transformations=transformations,
         )
-        self.verify_label_data(label_name, label_data, version, shape, transformations)
+        self.verify_label_data(label_name, label_data, fmt, shape, transformations)
 
     @pytest.mark.parametrize(
         "format_version",
@@ -953,7 +952,7 @@ class TestLabelWriter:
         ),
     )
     def test_write_multiscale_labels(self, shape, scaler, format_version):
-        version = format_version()
+        fmt = format_version()
         axes = "tczyx"[-len(shape) :]
         transformations = []
         for dataset_transfs in TRANSFORMATIONS:
@@ -965,7 +964,7 @@ class TestLabelWriter:
 
         # create the actual label data
         label_data = np.random.randint(0, 1000, size=shape)
-        if version.version in ("0.1", "0.2"):
+        if fmt.version in ("0.1", "0.2"):
             # v0.1 and v0.2 require 5d
             expand_dims = (np.s_[None],) * (5 - len(shape))
             label_data = label_data[expand_dims]
@@ -978,17 +977,17 @@ class TestLabelWriter:
             labels_mip = scaler.nearest(label_data)
 
         # create the root level image data
-        self.create_image_data(shape, scaler, version, axes, transformations)
+        self.create_image_data(shape, scaler, fmt, axes, transformations)
 
         write_multiscale_labels(
             labels_mip,
             self.root,
             name=label_name,
-            fmt=version,
+            fmt=fmt,
             axes=axes,
             coordinate_transformations=transformations,
         )
-        self.verify_label_data(label_name, label_data, version, shape, transformations)
+        self.verify_label_data(label_name, label_data, fmt, shape, transformations)
 
     def test_two_label_images(self):
         axes = "tczyx"
@@ -1000,12 +999,12 @@ class TestLabelWriter:
         # create the root level image data
         shape = (1, 2, 1, 256, 256)
         scaler = Scaler()
-        version = FormatV04()
+        fmt = FormatV04()
         self.create_image_data(
             shape,
             scaler,
             axes=axes,
-            version=version,
+            fmt=fmt,
             transformations=transformations,
         )
 
@@ -1021,9 +1020,7 @@ class TestLabelWriter:
                 axes=axes,
                 coordinate_transformations=transformations,
             )
-            self.verify_label_data(
-                label_name, label_data, version, shape, transformations
-            )
+            self.verify_label_data(label_name, label_data, fmt, shape, transformations)
 
         # Verify label metadata
         label_root = zarr.open(f"{self.path}/labels", "r")


### PR DESCRIPTION
Discovered during the testing of https://github.com/ome/omero-cli-zarr/pull/107

The `write*label*` APIs introduced in #178 do not store the OME-NGFF specification version in the `image-label` attributes.

The changes proposed in this PR

- add a `fmt` optional parameter to `write_label_metadata`
- add the logic to store the format version in the `image-label` attributes
- updates the label writing tests to test the version metadata


I would be inclined this as a bug fix and would suggest to get it out as a patch release `0.4.3`. But strictly speaking, this adds an optional parameter to a public API and could be released as a minor version increment. 