### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: ['windows-latest', 'macos-latest', 'ubuntu-latest']
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: windows-latest, python_Version: '3.9', toxenv: 'py39'}
-          - {os: macos-latest, python_Version: '3.8', toxenv: 'py38'}
+          - {os: windows-latest, python_Version: '3.11', toxenv: 'py311'}
+          - {os: macos-latest, python_Version: '3.10', toxenv: 'py310'}
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Drop support for Python 3.8.
+
 # 0.9.0 (May 2024)
 
 - Correctly specify maximum compatible fsspec version. ([#338](https://github.com/ome/ome-zarr-py/pull/338))

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     long_description=read("README.rst"),
     packages=["ome_zarr"],
     py_modules=["ome_zarr"],
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     install_requires=install_requires,
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{38,39,310,311,312}
+envlist = py{39,310,311,312}
 
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
As per [SPEC 0](https://scientific-python.org/specs/spec-0000/), don't need to support Python 3.8 or 3.9 any more. As per a comment below, I've only dropped support for 3.8 here.