### PR TITLE
Changes to scale.py and writer.py to support scaling methods.

### DIFF
--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -187,7 +187,7 @@ class Scaler:
                 base,
                 downscale=self.downscale,
                 max_layer=self.max_layer,
-                multichannel=False,
+                channel_axis=None,
             )
         )
 
@@ -198,7 +198,7 @@ class Scaler:
                 base,
                 downscale=self.downscale,
                 max_layer=self.max_layer,
-                multichannel=False,
+                channel_axis=None,
             )
         )
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -882,7 +882,7 @@ def _create_mip(
                 "Can't downsample if size of x or y dimension is 1. "
                 "Shape: %s" % (image.shape,)
             )
-        mip = scaler.nearest(image)
+        mip = getattr(scaler, scaler.method)(image)
     else:
         LOGGER.debug("disabling pyramid")
         mip = [image]


### PR DESCRIPTION
Based on this - https://github.com/scikit-image/scikit-image/issues/4294
multichannel=False nees to be changed to channel_axis=None on lines 190 & 201.

In writer.py line 885
mip = scaler.nearest(image)
should be
mip = getattr(scaler, scaler.method)(image)
(else it always calls the 'nearest' scale method).