### PR TITLE
Allow to change downsample function

### DIFF
--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -77,9 +77,7 @@ class Scaler:
 
     def scale(self, input_array: str, output_directory: str) -> None:
         """Perform downsampling to disk."""
-        func = getattr(self, self.method, None)
-        if not func:
-            raise Exception
+        func = self.func
 
         store = self.__check_store(output_directory)
         base = zarr.open_array(input_array)
@@ -93,6 +91,14 @@ class Scaler:
         if self.copy_metadata:
             print(f"copying attribute keys: {list(base.attrs.keys())}")
             grp.attrs.update(base.attrs)
+
+    @property
+    def func(self) -> Callable[[np.ndarray, int, int], np.ndarray]:
+        """Get downsample function."""
+        func = getattr(self, self.method, None)
+        if not func:
+            raise Exception
+        return func
 
     def __check_store(self, output_directory: str) -> MutableMapping:
         """Return a Zarr store if it doesn't already exist."""

--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -93,7 +93,7 @@ class Scaler:
             grp.attrs.update(base.attrs)
 
     @property
-    def func(self) -> Callable[[np.ndarray, int, int], np.ndarray]:
+    def func(self) -> Callable[[np.ndarray], List[np.ndarray]]:
         """Get downsample function."""
         func = getattr(self, self.method, None)
         if not func:

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -906,7 +906,7 @@ def _create_mip(
                 "Can't downsample if size of x or y dimension is 1. "
                 "Shape: %s" % (image.shape,)
             )
-        mip = scaler.nearest(image)
+        mip = scaler.func(image)
     else:
         LOGGER.debug("disabling pyramid")
         mip = [image]

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -72,7 +72,7 @@ class TestScaler:
         downscaled = scaler.laplacian(data)
         self.check_downscaled(downscaled, shape)
 
-    def test_nearest(self, shape):
+    def test_local_mean(self, shape):
         data = self.create_data(shape)
         scaler = Scaler()
         downscaled = scaler.local_mean(data)

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -15,10 +15,14 @@ class TestScaler:
             [(256, 256), True],
             [(256, 256), False],
         ),
-        ids=["5D-directly", "5D-indirectly",
-             "3D-directly", "3D-indirectly",
-             "2D-directly", "2D-indirectly"
-            ],
+        ids=[
+            "5D-directly",
+            "5D-indirectly",
+            "3D-directly",
+            "3D-indirectly",
+            "2D-directly",
+            "2D-indirectly",
+        ],
     )
     def test_case(self, request):
         return request.param

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -46,10 +46,15 @@ class TestScaler:
         downscaled = scaler.func(data)
         self.check_downscaled(downscaled, shape)
 
-        assert np.sum([
-            not np.array_equal(downscaled[i], expected_downscaled[i])
-            for i in range(len(downscaled))
-        ]) == 0
+        assert (
+            np.sum(
+                [
+                    not np.array_equal(downscaled[i], expected_downscaled[i])
+                    for i in range(len(downscaled))
+                ]
+            )
+            == 0
+        )
 
     # this fails because of wrong channel dimension; need to fix in follow-up PR
     @pytest.mark.xfail
@@ -83,10 +88,15 @@ class TestScaler:
         downscaled = scaler.func(data)
         self.check_downscaled(downscaled, shape)
 
-        assert np.sum([
-            not np.array_equal(downscaled[i], expected_downscaled[i])
-            for i in range(len(downscaled))
-        ]) == 0
+        assert (
+            np.sum(
+                [
+                    not np.array_equal(downscaled[i], expected_downscaled[i])
+                    for i in range(len(downscaled))
+                ]
+            )
+            == 0
+        )
 
     @pytest.mark.skip(reason="This test does not terminate")
     def test_zoom(self, shape):


### PR DESCRIPTION
- Define property ``func`` to get downsample function.
- Use ``scaler.func`` instead of ``scaler.nearest`` in function ``_create_mip``.