### PR TITLE
allow main with empty args

### DIFF
--- a/ome_zarr/cli.py
+++ b/ome_zarr/cli.py
@@ -2,7 +2,7 @@
 import argparse
 import logging
 import sys
-from typing import List
+from typing import List, Union
 
 from .csv import csv_to_zarr
 from .data import astronaut, coins, create_zarr
@@ -73,7 +73,7 @@ def csv_to_labels(args: argparse.Namespace) -> None:
     csv_to_zarr(args.csv_path, args.csv_id, args.csv_keys, args.zarr_path, args.zarr_id)
 
 
-def main(args: List[str]) -> None:
+def main(args: Union[List[str], None] = None) -> None:
     """Run appropriate function with argparse arguments, handling errors."""
     parser = argparse.ArgumentParser()
     parser.add_argument(


### PR DESCRIPTION
requiring arguments breaks being able to use `main` as a python entry point. (this also breaks conda recipe currently as conda build tests the entry point)

It seems arguments to `main` are ... a testing feature here? For testing one could also manipulate `sys.argv`...
