### PR TITLE
pin zarr at < 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires += (["tifffile<2020.09.22;python_version<'3.7'"],)
 install_requires += (["numpy"],)
 install_requires += (["dask"],)
 install_requires += (["distributed"],)
-install_requires += (["zarr>=2.8.1"],)
+install_requires += (["zarr>=2.8.1,<3"],)
 install_requires += (["fsspec[s3]>=0.8,!=2021.07.0"],)
 # See https://github.com/fsspec/filesystem_spec/issues/819
 install_requires += (["aiohttp<4"],)


### PR DESCRIPTION
Trying to fix build at https://github.com/ome/ome-zarr-py/actions/runs/12038548002 which failed because Zarr v3 somehow got installed.