### PR TITLE
Use integer division for new_shape in resize_image

### DIFF
--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -144,8 +144,8 @@ class Scaler:
 
         # only down-sample in X and Y dimensions for now...
         new_shape = list(image.shape)
-        new_shape[-1] = np.ceil(float(image.shape[-1]) / self.downscale)
-        new_shape[-2] = np.ceil(float(image.shape[-2]) / self.downscale)
+        new_shape[-1] = image.shape[-1] // self.downscale
+        new_shape[-2] = image.shape[-2] // self.downscale
         out_shape = tuple(new_shape)
 
         dtype = image.dtype

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -137,10 +137,10 @@ class TestWriter:
     @pytest.mark.parametrize("read_from_zarr", [True, False])
     def test_write_image_dask(self, read_from_zarr):
         # Size 100 tests resize shapes: https://github.com/ome/ome-zarr-py/issues/219
-        shape = (128, 100, 100)
+        shape = (128, 200, 200)
         data = self.create_data(shape)
         data_delayed = da.from_array(data)
-        chunks = (64, 64)
+        chunks = (32, 32)
         opts = {"chunks": chunks, "compressor": None}
         if read_from_zarr:
             # write to zarr and re-read as dask...
@@ -176,7 +176,9 @@ class TestWriter:
             assert transfs[0]["scale"][0] == 1
             for value in transfs[0]["scale"]:
                 assert value >= 1
-            if read_from_zarr:
+            if read_from_zarr and level < 3:
+                # if shape smaller than chunk, dask writer uses chunk == shape
+                # so we only compare larger resolutions
                 assert filecmp.cmp(
                     f"{self.path}/temp/test/{level}/.zarray",
                     f"{self.path}/test/{level}/.zarray",

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,3 +1,4 @@
+import filecmp
 import pathlib
 
 import dask.array as da
@@ -7,7 +8,7 @@ import zarr
 from numcodecs import Blosc
 
 from ome_zarr.format import CurrentFormat, FormatV01, FormatV02, FormatV03, FormatV04
-from ome_zarr.io import parse_url
+from ome_zarr.io import ZarrLocation, parse_url
 from ome_zarr.reader import Multiscales, Reader
 from ome_zarr.scale import Scaler
 from ome_zarr.writer import (
@@ -133,19 +134,41 @@ class TestWriter:
             for value in transfs[0]["scale"]:
                 assert value >= 1
 
-    def test_write_image_dask(self):
-        shape = (128, 128, 128)
+    @pytest.mark.parametrize("read_from_zarr", [True, False])
+    def test_write_image_dask(self, read_from_zarr):
+        # Size 100 tests resize shapes: https://github.com/ome/ome-zarr-py/issues/219
+        shape = (128, 100, 100)
         data = self.create_data(shape)
         data_delayed = da.from_array(data)
         chunks = (64, 64)
+        opts = {"chunks": chunks, "compressor": None}
+        if read_from_zarr:
+            # write to zarr and re-read as dask...
+            path = f"{self.path}/temp/"
+            store = parse_url(path, mode="w").store
+            temp_group = zarr.group(store=store).create_group("test")
+            write_image(data, temp_group, axes="zyx", storage_options=opts)
+            loc = ZarrLocation(f"{self.path}/temp/test")
+            reader = Reader(loc)()
+            nodes = list(reader)
+            data_delayed = (
+                nodes[0]
+                .load(Multiscales)
+                .array(resolution="0", version=CurrentFormat().version)
+            )
         write_image(
-            data_delayed, self.group, axes="zyx", storage_options={"chunks": chunks}
+            data_delayed,
+            self.group,
+            axes="zyx",
+            storage_options={"chunks": chunks, "compressor": None},
         )
         reader = Reader(parse_url(f"{self.path}/test"))
         image_node = list(reader())[0]
         first_chunk = [c[0] for c in image_node.data[0].chunks]
         assert tuple(first_chunk) == _retuple(chunks, image_node.data[0].shape)
-        for transfs in image_node.metadata["coordinateTransformations"]:
+        for level, transfs in enumerate(
+            image_node.metadata["coordinateTransformations"]
+        ):
             assert len(transfs) == 1
             assert transfs[0]["type"] == "scale"
             assert len(transfs[0]["scale"]) == len(shape)
@@ -153,6 +176,20 @@ class TestWriter:
             assert transfs[0]["scale"][0] == 1
             for value in transfs[0]["scale"]:
                 assert value >= 1
+            if read_from_zarr:
+                assert filecmp.cmp(
+                    f"{self.path}/temp/test/{level}/.zarray",
+                    f"{self.path}/test/{level}/.zarray",
+                    shallow=False,
+                )
+
+        if read_from_zarr:
+            # .zattrs should be the same
+            assert filecmp.cmp(
+                f"{self.path}/temp/test/.zattrs",
+                f"{self.path}/test/.zattrs",
+                shallow=False,
+            )
 
     @pytest.mark.parametrize("array_constructor", [np.array, da.from_array])
     def test_write_image_compressed(self, array_constructor):


### PR DESCRIPTION
Fixes issue reported at https://github.com/ome/ome-zarr-py/issues/219#issuecomment-1231613397

The issue there was that the dask writing used `resize_image()` which calculated down-sizing using `ceil()` so the sizes of pyramids levels were `100, 50, 25, 13, 7` instead of `100, 50, 25, 12, 6` as for the non-dask data.

I updated `resize_image()` to use the same integer division for calculating new_shape as is used in the `def __nearest()` for non-dask data.

To test:
 - run the sample script on issue above (using ome-zarr-py installed from this branch)
 - check that the pyramid sizes are `100, 50, 25, 12, 6` for both the `debug0.zarr` (non-dask) and `debug1.zarr` (dask).
 - The `coordinateTransforms` should also be the same for both 