### PR TITLE
Write metadata using delayed that depends on writing array(s)

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -7,6 +7,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import dask
 import dask.array as da
 import numpy as np
 import zarr
@@ -629,8 +630,10 @@ Please use the 'storage_options' argument instead."""
     if coordinate_transformations is not None:
         for dataset, transform in zip(datasets, coordinate_transformations):
             dataset["coordinateTransformations"] = transform
-
-    write_multiscales_metadata(group, datasets, fmt, axes, name, **metadata)
+    if not compute:
+        delayed.append(dask.delayed(write_multiscales_metadata)(group, datasets, fmt, axes, name, **metadata))
+    else:
+        write_multiscales_metadata(group, datasets, fmt, axes, name, **metadata)
 
     return delayed
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -234,7 +234,6 @@ def write_multiscale(
         msg = """The 'chunks' argument is deprecated and will be removed in version 0.5.
 Please use the 'storage_options' argument instead."""
         warnings.warn(msg, DeprecationWarning)
-    is_dask = False
     datasets: List[dict] = []
     for path, data in enumerate(pyramid):
         options = _resolve_storage_options(storage_options, path)
@@ -249,7 +248,6 @@ Please use the 'storage_options' argument instead."""
             chunks_opt = _retuple(chunks_opt, data.shape)
 
         if isinstance(data, da.Array):
-            is_dask = True
             if chunks_opt is not None:
                 data = da.array(data).rechunk(chunks=chunks_opt)
                 options["chunks"] = chunks_opt
@@ -283,7 +281,7 @@ Please use the 'storage_options' argument instead."""
         for dataset, transform in zip(datasets, coordinate_transformations):
             dataset["coordinateTransformations"] = transform
 
-    if is_dask and not compute:
+    if len(dask_delayed) > 0 and not compute:
         write_multiscales_metadata_delayed = dask.delayed(write_multiscales_metadata)
         return dask_delayed + [
             bind(write_multiscales_metadata_delayed, dask_delayed)(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -180,7 +180,7 @@ class TestWriter:
 
         assert not compute == len(dask_delayed_jobs)
 
-        if not len(dask_delayed_jobs):
+        if not compute:
             # can be configured to use a Local or Slurm cluster
             # before persisting the jobs
             dask_delayed_jobs = persist(*dask_delayed_jobs)


### PR DESCRIPTION
If writing a dask array and `compute = False`, the image metadata will be written even if some of the array chunks are not written successfully. This ensures that metadata is written only after all chunks are stored. Thanks.