### PR TITLE
Use multiscales name for node metadata['name']

### DIFF
--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -288,6 +288,8 @@ class Multiscales(Spec):
             # Raises ValueError if not valid
             axes_obj = Axes(axes, fmt)
             node.metadata["axes"] = axes_obj.to_list()
+            # This will get overwritten by 'omero' metadata if present
+            node.metadata["name"] = multiscales[0].get("name")
             paths = [d["path"] for d in datasets]
             self.datasets: List[str] = paths
             transformations = [d.get("coordinateTransformations") for d in datasets]


### PR DESCRIPTION
Fixes https://github.com/ome/napari-ome-zarr/issues/36

This uses the `multiscales` "name" field to populate the `node.metadata["name"]` which is then used by `napari-ome-zarr` for the layer names.

To test, using the data provided on the issue above (https://oc.embl.de/index.php/s/yfwGLkFRHsopcug) and opened in `napari`, the name ("image") is used for each layer.

<img width="860" alt="Screenshot 2022-07-22 at 15 04 25" src="https://user-images.githubusercontent.com/900055/180456555-e9266b3e-af79-4510-b52a-a1421a00bee6.png">

