### PR TITLE
Fix sphinx package typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Documentation will be automatically built with `readthedocs`.
 
 It can be built locally with::
 
-    $ pip install spinx
+    $ pip install sphinx
     $ sphinx-build -b html docs/source/ docs/build/html
 
 Tests


### PR DESCRIPTION
I've been programming against and looking into `ome-zarr` recently and couldn't unsee this typo (and also couldn't see any others), so I thought I'd submit a quick fix PR. Feel free to roll this into something else if desired. Hope this doesn't cause any undesired CI expense!