### PR TITLE
Disable auto_mkdir when path begins with `s3`

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -187,7 +187,7 @@ class FormatV02(FormatV01):
         }
 
         mkdir = True
-        if "r" in mode or path.startswith("http"):
+        if "r" in mode or path.startswith("http") or path.startswith("s3"):
             # Could be simplified on the fsspec side
             mkdir = False
         if mkdir:


### PR DESCRIPTION
When trying to use `ome-zarr-py` I was getting an error thrown that complained about `aiobotocore.session.AioSession`'s `__init__` not having an `auto_mkdir` parameter, which I believe was being incorrectly passed to it. This PR fixes that by adding a condition to exclude `auto_mkdir` from `kwargs` when the path starts with `s3`, similarly to what is already done when the path starts with `http`.