### PR TITLE
Modify the configuration cf. rtd email

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,18 +15,8 @@ build:
     # rust: "1.55"
     # golang: "1.17"
 
+
+# Build documentation in the "docs/" directory with Sphinx
 sphinx:
   fail_on_warning: true
-
-# Build documentation in the docs/ directory with Sphinx
-# sphinx:
-#    configuration: docs/conf.py
-
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
-
-# Optionally declare the Python requirements required to build your docs
-python:
-  install:
-    - requirements: docs/requirements.txt
+  configuration: docs/requirements.txt


### PR DESCRIPTION
```
We are announcing the deprecation of projects using Sphinx or MkDocs without an explicit configuration in their .readthedocs.yaml file. After January 20, 2025, Read the Docs will require explicit configuration for all Sphinx and MkDocs projects.
```