### PR TITLE
Add dask to intersphinx mapping

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,9 +25,10 @@ author = "Open Microscopy Environment"
 # use in refs e.g:
 # :ref:`comparison manual <python:comparisons>`
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/", None),
+    "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "zarr": ("https://zarr.readthedocs.io/en/stable/", None),
+    "dask": ("https://docs.dask.org/en/stable", None),
 }
 
 # https://github.com/readthedocs/sphinx_rtd_theme


### PR DESCRIPTION
Since there's some dask references (e.g. on https://ome-zarr.readthedocs.io/en/stable/api/writer.html#ome_zarr.writer.write_image), I've added dask to the intersphinx mapping.

I also updated the Python link, which was showing up as a redirect before.