### PR TITLE
Enable numpy 2 (lift pin in setup.py)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(fname):
 install_requires: List[List[str]] = []
 install_requires += (["dataclasses;python_version<'3.7'"],)
 install_requires += (["tifffile<2020.09.22;python_version<'3.7'"],)
-install_requires += (["numpy<2"],)
+install_requires += (["numpy"],)
 install_requires += (["dask"],)
 install_requires += (["distributed"],)
 install_requires += (["zarr>=2.8.1"],)


### PR DESCRIPTION
- I tested with the ruff plugin: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ruff-plugin
```
> ruff check . --select NPY201
All checks passed!
```
- I ran tests locally with numpy 2 and all pass
- I checked dependencies and everything seems good:
https://github.com/numpy/numpy/issues/26191

I think everything should be good to go?