### PR TITLE
Add sphinx_rtd_theme to docs dependencies

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx_rtd_theme",
 ]
 
 # use index.rst instead of contents.rst

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==5.3.0
+sphinx_rtd_theme==1.1.1


### PR DESCRIPTION
Try to fix sphinx readthedocs build - similar to:
https://github.com/ome/omero-scripts/commit/07e130dda4e9b58de423a0d0c48be8dd40190e6d
