### PR TITLE
Don't hard-code dimension_separator when reading

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -183,10 +183,14 @@ class FormatV02(FormatV01):
         TODO: could also check dimension_separator
         """
 
-        kwargs = {
-            "dimension_separator": "/",
+        kwargs: Dict[str, Any] = {
             "normalize_keys": False,
         }
+
+        # if creating a store, use / by default. If reading, use the
+        # dimension_separator specified in the .zarray
+        if mode == "w":
+            kwargs["dimension_separator"] = "/"
 
         mkdir = True
         if "r" in mode or path.startswith("http") or path.startswith("s3"):

--- a/tests/data/v2/0/.zarray
+++ b/tests/data/v2/0/.zarray
@@ -13,6 +13,7 @@
         "id": "blosc",
         "shuffle": 1
     },
+    "dimension_separator": "/",
     "dtype": "|u1",
     "fill_value": 0,
     "filters": null,


### PR DESCRIPTION
Fixes https://github.com/ome/napari-ome-zarr/issues/66

Allows reading of OME-NGFF that use `dimension_separator: "."`,
corresponding to the proposal to allow `.` as dimension_separator: https://github.com/ome/ngff/pull/161

When writing, the behaviour is unchanged and we still use `/`.