### PR TITLE
Read tables using anndata._io.read_zarr for local data

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = dask,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
+known_third_party = anndata,dask,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ def read(fname):
 
 
 install_requires: List[List[str]] = []
+install_requires += (["anndata"],)
 install_requires += (["dataclasses;python_version<'3.7'"],)
 install_requires += (["tifffile<2020.09.22;python_version<'3.7'"],)
 install_requires += (["numpy"],)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 
 install_requires: List[List[str]] = []
-install_requires += (["anndata"],)
+install_requires += (["anndata==0.9.0.rc1"],)
 install_requires += (["dataclasses;python_version<'3.7'"],)
 install_requires += (["tifffile<2020.09.22;python_version<'3.7'"],)
 install_requires += (["numpy"],)


### PR DESCRIPTION
This creates a Node for each table listed under `image.zarr/tables/.zattrs` and adds a `node.table` AnnData object to the node. The `node.metadata` dict is populated with the `image.zarr/tables/my_table/.zattrs` data.

These tables can be used by e.g. `napari-ome-zarr` as needed to read "regions" or "tracking" data etc.

We read remote anndata using `anndata.experimental` methods so the anndata requirement is pinned to an exact version.
