### PR TITLE
Support init of ome_zarr_py.io.ZarrLocation with zarr.storage.FSStore

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = dask,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
+known_third_party = dask,fsspec,numcodecs,numpy,pytest,scipy,setuptools,skimage,zarr
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -28,12 +28,14 @@ class ZarrLocation:
     """
 
     def __init__(
-        self, path: Union[Path, str, FSStore], mode: str = "r", fmt: Format = CurrentFormat()
+        self,
+        path: Union[Path, str, FSStore],
+        mode: str = "r",
+        fmt: Format = CurrentFormat(),
     ) -> None:
         LOGGER.debug("ZarrLocation.__init__ path: %s, fmt: %s", path, fmt.version)
         self.__fmt = fmt
         self.__mode = mode
-        self.__store = None
         if isinstance(path, Path):
             self.__path = str(path.resolve())
         elif isinstance(path, str):
@@ -47,7 +49,7 @@ class ZarrLocation:
         loader = fmt
         if loader is None:
             loader = CurrentFormat()
-        if self.__store is None:
+        if not (hasattr(self, "__store") and self.__store):
             self.__store = loader.init_store(self.__path, mode)
 
         self.__init_metadata()
@@ -58,8 +60,8 @@ class ZarrLocation:
                 "version mismatch: detected: %s, requested: %s", detected, fmt
             )
             self.__fmt = detected
-            if self.__store is None:
-                self.__store = detected.init_store(self.__path, mode)
+            if not (hasattr(self, "__store") and self.__store):
+                self.__store = loader.init_store(self.__path, mode)
             self.__init_metadata()
 
     def __init_metadata(self) -> None:

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -42,15 +42,15 @@ class ZarrLocation:
             self.__path = path
         elif isinstance(path, FSStore):
             self.__path = path.path
-            self.__store = path
         else:
             raise TypeError(f"not expecting: {type(path)}")
 
         loader = fmt
         if loader is None:
             loader = CurrentFormat()
-        if not (hasattr(self, "__store") and self.__store):
-            self.__store = loader.init_store(self.__path, mode)
+        self.__store: FSStore = (
+            path if isinstance(path, FSStore) else loader.init_store(self.__path, mode)
+        )
 
         self.__init_metadata()
         detected = detect_format(self.__metadata, loader)
@@ -60,8 +60,7 @@ class ZarrLocation:
                 "version mismatch: detected: %s, requested: %s", detected, fmt
             )
             self.__fmt = detected
-            if not (hasattr(self, "__store") and self.__store):
-                self.__store = loader.init_store(self.__path, mode)
+            self.__store = detected.init_store(self.__path, mode)
             self.__init_metadata()
 
     def __init_metadata(self) -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,10 +1,12 @@
+from pathlib import Path
+
+import fsspec
 import pytest
 import zarr
-from pathlib import Path
-import fsspec
 
 from ome_zarr.data import create_zarr
 from ome_zarr.io import ZarrLocation, parse_url
+
 
 class TestIO:
     @pytest.fixture(autouse=True)
@@ -31,6 +33,6 @@ class TestIO:
 
     def test_loc_fs(self):
         fs = fsspec.filesystem("memory")
-        fsstore = zarr.storage.FSStore(url='/', fs=fs)
+        fsstore = zarr.storage.FSStore(url="/", fs=fs)
         loc = ZarrLocation(fsstore)
         assert loc

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,36 @@
+import pytest
+import zarr
+from pathlib import Path
+import fsspec
+
+from ome_zarr.data import create_zarr
+from ome_zarr.io import ZarrLocation, parse_url
+
+class TestIO:
+    @pytest.fixture(autouse=True)
+    def initdir(self, tmpdir):
+        self.path = tmpdir.mkdir("data")
+        create_zarr(str(self.path))
+        self.store = parse_url(str(self.path), mode="w").store
+        self.root = zarr.group(store=self.store)
+
+    def test_parse_url(self):
+        assert parse_url(str(self.path))
+
+    def test_parse_nonexistent_url(self):
+        assert parse_url(self.path + "/does-not-exist") is None
+
+    def test_loc_str(self):
+        assert ZarrLocation(str(self.path))
+
+    def test_loc_path(self):
+        assert ZarrLocation(Path(self.path))
+
+    def test_loc_store(self):
+        assert ZarrLocation(self.store)
+
+    def test_loc_fs(self):
+        fs = fsspec.filesystem("memory")
+        fsstore = zarr.storage.FSStore(url='/', fs=fs)
+        loc = ZarrLocation(fsstore)
+        assert loc


### PR DESCRIPTION
By supporting FSStore as input, more complex ZarrLocations are possible like private remote stores.