### PR TITLE
fix reading HCS datasets at cloud paths https://github.com/ome/ome-zarr-py/issues/321

### DIFF
--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -169,11 +169,16 @@ class ZarrLocation:
             filename = Path(self.__path) / subpath
             filename = filename.resolve()
             return str(filename)
-        else:
+        if self.__store.fs.protocol in ["http", "https"]:
             url = str(self.__path)
             if not url.endswith("/"):
                 url = f"{url}/"
             return urljoin(url, subpath)
+        else:
+            if self.__path.endswith("/"):
+                return f"{self.__path}{subpath}"
+            else:
+                return f"{self.__path}/{subpath}"
 
 
 def parse_url(


### PR DESCRIPTION
Solves being unable to load HCS datasets on S3, GCP, or Azure, see this issue: https://github.com/ome/ome-zarr-py/issues/321.