### PR TITLE
View in validator

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -21,6 +21,14 @@ Use the `ome_zarr` command to interrogate Zarr datasets::
     # Local data (after downloading as below)
     $ ome_zarr info 6001240.zarr/
 
+view
+====
+
+Use the `ome_zarr` command to view Zarr data in the https://ome.github.io/ome-ngff-validator::
+
+    # Local data (after downloading as below)
+    $ ome_zarr view 6001240.zarr/
+
 download
 ========
 

--- a/ome_zarr/cli.py
+++ b/ome_zarr/cli.py
@@ -9,6 +9,7 @@ from .data import astronaut, coins, create_zarr
 from .scale import Scaler
 from .utils import download as zarr_download
 from .utils import info as zarr_info
+from .utils import view as zarr_view
 
 
 def config_logging(loglevel: int, args: argparse.Namespace) -> None:
@@ -27,6 +28,12 @@ def info(args: argparse.Namespace) -> None:
     """Wrap the :func:`~ome_zarr.utils.info` method."""
     config_logging(logging.WARN, args)
     list(zarr_info(args.path, stats=args.stats))
+
+
+def view(args: argparse.Namespace) -> None:
+    """Wrap the :func:`~ome_zarr.utils.view` method."""
+    config_logging(logging.WARN, args)
+    zarr_view(args.path, args.port)
 
 
 def download(args: argparse.Namespace) -> None:
@@ -104,6 +111,12 @@ def main(args: Union[List[str], None] = None) -> None:
     parser_download.add_argument("path")
     parser_download.add_argument("--output", default=".")
     parser_download.set_defaults(func=download)
+
+    # view (in ome-ngff-validator in a browser)
+    parser_view = subparsers.add_parser("view")
+    parser_view.add_argument("path")
+    parser_view.add_argument("--port", type=int, default=8000)
+    parser_view.set_defaults(func=view)
 
     # create
     parser_create = subparsers.add_parser("create")

--- a/ome_zarr/utils.py
+++ b/ome_zarr/utils.py
@@ -2,6 +2,13 @@
 
 import json
 import logging
+import os
+import webbrowser
+from http.server import (  # type: ignore[attr-defined]
+    HTTPServer,
+    SimpleHTTPRequestHandler,
+    test,
+)
 from pathlib import Path
 from typing import Iterator, List
 
@@ -43,6 +50,35 @@ def info(path: str, stats: bool = False) -> Iterator[Node]:
             print(f"   - {array.shape}{minmax}")
         LOGGER.debug(node.data)
         yield node
+
+
+def view(input_path: str, port: int = 8000) -> None:
+    # serve the parent directory in a simple server with CORS. Open browser
+
+    parent_dir, image_name = os.path.split(input_path)
+    parent_dir = str(parent_dir)
+
+    class CORSRequestHandler(SimpleHTTPRequestHandler):
+        def end_headers(self) -> None:
+            self.send_header("Access-Control-Allow-Origin", "*")
+            SimpleHTTPRequestHandler.end_headers(self)
+
+        def translate_path(self, path: str) -> str:
+            # Since we don't call the class constructor ourselves,
+            # we set the directory here instead
+            self.directory = parent_dir
+            super_path = super().translate_path(path)
+            return super_path
+
+    # open ome-ngff-validator in a web browser...
+    url = (
+        f"https://ome.github.io/ome-ngff-validator/"
+        f"?source=http://localhost:{port}/{image_name}"
+    )
+    webbrowser.open(url)
+
+    # ...then start serving content
+    test(CORSRequestHandler, HTTPServer, port=port)
 
 
 def download(input_path: str, output_dir: str = ".") -> None:


### PR DESCRIPTION
I had another case where I pasted some python script to tell a user how to serve the local files so that they can be viewed in ome-ngff-validator etc. at https://github.com/ome/ome-zarr-py/issues/284

It occurred to me that I've done this a few times, so instead we should just ship the code.

This PR allows you to do:

```
$ ome_zarr view path/to/image.zarr
```

and it will serve that `path/to` directory with the correct CORS headers and open your browser at https://ome.github.io/ome-ngff-validator/?source=http://localhost:8000/image.zarr to view your data (and allow you to open it in vizarr etc).