### PR TITLE
Exclude fsspec 2023.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires += (["numpy"],)
 install_requires += (["dask"],)
 install_requires += (["distributed"],)
 install_requires += (["zarr>=2.8.1"],)
-install_requires += (["fsspec[s3]>=0.8,!=2021.07.0"],)
+install_requires += (["fsspec[s3]>=0.8,!=2021.07.0,!=2023.09.0"],)
 # See https://github.com/fsspec/filesystem_spec/issues/819
 install_requires += (["aiohttp<4"],)
 install_requires += (["requests"],)


### PR DESCRIPTION
In https://github.com/ome/ome-zarr-py/pull/301/files we needed to avoid the latest fsspec version `fsspec 2023.9.0` due to avoid https://github.com/fsspec/filesystem_spec/issues/1357 (also reported at https://github.com/ome/ome-zarr-py/issues/304).

The fix at https://github.com/fsspec/filesystem_spec/pull/1358 is merged and should be included in the next fsspec release so we only need to exclude the current release version.

This makes the corresponding change to setup.py