### PR TITLE
Optimize zarr multiscale writing based on #237

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = dask,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
+known_third_party = dask,distributed,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = dask,distributed,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
+known_third_party = dask,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -531,7 +531,6 @@ def _write_dask_image(
     compute: Optional[bool] = True,
     **metadata: Union[str, JSONDict, List[JSONDict]],
 ) -> List:
-
     if fmt.version in ("0.1", "0.2"):
         # v0.1 and v0.2 are strictly 5D
         shape_5d: Tuple[Any, ...] = (*(1,) * (5 - image.ndim), *image.shape)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -223,6 +223,10 @@ def write_multiscale(
     :param compute:
         If true compute immediately otherwise a list of :class:`dask.delayed.Delayed`
         is returned.
+    :return:
+        Empty list if the compute flag is True, otherwise it returns a list of
+        :class:`dask.delayed.Delayed` representing the value to be computed by
+        dask.
     """
     dims = len(pyramid[0].shape)
     axes = _get_valid_axes(dims, axes, fmt)
@@ -467,6 +471,10 @@ def write_image(
     :param compute:
         If true compute immediately otherwise a list of :class:`dask.delayed.Delayed`
         is returned.
+    :return:
+        Empty list if the compute flag is True, otherwise it returns a list of
+        :class:`dask.delayed.Delayed` representing the value to be computed by
+        dask.
     """
     dask_delayed_jobs = []
 
@@ -716,6 +724,10 @@ def write_multiscale_labels(
     :param compute:
         If true compute immediately otherwise a list of :class:`dask.delayed.Delayed`
         is returned.
+    :return:
+        Empty list if the compute flag is True, otherwise it returns a list of
+        :class:`dask.delayed.Delayed` representing the value to be computed by
+        dask.
     """
     sub_group = group.require_group(f"labels/{name}")
     dask_delayed_jobs = write_multiscale(
@@ -805,6 +817,10 @@ def write_labels(
     :param compute:
         If true compute immediately otherwise a list of :class:`dask.delayed.Delayed`
         is returned.
+    :return:
+        Empty list if the compute flag is True, otherwise it returns a list of
+        :class:`dask.delayed.Delayed` representing the value to be computed by
+        dask.
     """
     sub_group = group.require_group(f"labels/{name}")
     dask_delayed_jobs = []

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -590,6 +590,7 @@ Please use the 'storage_options' argument instead."""
     # Computing delayed jobs if necessary
     if compute:
         da.compute(*delayed)
+        delayed = []
 
     if coordinate_transformations is None:
         # shapes = [data.shape for data in delayed]

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires += (["dataclasses;python_version<'3.7'"],)
 install_requires += (["tifffile<2020.09.22;python_version<'3.7'"],)
 install_requires += (["numpy"],)
 install_requires += (["dask"],)
+install_requires += (["distributed"],)
 install_requires += (["zarr>=2.8.1"],)
 install_requires += (["fsspec[s3]!=2021.07.0"],)
 # See https://github.com/fsspec/filesystem_spec/issues/819

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 import zarr
 from dask import persist
-from distributed import wait
 from numcodecs import Blosc
 
 from ome_zarr.format import CurrentFormat, FormatV01, FormatV02, FormatV03, FormatV04
@@ -179,11 +178,12 @@ class TestWriter:
             compute=compute,
         )
 
+        assert not compute == len(dask_delayed_jobs)
+
         if not len(dask_delayed_jobs):
             # can be configured to use a Local or Slurm cluster
             # before persisting the jobs
             dask_delayed_jobs = persist(*dask_delayed_jobs)
-            wait(dask_delayed_jobs)
 
         reader = Reader(parse_url(f"{self.path}/test"))
         image_node = list(reader())[0]


### PR DESCRIPTION
Please, consider this PR as a possible solution to #237. It is more convenient to let the user decide how to compute the dask delayed objects. This is certainly useful/optimal when we are working with large image datasets. 