### PR TITLE
Rtd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build
 dist/
 target/
 docs/build/
-
+*.DS_Store
 # Testing files
 .tox*
 .coverage*

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,17 +10,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-    # You can also specify other tool versions:
-    # nodejs: "16"
-    # rust: "1.55"
-    # golang: "1.17"
-
-sphinx:
-  fail_on_warning: true
 
 # Build documentation in the docs/ directory with Sphinx
-# sphinx:
-#    configuration: docs/conf.py
+sphinx:
+  fail_on_warning: true
+  configuration: docs/source/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==7.1.2
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==3.0.2
 fsspec==2023.6.0
 zarr
 dask


### PR DESCRIPTION
Review installation to be compatible with rtd requirements

```
We are announcing the deprecation of projects using Sphinx or MkDocs without an explicit configuration in their .readthedocs.yaml file. After January 20, 2025, Read the Docs will require explicit configuration for all Sphinx and MkDocs projects.


```