### PR TITLE
Pin numpy<2 in setup.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,3 @@ jobs:
         with:
           file: ./coverage.xml
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./coverage.xml
           fail_ci_if_error: true

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(fname):
 install_requires: List[List[str]] = []
 install_requires += (["dataclasses;python_version<'3.7'"],)
 install_requires += (["tifffile<2020.09.22;python_version<'3.7'"],)
-install_requires += (["numpy"],)
+install_requires += (["numpy<2"],)
 install_requires += (["dask"],)
 install_requires += (["distributed"],)
 install_requires += (["zarr>=2.8.1"],)


### PR DESCRIPTION
numpy 2.0.0 has been released with breaking changes. Avoid installing till this can be reviewed etc.
Same as https://github.com/ome/omero-py/pull/414

cc @sbesson 