### PR TITLE
Use zarr default compressor by default

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -250,7 +250,7 @@ Please use the 'storage_options' argument instead."""
                 url=group.store,
                 component=str(Path(group.path, str(path))),
                 storage_options=options,
-                compressor=options.get("compressor"),
+                compressor=options.get("compressor", zarr.storage.default_compressor),
                 dimension_separator=group._store._dimension_separator,
             )
         else:
@@ -558,7 +558,7 @@ Please use the 'storage_options' argument instead."""
                 component=str(Path(group.path, str(path))),
                 storage_options=options,
                 compute=False,
-                compressor=options.get("compressor"),
+                compressor=options.get("compressor", zarr.storage.default_compressor),
                 dimension_separator=group._store._dimension_separator,
             )
         )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,5 +1,6 @@
 import filecmp
 import pathlib
+from tempfile import TemporaryDirectory
 
 import dask.array as da
 import numpy as np
@@ -16,6 +17,7 @@ from ome_zarr.writer import (
     _retuple,
     write_image,
     write_labels,
+    write_multiscale,
     write_multiscale_labels,
     write_multiscales_metadata,
     write_plate_metadata,
@@ -219,6 +221,28 @@ class TestWriter:
             "shuffle": Blosc.SHUFFLE,
             "blocksize": 0,
         }
+
+    def test_default_compression(self):
+        """Test that the default compression is not None.
+
+        We make an array of zeros which should compress trivially easily,
+        write out the chunks, and check that they are smaller than the raw
+        data.
+        """
+        arr_np = np.zeros((2, 50, 200, 400), dtype=np.uint8)
+        # avoid empty chunks so they are guaranteed to be written out to disk
+        arr_np[0, 0, 0, 0] = 1
+        # 4MB chunks, trivially compressible
+        arr = da.from_array(arr_np, chunks=(1, 50, 200, 400))
+        with TemporaryDirectory(suffix='.ome.zarr') as tempdir:
+            path = tempdir
+            store = parse_url(path, mode='w').store
+            root = zarr.group(store=store)
+            # no compressor options, we are checking default
+            write_multiscale([arr], group=root, axes='tzyx')
+            # check chunk: multiscale level 0, 4D chunk at (0, 0, 0, 0)
+            chunk_size = (pathlib.Path(path) / '0/0/0/0/0').stat().st_size
+            assert chunk_size < 4e6
 
     def test_validate_coordinate_transforms(self):
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -234,14 +234,14 @@ class TestWriter:
         arr_np[0, 0, 0, 0] = 1
         # 4MB chunks, trivially compressible
         arr = da.from_array(arr_np, chunks=(1, 50, 200, 400))
-        with TemporaryDirectory(suffix='.ome.zarr') as tempdir:
+        with TemporaryDirectory(suffix=".ome.zarr") as tempdir:
             path = tempdir
-            store = parse_url(path, mode='w').store
+            store = parse_url(path, mode="w").store
             root = zarr.group(store=store)
             # no compressor options, we are checking default
-            write_multiscale([arr], group=root, axes='tzyx')
+            write_multiscale([arr], group=root, axes="tzyx")
             # check chunk: multiscale level 0, 4D chunk at (0, 0, 0, 0)
-            chunk_size = (pathlib.Path(path) / '0/0/0/0/0').stat().st_size
+            chunk_size = (pathlib.Path(path) / "0/0/0/0/0").stat().st_size
             assert chunk_size < 4e6
 
     def test_validate_coordinate_transforms(self):


### PR DESCRIPTION
Fixes #250 

Notes:
- I couldn't get pre-commit to work on my machine — some Poetry error? — so apologies if there's some formatting issues, will fix
- The tests will fail if zarr ever changes its defaults to no compression, but that seems like a small risk.