### PR TITLE
Read multi-resolution pyramids in Well class (closes #208)

### DIFF
--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -405,56 +405,63 @@ class Well(Spec):
         LOGGER.info("well_data: %s", self.well_data)
 
         image_paths = [image["path"] for image in self.well_data.get("images")]
-        field_count = len(image_paths)
-        column_count = math.ceil(math.sqrt(field_count))
-        row_count = math.ceil(field_count / column_count)
 
-        # Use first Field for rendering settings, shape etc.
+        # Construct a 2D almost-square grid
+        field_count = len(image_paths)
+        self.row_count = math.ceil(math.sqrt(field_count))
+        self.column_count = math.ceil(field_count / self.row_count)
+
+        # Use first Field and highest-resolution level for rendering settings,
+        # shapes etc.
         image_zarr = self.zarr.create(image_paths[0])
         image_node = Node(image_zarr, node)
-        x_index = len(image_node.metadata["axes"]) - 1
-        y_index = len(image_node.metadata["axes"]) - 2
-        level = 0  # load full resolution image
-        self.numpy_type = image_node.data[level].dtype
+        self.x_index = len(image_node.metadata["axes"]) - 1
+        self.y_index = len(image_node.metadata["axes"]) - 2
+        self.numpy_type = image_node.data[0].dtype
+        self.img_shape = image_node.data[0].shape
         self.img_metadata = image_node.metadata
-        self.img_shape = image_node.data[level].shape
         self.img_pyramid_shapes = [d.shape for d in image_node.data]
 
-        # stitch full-resolution images into a grid
-        def get_field(tile_name: str) -> np.ndarray:
-            """tile_name is 'row,col'"""
-            row, col = (int(n) for n in tile_name.split(","))
-            field_index = (column_count * row) + col
-            path = f"{field_index}/{level}"
-            LOGGER.debug(f"LOADING tile... {path}")
-            try:
-                data = self.zarr.load(path)
-            except ValueError:
-                LOGGER.error(f"Failed to load {path}")
-                data = np.zeros(self.img_shape, dtype=self.numpy_type)
-            return data
+        # Create a pyramid of layers at different resolutions
+        pyramid = []
+        for level, tile_shape in enumerate(self.img_pyramid_shapes):
+            lazy_well = self.get_lazy_well(level, tile_shape)
+            pyramid.append(lazy_well)
 
-        lazy_reader = delayed(get_field)
-
-        def get_lazy_well() -> da.Array:
-            lazy_rows = []
-            # For level 0, return whole image for each tile
-            for row in range(row_count):
-                lazy_row: List[da.Array] = []
-                for col in range(column_count):
-                    tile_name = f"{row},{col}"
-                    LOGGER.debug(f"creating lazy_reader. row:{row} col:{col}")
-                    lazy_tile = da.from_delayed(
-                        lazy_reader(tile_name),
-                        shape=self.img_shape,
-                        dtype=self.numpy_type,
-                    )
-                    lazy_row.append(lazy_tile)
-                lazy_rows.append(da.concatenate(lazy_row, axis=x_index))
-            return da.concatenate(lazy_rows, axis=y_index)
-
-        node.data = [get_lazy_well()]
+        # Set the node.data to be pyramid view of the plate
+        node.data = pyramid
         node.metadata = image_node.metadata
+
+    def get_field(self, tile_name: str, level: int) -> np.ndarray:
+        """tile_name is 'row,col'"""
+        row, col = (int(n) for n in tile_name.split(","))
+        field_index = (self.column_count * row) + col
+        path = f"{field_index}/{level}"
+        LOGGER.debug(f"LOADING tile... {path}")
+        try:
+            data = self.zarr.load(path)
+        except ValueError:
+            LOGGER.error(f"Failed to load {path}")
+            data = np.zeros(self.img_pyramid_shapes[level], dtype=self.numpy_type)
+        return data
+
+    def get_lazy_well(self, level: int, tile_shape: tuple) -> da.Array:
+        lazy_reader = delayed(self.get_field)
+
+        lazy_rows = []
+        for row in range(self.row_count):
+            lazy_row: List[da.Array] = []
+            for col in range(self.column_count):
+                tile_name = f"{row},{col}"
+                LOGGER.debug(f"creating lazy_reader. row:{row} col:{col} level:{level}")
+                lazy_tile = da.from_delayed(
+                    lazy_reader(tile_name, level),
+                    shape=tile_shape,
+                    dtype=self.numpy_type,
+                )
+                lazy_row.append(lazy_tile)
+            lazy_rows.append(da.concatenate(lazy_row, axis=self.x_index))
+        return da.concatenate(lazy_rows, axis=self.y_index)
 
 
 class Plate(Spec):


### PR DESCRIPTION
Fixes #208, by replicating a structure similar to the `Plate` class into the `Well` class (i.e. reading multi-resolution pyramids).

Logs for `napari -vvv --plugin napari-ome-zarr xxx.zarr/B/03/` (also including a bit of zooming in/out, to trigger more loading) show that different levels are actually loaded:
<details>
  <summary>Click to expand!</summary>
  
  ```11:20:51 DEBUG ZarrLocation.__init__ path:xxx.zarr/B/03/, fmt:0.4
11:20:51 DEBUG Created nested FSStore(xxx.zarr/B/03/, r, {'dimension_separator': '/', 'normalize_keys': False})
11:20:51 DEBUG 0.4 matches 0.3?
11:20:51 DEBUG 0.3 matches 0.3?
11:20:51 DEBUG ZarrLocation.__init__ xxx.zarr/B/03/ detected:FormatV03
11:20:51 WARNING version mismatch: detected:FormatV03, requested:FormatV04
11:20:51 DEBUG Created nested FSStore(xxx.zarr/B/03/, r, {'dimension_separator': '/', 'normalize_keys': False})
11:20:51 DEBUG treating /tmp/xxx.zarr/B/03 [zgroup] as Well
11:20:51 INFO root_attr: well
11:20:51 DEBUG {'images': [{'path': '0'}], 'version': '0.3'}
11:20:51 INFO well_data: {'images': [{'path': '0'}], 'version': '0.3'}
11:20:51 DEBUG open(ZarrLocation(/tmp/xxx.zarr/B/03/0))
11:20:51 DEBUG ZarrLocation.__init__ path:/tmp/xxx.zarr/B/03/0, fmt:0.3
11:20:51 DEBUG Created nested FSStore(/tmp/xxx.zarr/B/03/0, r, {'dimension_separator': '/', 'normalize_keys': False})
11:20:51 DEBUG 0.4 matches 0.3?
11:20:51 DEBUG 0.3 matches 0.3?
11:20:51 DEBUG ZarrLocation.__init__ /tmp/xxx.zarr/B/03/0 detected:FormatV03
11:20:51 DEBUG treating /tmp/xxx.zarr/B/03/0 [zgroup] as Multiscales
11:20:51 INFO root_attr: multiscales
11:20:51 DEBUG [{'axes': [{'name': 'c', 'type': 'channel'}, {'name': 'z', 'type': 'space', 'unit': 'micrometer'}, {'name': 'y', 'type': 'space'}, {'name': 'x', 'type': 'space'}], 'datasets': [{'path': '0'}, {'path': '1'}, {'path': '2'}, {'path': '3'}], 'version': '0.3'}]
11:20:51 INFO root_attr: omero
11:20:51 DEBUG {'channels': [{'coefficient': 1, 'color': '00FFFF', 'family': 'linear', 'label': 'DAPI', 'window': {'end': 600, 'max': 65535, 'min': 0, 'start': 0}}, {'coefficient': 1, 'color': 'FF00FF', 'family': 'linear', 'label': 'nanog', 'window': {'end': 180, 'max': 65535, 'min': 0, 'start': 0}}, {'coefficient': 1, 'color': 'FFFF00', 'family': 'linear', 'label': 'Lamin B1', 'window': {'end': 1000, 'max': 65535, 'min': 0, 'start': 0}}], 'id': 1, 'name': 'TBD', 'version': '0.4'}
11:20:51 INFO datasets [{'path': '0'}, {'path': '1'}, {'path': '2'}, {'path': '3'}]
11:20:51 INFO resolution: 0
11:20:51 INFO  - shape ('c', 'z', 'y', 'x') = (3, 1, 19440, 20480)
11:20:51 INFO  - chunks =  ['1', '1', '2160', '2560']
11:20:51 INFO  - dtype = uint16
11:20:51 INFO resolution: 1
11:20:51 INFO  - shape ('c', 'z', 'y', 'x') = (3, 1, 9720, 10240)
11:20:51 INFO  - chunks =  ['1', '1', '2430', '2560']
11:20:51 INFO  - dtype = uint16
11:20:51 INFO resolution: 2
11:20:51 INFO  - shape ('c', 'z', 'y', 'x') = (3, 1, 4860, 5120)
11:20:51 INFO  - chunks =  ['1', '1', '2430', '2560']
11:20:51 INFO  - dtype = uint16
11:20:51 INFO resolution: 3
11:20:51 INFO  - shape ('c', 'z', 'y', 'x') = (3, 1, 2430, 2560)
11:20:51 INFO  - chunks =  ['1', '1', '2160 (+ 270)', '2560']
11:20:51 INFO  - dtype = uint16
11:20:51 DEBUG open(ZarrLocation(/tmp/xxx.zarr/B/03/0/labels))
11:20:51 DEBUG ZarrLocation.__init__ path:/tmp/xxx.zarr/B/03/0/labels, fmt:0.3
11:20:51 DEBUG Created nested FSStore(/tmp/xxx.zarr/B/03/0/labels, r, {'dimension_separator': '/', 'normalize_keys': False})
11:20:51 DEBUG ZarrLocation.__init__ /tmp/xxx.zarr/B/03/0/labels detected:FormatV03
11:20:51 DEBUG treating /tmp/xxx.zarr/B/03/0 [zgroup] as OMERO
11:20:51 INFO root_attr: multiscales
11:20:51 DEBUG [{'axes': [{'name': 'c', 'type': 'channel'}, {'name': 'z', 'type': 'space', 'unit': 'micrometer'}, {'name': 'y', 'type': 'space'}, {'name': 'x', 'type': 'space'}], 'datasets': [{'path': '0'}, {'path': '1'}, {'path': '2'}, {'path': '3'}], 'version': '0.3'}]
11:20:51 INFO root_attr: omero
11:20:51 DEBUG {'channels': [{'coefficient': 1, 'color': '00FFFF', 'family': 'linear', 'label': 'DAPI', 'window': {'end': 600, 'max': 65535, 'min': 0, 'start': 0}}, {'coefficient': 1, 'color': 'FF00FF', 'family': 'linear', 'label': 'nanog', 'window': {'end': 180, 'max': 65535, 'min': 0, 'start': 0}}, {'coefficient': 1, 'color': 'FFFF00', 'family': 'linear', 'label': 'Lamin B1', 'window': {'end': 1000, 'max': 65535, 'min': 0, 'start': 0}}], 'id': 1, 'name': 'TBD', 'version': '0.4'}
11:20:51 DEBUG creating lazy_reader. row:0 col:0 level:0
11:20:51 DEBUG creating lazy_reader. row:0 col:0 level:1
11:20:51 DEBUG creating lazy_reader. row:0 col:0 level:2
11:20:51 DEBUG creating lazy_reader. row:0 col:0 level:3
11:20:51 DEBUG treating /tmp/xxx.zarr/B/03 [zgroup] as ome-zarr
11:20:51 DEBUG returning /tmp/xxx.zarr/B/03 [zgroup]
11:20:51 DEBUG transforming /tmp/xxx.zarr/B/03 [zgroup]
11:20:51 DEBUG node.metadata: {'axes': [{'name': 'c', 'type': 'channel'}, {'name': 'z', 'type': 'space', 'unit': 'micrometer'}, {'name': 'y', 'type': 'space'}, {'name': 'x', 'type': 'space'}], 'name': ['DAPI', 'nanog', 'Lamin B1'], 'visible': [True, True, True], 'contrast_limits': [[0, 600], [0, 180], [0, 1000]], 'colormap': [[[0, 0, 0], [0.0, 1.0, 1.0]], [[0, 0, 0], [1.0, 0.0, 1.0]], [[0, 0, 0], [1.0, 1.0, 0.0]]]}
11:20:51 DEBUG Transformed: ([dask.array<from-value, shape=(3, 1, 19440, 20480), dtype=uint16, chunksize=(3, 1, 19440, 20480), chunktype=numpy.ndarray>, dask.array<from-value, shape=(3, 1, 9720, 10240), dtype=uint16, chunksize=(3, 1, 9720, 10240), chunktype=numpy.ndarray>, dask.array<from-value, shape=(3, 1, 4860, 5120), dtype=uint16, chunksize=(3, 1, 4860, 5120), chunktype=numpy.ndarray>, dask.array<from-value, shape=(3, 1, 2430, 2560), dtype=uint16, chunksize=(3, 1, 2430, 2560), chunktype=numpy.ndarray>], {'channel_axis': 0, 'name': ['DAPI', 'nanog', 'Lamin B1'], 'visible': [True, True, True], 'contrast_limits': [[0, 600], [0, 180], [0, 1000]], 'colormap': [<vispy.color.colormap.Colormap object at 0x7f1a61b62a60>, <vispy.color.colormap.Colormap object at 0x7f1a61b62af0>, <vispy.color.colormap.Colormap object at 0x7f1a61b62b80>]}, 'image')
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG LOADING tile... 0/3
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG LOADING tile... 0/0
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG LOADING tile... 0/0
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG ImageSlice.__init__
11:20:51 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:52 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG LOADING tile... 0/2
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG LOADING tile... 0/1
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG LOADING tile... 0/1
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG LOADING tile... 0/0
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG LOADING tile... 0/0
11:20:53 DEBUG ImageSlice.__init__
11:20:53 DEBUG LOADING tile... 0/0
11:20:54 DEBUG ImageSlice.__init__
11:20:54 DEBUG LOADING tile... 0/0
11:20:54 DEBUG ImageSlice.__init__
11:20:54 DEBUG LOADING tile... 0/0
11:20:54 DEBUG ImageSlice.__init__
11:20:54 DEBUG LOADING tile... 0/0
11:20:54 DEBUG ImageSlice.__init__
11:20:54 DEBUG LOADING tile... 0/0
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG LOADING tile... 0/0
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG LOADING tile... 0/0
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG LOADING tile... 0/1
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG LOADING tile... 0/2
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG ImageSlice.__init__
11:20:55 DEBUG ImageSlice.__init__
11:20:56 DEBUG ImageSlice.__init__
11:20:56 DEBUG ImageSlice.__init__
11:20:56 DEBUG ImageSlice.__init__
11:20:56 DEBUG ImageSlice.__init__
11:20:56 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
11:20:57 DEBUG ImageSlice.__init__
  ```
</details>

[this example is for an image where the highest-resolution level has Channel-ZYX shape `(3, 1, 19440, 20480)`]