### PR TITLE
Don't handle exception in Multiscales init()

### DIFF
--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -104,7 +104,7 @@ def create_zarr(
     label_name: str = "coins",
     fmt: Format = CurrentFormat(),
     chunks: Union[Tuple, List] = None,
-) -> None:
+) -> zarr.Group:
     """Generate a synthetic image pyramid with labels."""
     pyramid, labels = method()
 
@@ -192,3 +192,5 @@ def create_zarr(
             "properties": properties,
             "source": {"image": "../../"},
         }
+
+    return grp

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -277,28 +277,24 @@ class Multiscales(Spec):
     def __init__(self, node: Node) -> None:
         super().__init__(node)
 
-        try:
-            multiscales = self.lookup("multiscales", [])
-            version = multiscales[0].get(
-                "version", "0.1"
-            )  # should this be matched with Format.version?
-            datasets = multiscales[0]["datasets"]
-            axes = multiscales[0].get("axes")
-            fmt = format_from_version(version)
-            # Raises ValueError if not valid
-            axes_obj = Axes(axes, fmt)
-            node.metadata["axes"] = axes_obj.to_list()
-            # This will get overwritten by 'omero' metadata if present
-            node.metadata["name"] = multiscales[0].get("name")
-            paths = [d["path"] for d in datasets]
-            self.datasets: List[str] = paths
-            transformations = [d.get("coordinateTransformations") for d in datasets]
-            if any(trans is not None for trans in transformations):
-                node.metadata["coordinateTransformations"] = transformations
-            LOGGER.info("datasets %s", datasets)
-        except Exception:
-            LOGGER.exception("Failed to parse multiscale metadata")
-            return  # EARLY EXIT
+        multiscales = self.lookup("multiscales", [])
+        version = multiscales[0].get(
+            "version", "0.1"
+        )  # should this be matched with Format.version?
+        datasets = multiscales[0]["datasets"]
+        axes = multiscales[0].get("axes")
+        fmt = format_from_version(version)
+        # Raises ValueError if not valid
+        axes_obj = Axes(axes, fmt)
+        node.metadata["axes"] = axes_obj.to_list()
+        # This will get overwritten by 'omero' metadata if present
+        node.metadata["name"] = multiscales[0].get("name")
+        paths = [d["path"] for d in datasets]
+        self.datasets: List[str] = paths
+        transformations = [d.get("coordinateTransformations") for d in datasets]
+        if any(trans is not None for trans in transformations):
+            node.metadata["coordinateTransformations"] = transformations
+        LOGGER.info("datasets %s", datasets)
 
         for resolution in self.datasets:
             data: da.core.Array = self.array(resolution, version)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -33,6 +33,24 @@ class TestReader:
         assert len(list(reader())) == 3
 
 
+class TestInvalid:
+    @pytest.fixture(autouse=True)
+    def initdir(self, tmpdir):
+        self.path = tmpdir.mkdir("data")
+
+    def test_invalid_version(self):
+        grp = create_zarr(str(self.path))
+        # update version to something invalid
+        attrs = grp.attrs.asdict()
+        attrs["multiscales"][0]["version"] = "invalid"
+        grp.attrs.put(attrs)
+        # should raise exception
+        with pytest.raises(ValueError) as exe:
+            reader = Reader(parse_url(str(self.path)))
+            assert len(list(reader())) == 2
+        assert str(exe.value) == "Version invalid not recognized"
+
+
 class TestHCSReader:
     @pytest.fixture(autouse=True)
     def initdir(self, tmpdir):


### PR DESCRIPTION
See #258.

This removes the exception handling that was obscuring useful errors there.

E.g. edit a sample zarr to an invalid version, e.g. `"version": 0.5` then try to open in `napari`:

```
$ napari --plugin napari-ome-zarr /path/to/image.zarr

Traceback (most recent call last):
  File "/Users/wmoore/opt/anaconda3/envs/SSBD/bin/napari", line 8, in <module>
    sys.exit(main())
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/napari/__main__.py", line 570, in main
    _run()
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/napari/__main__.py", line 344, in _run
    viewer._window._qt_viewer._qt_open(
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/napari/_qt/qt_viewer.py", line 867, in _qt_open
    self.viewer.open(
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/napari/components/viewer_model.py", line 1076, in open
    self._add_layers_with_plugins(
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/napari/components/viewer_model.py", line 1276, in _add_layers_with_plugins
    layer_data, hookimpl = read_data_with_plugins(
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/napari/plugins/io.py", line 77, in read_data_with_plugins
    res = _npe2.read(paths, plugin, stack=stack)
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/napari/plugins/_npe2.py", line 61, in read
    raise e from e
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/napari/plugins/_npe2.py", line 55, in read
    layer_data, reader = io_utils.read_get_reader(
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/npe2/io_utils.py", line 66, in read_get_reader
    return _read(
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/npe2/io_utils.py", line 163, in _read
    ld = read_func(paths, stack=stack)
  File "/Users/wmoore/opt/anaconda3/envs/ssbd/lib/python3.9/site-packages/npe2/manifest/contributions/_readers.py", line 60, in npe1_compat
    return callable_(path)  # type: ignore
  File "/Users/wmoore/Desktop/ZARR/napari-ome-zarr/napari_ome_zarr/_reader.py", line 108, in f
    for node in nodes:
  File "/Users/wmoore/Desktop/ZARR/ome-zarr-py/ome_zarr/reader.py", line 625, in __call__
    node = Node(self.zarr, self)
  File "/Users/wmoore/Desktop/ZARR/ome-zarr-py/ome_zarr/reader.py", line 53, in __init__
    self.specs.append(Multiscales(self))
  File "/Users/wmoore/Desktop/ZARR/ome-zarr-py/ome_zarr/reader.py", line 286, in __init__
    fmt = format_from_version(version)
  File "/Users/wmoore/Desktop/ZARR/ome-zarr-py/ome_zarr/format.py", line 22, in format_from_version
    raise ValueError(f"Version {version} not recognized")
ValueError: Version 0.5 not recognized
```