### PR TITLE
Only install required deps when testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,7 @@ jobs:
 
       - name: Install & test
         run: |
-          python -m pip install -U pip setuptools wheel pytest
-          python -m pip install -r requirements/requirements-dev.txt
+          python -m pip install tox
           tox -e ${{ matrix.toxenv }}
 
   test_coverage:


### PR DESCRIPTION
Since tox creates a new environment and installs dependencies there, no need to install all the dependencies beforehand.