### PR TITLE
Fix compute() on plate grid

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -541,7 +541,8 @@ class Plate(Spec):
             LOGGER.debug("LOADING tile... %s with shape: %s", path, tile_shape)
 
             try:
-                data = self.zarr.load(path)
+                # compute() to get the data from dask - we want to return array
+                data = self.zarr.load(path).compute()
             except ValueError:
                 LOGGER.exception("Failed to load %s", path)
                 data = np.zeros(tile_shape, dtype=self.numpy_type)

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -422,13 +422,16 @@ class Well(Spec):
         def get_field(row: int, col: int, level: int) -> da.core.Array:
             """tile_name is 'row,col'"""
             field_index = (column_count * row) + col
-            image_path = image_paths[field_index]
-            path = f"{image_path}/{level}"
-            LOGGER.debug("LOADING tile... %s", path)
+            data = None
             try:
-                data = self.zarr.load(path)
+                # handle e.g. 2x2 grid with only 3 images/fields
+                if field_index < len(image_paths):
+                    image_path = image_paths[field_index]
+                    path = f"{image_path}/{level}"
+                    data = self.zarr.load(path)
             except ValueError:
                 LOGGER.error("Failed to load %s", path)
+            if data is None:
                 data = da.zeros(self.img_pyramid_shapes[level], dtype=self.numpy_type)
             return data
 


### PR DESCRIPTION
Fixes #297

This fixes the issue above: The `get_tile()` already returns a dask array so it doesn't need to be wrapped in `dask.delayed()`.

Test using the code sample on the ticket above.
