### PR TITLE
Minor improvements to format docs

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -45,6 +45,9 @@ def detect_format(metadata: dict, default: "Format") -> "Format":
 
 
 class Format(ABC):
+    """
+    Abstract base class for format implementations.
+    """
     @property
     @abstractmethod
     def version(self) -> str:  # pragma: no cover
@@ -275,8 +278,9 @@ class FormatV04(FormatV03):
         """
         Validates that a list of dicts contains a 'scale' transformation
 
-        Raises ValueError if no 'scale' found or doesn't match ndim
-        :param ndim:       Number of image dimensions
+        Raises ValueError if no 'scale' found or doesn't match ndim.
+
+        :param ndim: Number of image dimensions.
         """
 
         if coordinate_transformations is None:

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -48,6 +48,7 @@ class Format(ABC):
     """
     Abstract base class for format implementations.
     """
+
     @property
     @abstractmethod
     def version(self) -> str:  # pragma: no cover


### PR DESCRIPTION
- Add a short docstring to `Format` explaining it's a base class.
- Fix formatting in `validate_coordinate_transformations`