### PR TITLE
Pin bad version of fsspec

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx==7.1.2
 sphinx-rtd-theme==3.0.2
-fsspec==2023.6.0
+fsspec
 zarr
 dask
 numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "dask",
     "distributed",
     "zarr>=2.8.1,<3",
-    "fsspec[s3]>=0.8,!=2021.07.0",
+    "fsspec[s3]>=0.8,!=2021.07.0,!=2023.9.0",
     # See https://github.com/fsspec/filesystem_spec/issues/819
     "aiohttp<4",
     "requests",


### PR DESCRIPTION
Based on a combination of comments in https://github.com/ome/ome-zarr-py/issues/302 and https://github.com/fsspec/filesystem_spec/pull/1358, I think the bad version of fsspec was 2023.9.0, so remove the pin from the doc requirements and exlucde this as a bad version in the package dependencies.