### PR TITLE
scaler.local_mean() maintains dype

### DIFF
--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -208,7 +208,7 @@ class Scaler:
         stack_dims = base.ndim - 2
         factors = (*(1,) * stack_dims, *(self.downscale, self.downscale))
         for i in range(self.max_layer):
-            rv.append(downscale_local_mean(rv[-1], factors=factors))
+            rv.append(downscale_local_mean(rv[-1], factors=factors).astype(base.dtype))
         return rv
 
     def zoom(self, base: np.ndarray) -> List[np.ndarray]:


### PR DESCRIPTION
Fixes #217. 

To test, use the sample script on the above issue. The downsampled array should be `<u2`

```
$ cat data/1/.zarray
...
"dtype": "<u2"
...
```