### PR TITLE
`seed-isort-config` no longer needed as of `isort>=5`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,6 @@
 ---
 repos:
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:


### PR DESCRIPTION
https://github.com/asottile-archive/seed-isort-config is deprecated and has been archived in 2020:

> this is no longer needed as of `isort>=5`