### PR TITLE
Avoid hard-coded field-of-view path "0"

### DIFF
--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -424,7 +424,8 @@ class Well(Spec):
             """tile_name is 'row,col'"""
             row, col = (int(n) for n in tile_name.split(","))
             field_index = (column_count * row) + col
-            path = f"{field_index}/{level}"
+            image_path = image_paths[field_index]
+            path = f"{image_path}/{level}"
             LOGGER.debug("LOADING tile... %s", path)
             try:
                 data = self.zarr.load(path)
@@ -486,7 +487,6 @@ class Plate(Spec):
         LOGGER.info("plate_data: %s", self.plate_data)
         self.rows = self.plate_data.get("rows")
         self.columns = self.plate_data.get("columns")
-        self.first_field = "0"
         self.row_names = [row["name"] for row in self.rows]
         self.col_names = [col["name"] for col in self.columns]
 
@@ -502,6 +502,7 @@ class Plate(Spec):
         well_spec: Optional[Well] = well_node.first(Well)
         if well_spec is None:
             raise Exception("Could not find first well")
+        self.first_field = well_spec.well_data["images"][0]["path"]
         self.numpy_type = well_spec.numpy_type
 
         LOGGER.debug("img_pyramid_shapes: %s", well_spec.img_pyramid_shapes)

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -502,7 +502,7 @@ class Plate(Spec):
         well_spec: Optional[Well] = well_node.first(Well)
         if well_spec is None:
             raise Exception("Could not find first well")
-        self.first_field = well_spec.well_data["images"][0]["path"]
+        self.first_field_path = well_spec.well_data["images"][0]["path"]
         self.numpy_type = well_spec.numpy_type
 
         LOGGER.debug("img_pyramid_shapes: %s", well_spec.img_pyramid_shapes)
@@ -529,7 +529,7 @@ class Plate(Spec):
     def get_tile_path(self, level: int, row: int, col: int) -> str:
         return (
             f"{self.row_names[row]}/"
-            f"{self.col_names[col]}/{self.first_field}/{level}"
+            f"{self.col_names[col]}/{self.first_field_path}/{level}"
         )
 
     def get_stitched_grid(self, level: int, tile_shape: tuple) -> da.core.Array:
@@ -569,7 +569,7 @@ class PlateLabels(Plate):
         """251.zarr/A/1/0/labels/0/3/"""
         path = (
             f"{self.row_names[row]}/{self.col_names[col]}/"
-            f"{self.first_field}/labels/0/{level}"
+            f"{self.first_field_path}/labels/0/{level}"
         )
         return path
 
@@ -591,7 +591,7 @@ class PlateLabels(Plate):
         properties: Dict[int, Dict[str, Any]] = {}
         for row in self.row_names:
             for col in self.col_names:
-                path = f"{row}/{col}/{self.first_field}/labels/0/.zattrs"
+                path = f"{row}/{col}/{self.first_field_path}/labels/0/.zattrs"
                 labels_json = self.zarr.get_json(path).get("image-label", {})
                 # NB: assume that 'label_val' is unique across all images
                 props_list = labels_json.get("properties", [])


### PR DESCRIPTION
Fixes https://github.com/ome/ome-zarr-py/issues/248

The current code assumes image paths under a well always match field of view indices, especially that "0" exists. However, the NGFF spec allows alphanumeric paths.

This change looks up the actual image path from the first well. This should not have a performance impact since the first well's `.zattrs` is read anyways. It is still assumed all wells have the same first image path (which the previous code did as well). In that case, an array of zeros is read (as previously).