### PR TITLE
Storage options copy

### DIFF
--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -157,8 +157,6 @@ class Scaler:
     def nearest(self, base: np.ndarray) -> List[np.ndarray]:
         """
         Downsample using :func:`skimage.transform.resize`.
-
-        The :const:`cvs2.INTER_NEAREST` interpolation method is used.
         """
         return self._by_plane(base, self.__nearest)
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -246,7 +246,6 @@ Please use the 'storage_options' argument instead."""
                 data = da.array(data).rechunk(chunks=chunks_opt)
                 options["chunks"] = chunks_opt
             da.to_zarr(
-                array_key=path,
                 arr=data,
                 url=group.store,
                 component=str(Path(group.path, str(path))),
@@ -553,7 +552,6 @@ Please use the 'storage_options' argument instead."""
         )
         delayed.append(
             da.to_zarr(
-                array_key=path,
                 arr=image,
                 url=group.store,
                 component=str(Path(group.path, str(path))),

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -228,7 +228,7 @@ Please use the 'storage_options' argument instead."""
         options = {}
         if storage_options:
             options = (
-                storage_options
+                storage_options.copy()
                 if not isinstance(storage_options, list)
                 else storage_options[path]
             )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -112,8 +112,10 @@ class TestWriter:
             ):
                 assert transf == expected
             assert len(node.metadata["coordinateTransformations"]) == len(node.data)
-        first_chunk = [c[0] for c in node.data[0].chunks]
-        assert tuple(first_chunk) == _retuple(chunks, node.data[0].shape)
+        # check chunks for first 2 resolutions (before shape gets smaller than chunk)
+        for nd_array in node.data[:2]:
+            first_chunk = [c[0] for c in nd_array.chunks]
+            assert tuple(first_chunk) == _retuple(chunks, nd_array.shape)
         assert np.allclose(data, node.data[0][...].compute())
 
     @pytest.mark.parametrize("array_constructor", [np.array, da.from_array])

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -70,7 +70,10 @@ class TestWriter:
         ),
     )
     @pytest.mark.parametrize("array_constructor", [np.array, da.from_array])
-    def test_writer(self, shape, scaler, format_version, array_constructor):
+    @pytest.mark.parametrize("storage_options_list", [True, False])
+    def test_writer(
+        self, shape, scaler, format_version, array_constructor, storage_options_list
+    ):
 
         data = self.create_data(shape)
         data = array_constructor(data)
@@ -85,7 +88,10 @@ class TestWriter:
             )
         if scaler is None:
             transformations = [transformations[0]]
-        chunks = (128, 128)
+        chunks = [(128, 128), (50, 50), (25, 25), (25, 25), (25, 25), (25, 25)]
+        storage_options = {"chunks": chunks[0]}
+        if storage_options_list:
+            storage_options = [{"chunks": chunk} for chunk in chunks]
         write_image(
             image=data,
             group=self.group,
@@ -93,7 +99,7 @@ class TestWriter:
             fmt=version,
             axes=axes,
             coordinate_transformations=transformations,
-            storage_options=dict(chunks=chunks),
+            storage_options=storage_options,
         )
 
         # Verify
@@ -113,9 +119,10 @@ class TestWriter:
                 assert transf == expected
             assert len(node.metadata["coordinateTransformations"]) == len(node.data)
         # check chunks for first 2 resolutions (before shape gets smaller than chunk)
-        for nd_array in node.data[:2]:
+        for level, nd_array in enumerate(node.data[:2]):
+            expected = chunks[level] if storage_options_list else chunks[0]
             first_chunk = [c[0] for c in nd_array.chunks]
-            assert tuple(first_chunk) == _retuple(chunks, nd_array.shape)
+            assert tuple(first_chunk) == _retuple(expected, nd_array.shape)
         assert np.allclose(data, node.data[0][...].compute())
 
     @pytest.mark.parametrize("array_constructor", [np.array, da.from_array])


### PR DESCRIPTION
This replaces #197, fixing merge conflicts between that and master and adding tests (described on the PR).

It also fixes an invalid comment and fixes a warning:

```
/Users/wmoore/opt/anaconda3/envs/omeroweb/lib/python3.9/site-packages/zarr/creation.py:221: UserWarning: ignoring keyword argument 'array_key'
  warn('ignoring keyword argument %r' % k)
```