### PR TITLE
Set minimum fsspec version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires += (["numpy"],)
 install_requires += (["dask"],)
 install_requires += (["distributed"],)
 install_requires += (["zarr>=2.8.1"],)
-install_requires += (["fsspec[s3]!=2021.07.0"],)
+install_requires += (["fsspec[s3]>=0.8,!=2021.07.0"],)
 # See https://github.com/fsspec/filesystem_spec/issues/819
 install_requires += (["aiohttp<4"],)
 install_requires += (["requests"],)


### PR DESCRIPTION
Peg dependency `fsspec`'s minimum version to `0.8.0` to address https://github.com/ome/ome-zarr-py/issues/294. 