### PR TITLE
Zarr v3 support

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -4,11 +4,9 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterator, List, Optional
 
-from zarr.v2.storage import FSStore
-
-from zarr.store import LocalStore, RemoteStore
-from zarr.store import StoreLike, StorePath
 from zarr.abc.store import Store
+from zarr.store import LocalStore, RemoteStore, StoreLike, StorePath
+from zarr.v2.storage import FSStore
 
 LOGGER = logging.getLogger("ome_zarr.format")
 
@@ -200,7 +198,6 @@ class FormatV02(FormatV01):
 
     #     mkdir = True
 
-        
     #     if "r" in mode or path.startswith(("http", "s3")):
     #         # Could be simplified on the fsspec side
     #         mkdir = False
@@ -214,7 +211,7 @@ class FormatV02(FormatV01):
     #     )  # TODO: open issue for using Path
     #     LOGGER.debug("Created nested FSStore(%s, %s, %s)", path, mode, kwargs)
     #     return store
-    
+
     def init_store(self, path: str, mode: str = "r") -> Store:
         """
         Returns a Zarr v3 PathStore
@@ -231,7 +228,9 @@ class FormatV02(FormatV01):
             mode=mode,
             **kwargs,
         )  # TODO: open issue for using Path
-        print("Created %s store %s(%s, %s, %s)" % (self.version, cls, path, mode, kwargs))
+        print(
+            "Created {} store {}({}, {}, {})".format(self.version, cls, path, mode, kwargs)
+        )
         return store
 
 
@@ -389,7 +388,7 @@ class FormatV05(FormatV04):
         version = self._get_metadata_version(metadata)
         LOGGER.debug("%s matches %s?", self.version, version)
         return version == self.version_key
-    
+
     def _get_metadata_version(self, metadata: dict) -> Optional[str]:
         """
         For version 0.5+ we use the NGFF_URL_0_5 key

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterator, List, Optional
 
-from zarr.storage import FSStore
+from zarr.v2.storage import FSStore
 
 LOGGER = logging.getLogger("ome_zarr.format")
 
@@ -342,4 +342,35 @@ class FormatV04(FormatV03):
                         )
 
 
-CurrentFormat = FormatV04
+class FormatV05(FormatV04):
+    """
+    Changelog: move to Zarr v3 (June 2024)
+    """
+
+    @property
+    def version(self) -> str:
+        return "0.5"
+
+    def init_store(self, path: str, mode: str = "r") -> FSStore:
+        """
+        Returns a Zarr v3 PathStore
+        """
+
+        from zarr.store import LocalStore, RemoteStore
+
+        cls = LocalStore
+        kwargs = {}
+        
+        if path.startswith(("http", "s3")):
+            cls = RemoteStore
+
+        store = cls(
+            path,
+            mode=mode,
+            **kwargs,
+        )  # TODO: open issue for using Path
+        LOGGER.debug("Created v0.5 store %s(%s, %s, %s)", cls, path, mode, kwargs)
+        return store
+    
+
+CurrentFormat = FormatV05

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -360,7 +360,7 @@ class FormatV05(FormatV04):
 
         cls = LocalStore
         kwargs = {}
-        
+
         if path.startswith(("http", "s3")):
             cls = RemoteStore
 
@@ -369,8 +369,8 @@ class FormatV05(FormatV04):
             mode=mode,
             **kwargs,
         )  # TODO: open issue for using Path
-        LOGGER.debug("Created v0.5 store %s(%s, %s, %s)", cls, path, mode, kwargs)
+        print("Created v0.5 store %s(%s, %s, %s)" % (cls, path, mode, kwargs))
         return store
-    
+
 
 CurrentFormat = FormatV05

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -229,7 +229,9 @@ class FormatV02(FormatV01):
             **kwargs,
         )  # TODO: open issue for using Path
         print(
-            "Created {} store {}({}, {}, {})".format(self.version, cls, path, mode, kwargs)
+            "Created {} store {}({}, {}, {})".format(
+                self.version, cls, path, mode, kwargs
+            )
         )
         return store
 

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -351,6 +351,10 @@ class FormatV05(FormatV04):
     def version(self) -> str:
         return "0.5"
 
+    @property
+    def version_key(self) -> str:
+        return "https://ngff.openmicroscopy.org/0.5"
+
     def init_store(self, path: str, mode: str = "r") -> FSStore:
         """
         Returns a Zarr v3 PathStore

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -71,7 +71,7 @@ class ZarrLocation:
         #         loader = CurrentFormat()
 
         self.__init_metadata()
-        print("init self.__metadata", self.__metadata)
+        print("ZarrLocation init self.__metadata", self.__metadata)
         detected = detect_format(self.__metadata, loader)
         LOGGER.debug("ZarrLocation.__init__ %s detected: %s", self.__path, detected)
         if detected != self.__fmt:
@@ -110,20 +110,18 @@ class ZarrLocation:
             # NB: zarr_format not supported in Group.open() or Array.open() yet
             # We want to use zarr_format=None to handle v2 or v3
             zarr_group = Group.open(self.__store)  #, zarr_format=None)
-            self.zgroup: JSONDict = zarr_group.metadata.to_dict()
+            self.zgroup = zarr_group.metadata.to_dict()
             self.__metadata = self.zgroup
         except FileNotFoundError:
             # group doesn't exist yet, try array
             try:
                 zarr_array = Array.open(self.__store)  #, zarr_format=None)
-                self.zarray: JSONDict = zarr_array.metadata.to_dict()
+                self.zarray = zarr_array.metadata.to_dict()
                 self.__metadata = self.zarray
             except (ValueError, KeyError, FileNotFoundError):
                 # exceptions raised may change here?
-                print("__init_metadata DOESN'T EXIST", self.__store)
                 self.__exists = False
                 
-        print("__init_metadat EXISTS?", self.__exists, self.__metadata)
         # self.zarray: JSONDict = await self.get_json(".zarray")
         # self.zgroup: JSONDict = await self.get_json(".zgroup")
         # v3_json = await self.get_json("zarr.json")

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Union
 from urllib.parse import urljoin
 
 import dask.array as da
-from zarr import Group, Array, open
+from zarr import Array, Group, open
 
 # from zarr.v2.storage import FSStore
 from zarr.abc.store import Store
@@ -75,9 +75,7 @@ class ZarrLocation:
         detected = detect_format(self.__metadata, loader)
         print("ZarrLocation.__init__ %s detected: %s", self.__path, detected)
         if detected != self.__fmt:
-            print(
-                "version mismatch: detected: %s, requested: %s", detected, self.__fmt
-            )
+            print("version mismatch: detected: %s, requested: %s", detected, self.__fmt)
             self.__fmt = detected
             self.__store = detected.init_store(self.__path, self.__mode)
             self.__init_metadata()
@@ -112,7 +110,7 @@ class ZarrLocation:
             print("ZarrLocation __init_metadata: TRY to open group...")
             # zarr_group = Group.open(self.__store)  #, zarr_format=None)
 
-            # NB: If the store is writable, open() will fail IF location doesn't exist because 
+            # NB: If the store is writable, open() will fail IF location doesn't exist because
             # zarr v3 will try to create an Array (instead of looking instead for a Group)
             # and fails because 'shape' is not provided - see TypeError below.
             # NB: we need zarr_format here to open V2 groups
@@ -134,7 +132,7 @@ class ZarrLocation:
         except TypeError:
             # open() tried to open_array() but we didn't supply 'shape' argument
             self.__exists = False
-                
+
         # self.zarray: JSONDict = await self.get_json(".zarray")
         # self.zgroup: JSONDict = await self.get_json(".zgroup")
         # v3_json = await self.get_json("zarr.json")
@@ -189,6 +187,7 @@ class ZarrLocation:
         """Use dask.array.from_zarr to load the subpath."""
         # return da.from_zarr(self.__store, subpath)
         from zarr import load
+
         # returns zarr Array (no chunks) instead of Dask
         return load(store=self.__store, path=subpath)
 
@@ -229,9 +228,9 @@ class ZarrLocation:
         All other exceptions log at the ERROR level.
         """
         try:
-            print('get_json', subpath)
+            print("get_json", subpath)
             data = await self.__store.get(subpath)
-            print('data', data)
+            print("data", data)
 
             if not data:
                 return {}

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -9,7 +9,7 @@ import dask.array as da
 import numpy as np
 
 from .axes import Axes
-from .format import format_from_version, NGFF_URL_0_5
+from .format import NGFF_URL_0_5, format_from_version
 from .io import ZarrLocation
 from .types import JSONDict
 
@@ -179,7 +179,11 @@ class Spec(ABC):
 
         # Handle zarr V3 where everything is under "attributes"
         if NGFF_URL_0_5 in self.zarr.root_attrs.get("attributes", {}):
-            return self.zarr.root_attrs.get("attributes", {}).get(NGFF_URL_0_5, {}).get(key, default)
+            return (
+                self.zarr.root_attrs.get("attributes", {})
+                .get(NGFF_URL_0_5, {})
+                .get(key, default)
+            )
 
         return self.zarr.root_attrs.get(key, default)
 
@@ -281,7 +285,9 @@ class Multiscales(Spec):
         if zarr.zgroup:
             if "multiscales" in zarr.root_attrs:
                 return True
-            if "multiscales" in (zarr.root_attrs.get("attributes", {}).get(NGFF_URL_0_5, {})):
+            if "multiscales" in (
+                zarr.root_attrs.get("attributes", {}).get(NGFF_URL_0_5, {})
+            ):
                 return True
         return False
 
@@ -331,7 +337,9 @@ class Multiscales(Spec):
         # e.g. 6001240.zarr/labels/0/labels doesn't exist
         # BUT calling this with zarr v3 fails since
         child_zarr = self.zarr.create("labels")
-        print("Multiscales child_zarr 'labels' exists??", child_zarr, child_zarr.exists())
+        print(
+            "Multiscales child_zarr 'labels' exists??", child_zarr, child_zarr.exists()
+        )
         if child_zarr.exists():
             node.add(child_zarr, visibility=False)
         print("Multiscales __init__ END")

--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -123,7 +123,7 @@ class Scaler:
 
     def __create_group(
         self, store: MutableMapping, base: np.ndarray, pyramid: List[np.ndarray]
-    ) -> zarr.hierarchy.Group:
+    ) -> zarr.Group:
         """Create group and datasets."""
         grp = zarr.group(store)
         grp.create_dataset("base", data=base)

--- a/ome_zarr/utils.py
+++ b/ome_zarr/utils.py
@@ -72,7 +72,7 @@ def view(input_path: str, port: int = 8000) -> None:
 
     # open ome-ngff-validator in a web browser...
     url = (
-        f"https://ome.github.io/ome-ngff-validator/"
+        f"https://deploy-preview-36--ome-ngff-validator.netlify.app/"
         f"?source=http://localhost:{port}/{image_name}"
     )
     webbrowser.open(url)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -353,11 +353,12 @@ def write_multiscales_metadata(
     # note: we construct the multiscale metadata via dict(), rather than {}
     # to avoid duplication of protected keys like 'version' in **metadata
     # (for {} this would silently over-write it, with dict() it explicitly fails)
+    print("group.store_path", group.store_path)
     multiscales = [
         dict(
             version=fmt.version,
             datasets=_validate_datasets(datasets, ndim, fmt),
-            name=name if name else group.name,
+            name=name if name else str(group.store_path.store.root),
             **metadata,
         )
     ]

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -265,7 +265,13 @@ Please use the 'storage_options' argument instead."""
 
         else:
             # We create the array and write data to it immediately...
-            a = group.create_array(str(path), chunks=chunks_opt, shape=data.shape, dtype=data.dtype, **options)
+            a = group.create_array(
+                str(path),
+                chunks=chunks_opt,
+                shape=data.shape,
+                dtype=data.dtype,
+                **options,
+            )
             # These 2 lines are equivalent to e.g. a[:,:] = data (for any number of dimensions)
             s = [np.s_[:]] * len(data.shape)
             a[tuple(s)] = data

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -264,7 +264,7 @@ Please use the 'storage_options' argument instead."""
                 dask_delayed.append(da_delayed)
 
         else:
-            group.create_dataset(str(path), data=data, chunks=chunks_opt, **options)
+            group.create_array(str(path), data=data, chunks=chunks_opt, **options)
 
         datasets.append({"path": str(path)})
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -365,7 +365,10 @@ def write_multiscales_metadata(
     if axes is not None:
         multiscales[0]["axes"] = axes
 
-    group.attrs["multiscales"] = multiscales
+    if hasattr(fmt, "version_key"):
+        group.attrs[fmt.version_key] = {"multiscales": multiscales}
+    else:
+        group.attrs["multiscales"] = multiscales
 
 
 def write_plate_metadata(

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -264,7 +264,11 @@ Please use the 'storage_options' argument instead."""
                 dask_delayed.append(da_delayed)
 
         else:
-            group.create_array(str(path), data=data, chunks=chunks_opt, **options)
+            # We create the array and write data to it immediately...
+            a = group.create_array(str(path), chunks=chunks_opt, shape=data.shape, dtype=data.dtype, **options)
+            # These 2 lines are equivalent to e.g. a[:,:] = data (for any number of dimensions)
+            s = [np.s_[:]] * len(data.shape)
+            a[tuple(s)] = data
 
         datasets.append({"path": str(path)})
 


### PR DESCRIPTION
Work in progress (not intended to merge - just playing)...

Trying to get familiar with the current Zarr v3 development code by seeing if I could use it for the simple example we have in the docs.
That sample needed updating - currently it looks like this:

```
import numpy as np
import zarr
import os

from ome_zarr.io import parse_url
from ome_zarr.writer import write_image
import asyncio

async def run():
    path = "test_ngff_image.zarr"
    # os.mkdir(path)

    size_xy = 128
    size_z = 10
    rng = np.random.default_rng(0)
    data = rng.poisson(lam=10, size=(size_z, size_xy, size_xy)).astype(np.uint8)

    # write the image data
    zarr_location = await parse_url(path, mode="w")
    store = zarr_location.store
    root = zarr.Group.create(store=store)
    write_image(image=data, group=root, axes="zyx", storage_options=dict(chunks=(1, size_xy, size_xy)))

asyncio.run(run())
```

 - I added a `FormatV05` class which creates Zarr v3 Stores (this will cause issues since the `init_store()` method returns different objects from the superclasses which return FSStore
 - However, the main blocker I ran into is the usage of `async` methods to load json etc. `ZarrLocation.__init_metadata()` loads json. This is called during `ZarrLocation.__init__` but you can't add `async` designation to constructors, so we need to move that do a separate method `init_meta()` that is called immediately after creation.
 - Also, the `parse_url()` is now async, so we can't call it in a script without wrapping with e.g. `asyncio.run(run())` above.
 - Current issue is that `zarr.json and chunk dirs are getting created in the current directory, not within a `test_ngff_image.zarr` group as intended....


cc @joshmoore @normanrz 