### PR TITLE
POC validation of NGFF with pydantic_ome_ngff

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = dask,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
+known_third_party = dask,numcodecs,numpy,pydantic_ome_ngff,pytest,scipy,setuptools,skimage,zarr
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -298,8 +298,9 @@ class Multiscales(Spec):
         LOGGER.info("datasets %s", datasets)
 
         for multi in multiscales:
-            # raises Exception if can't be parsed
-            Multiscale.parse_obj(multi)
+            # raises Exception if can't be parsed. Only v0.4 supported
+            if multi.get("version") == "0.4":
+                Multiscale.parse_obj(multi)
 
         for resolution in self.datasets:
             data: da.core.Array = self.array(resolution, version)

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterator, List, Optional, Type, Union, cast, overl
 import dask.array as da
 import numpy as np
 from dask import delayed
+from pydantic_ome_ngff.v04.multiscales import Multiscale
 
 from .axes import Axes
 from .format import format_from_version
@@ -295,6 +296,10 @@ class Multiscales(Spec):
         if any(trans is not None for trans in transformations):
             node.metadata["coordinateTransformations"] = transformations
         LOGGER.info("datasets %s", datasets)
+
+        for multi in multiscales:
+            # raises Exception if can't be parsed
+            Multiscale.parse_obj(multi)
 
         for resolution in self.datasets:
             data: da.core.Array = self.array(resolution, version)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ install_requires += (["aiohttp<4"],)
 install_requires += (["requests"],)
 install_requires += (["scikit-image"],)
 install_requires += (["toolz"],)
+install_requires += (["pydantic-ome-ngff"],)
 
 
 setup(


### PR DESCRIPTION
See #258.

This PR tests one possible approach for using https://github.com/JaneliaSciComp/pydantic-ome-ngff/ in `ome-zarr-py`:
 - Uses appropriate class to parse JSON data when reading NGFF data

However, this doesn't use `pydantic-ome-zarr` when *writing* data yet, as the integration there will likely have to be much closer