### PR TITLE
Unpin fsspec in dev requirements

### DIFF
--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -165,7 +165,10 @@ class ZarrLocation:
             return self.__path.split("/")
 
     def subpath(self, subpath: str = "") -> str:
-        if self.__store.fs.protocol == "file":
+        if self.__store.fs.protocol == "file" or self.__store.fs.protocol == (
+            "file",
+            "local",
+        ):
             filename = Path(self.__path) / subpath
             filename = filename.resolve()
             return str(filename)

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -159,29 +159,44 @@ class ZarrLocation:
             return {}
 
     def parts(self) -> List[str]:
-        if self.__store.fs.protocol == "file":
+        if self._isfile():
             return list(Path(self.__path).parts)
         else:
             return self.__path.split("/")
 
     def subpath(self, subpath: str = "") -> str:
-        if self.__store.fs.protocol == "file" or self.__store.fs.protocol == (
-            "file",
-            "local",
-        ):
+        if self._isfile():
             filename = Path(self.__path) / subpath
             filename = filename.resolve()
             return str(filename)
-        if self.__store.fs.protocol in ["http", "https"]:
+        elif self._ishttp():
             url = str(self.__path)
             if not url.endswith("/"):
                 url = f"{url}/"
             return urljoin(url, subpath)
         else:
+            # Might require a warning
             if self.__path.endswith("/"):
                 return f"{self.__path}{subpath}"
             else:
                 return f"{self.__path}/{subpath}"
+
+    def _isfile(self) -> bool:
+        """
+        Return whether the current underlying implementation
+        points to a local file or not.
+        """
+        return self.__store.fs.protocol == "file" or self.__store.fs.protocol == (
+            "file",
+            "local",
+        )
+
+    def _ishttp(self) -> bool:
+        """
+        Return whether the current underlying implementation
+        points to a URL
+        """
+        return self.__store.fs.protocol in ["http", "https"]
 
 
 def parse_url(

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,4 +1,4 @@
-fsspec==2023.6.0
+fsspec
 black
 cython >= 0.29.16
 numpy >= 1.16.0


### PR DESCRIPTION
In https://github.com/ome/ome-zarr-py/pull/338 I noticed that `fsspec` has been (accidentally??) pinned in the tests. Opening this PR to demonstrate that when it's unpinned the tests fail, indicating incompatibility with more recent versions of `fsspec`.