### PR TITLE
Add conda to installation options

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -20,6 +20,9 @@ Install the latest release of `ome-zarr`_ from PyPI::
 
     pip install ome-zarr
 
+or from conda-forge::
+
+    conda install -c conda-forge ome-zarr
 
 Installation for developers::
 


### PR DESCRIPTION
Since `ome-zarr` is available on conda-forge, I thought it would be good to list that option in the installation instructions.