### PR TITLE
Check Well exists before trying to load data

### DIFF
--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -537,6 +537,13 @@ class Plate(Spec):
         def get_tile(tile_name: str) -> np.ndarray:
             """tile_name is 'level,z,c,t,row,col'"""
             row, col = (int(n) for n in tile_name.split(","))
+
+            # check whether the Well exists at this row/column
+            well_path = f"{self.row_names[row]}/{self.col_names[col]}"
+            if well_path not in self.well_paths:
+                LOGGER.debug("empty well: %s", well_path)
+                return np.zeros(tile_shape, dtype=self.numpy_type)
+
             path = self.get_tile_path(level, row, col)
             LOGGER.debug("LOADING tile... %s with shape: %s", path, tile_shape)
 


### PR DESCRIPTION
Fixes #263.

For sparse Plates with empty Wells, we shouldn't try to load empty Wells.
Here, we check if the Well exists first - and return zeros.

To test, try to open a sparse plate in napari, e.g.

```
$ napari https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0072B/9512.zarr
```

Should see no errors in the terminal.
*Without* this PR you get lots of errors like this...
```
Traceback (most recent call last):
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/bin/napari", line 8, in <module>
    sys.exit(main())
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/site-packages/napari/__main__.py", line 551, in main
    _maybe_rerun_with_macos_fixes()
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/site-packages/napari/__main__.py", line 539, in _maybe_rerun_with_macos_fixes
    result = subprocess.run(cmd, env=env, cwd=cwd)
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/subprocess.py", line 507, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/subprocess.py", line 1126, in communicate
    self.wait()
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/subprocess.py", line 1189, in wait
    return self._wait(timeout=timeout)
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/subprocess.py", line 1917, in _wait
    (pid, sts) = self._try_wait(0)
  File "/Users/wmoore/opt/anaconda3/envs/omeroweb2/lib/python3.9/subprocess.py", line 1875, in _try_wait
    (pid, sts) = os.waitpid(self.pid, wait_flags)
KeyboardInterrupt
```