### PR TITLE
flake8, isort → ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,8 +43,7 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
-        # args: [--config-data=relaxed]
-        #
+        args: [--config-data=relaxed]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,6 @@
 ---
 repos:
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
-    hooks:
-      - id: black
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - --py310-plus
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -38,27 +21,17 @@ repos:
         args:
           - --autofix
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
     hooks:
-      - id: flake8
-        additional_dependencies: [
-          # flake8-blind-except, FIXME
-          flake8-builtins,
-          flake8-rst-docstrings,
-          # flake8-logging-format, FIXME
-        ]
-        args: [
-          # default black line length is 88
-          "--max-line-length=88",
-          # Conflicts with black: E203 whitespace before ':'
-          # Conflicts with PEP8 and black:
-          # W503 line break before binary operator
-          # Does not recognize deprecated directive in docstrings
-          "--ignore=E203,RST303,W503",
-          "--builtins-allowed-modules=csv,io,types",
-          "--rst-roles=class,func,ref,mod,meth,const",
-        ]
+    - id: ruff
+      args: ["--fix", "--show-fixes"]
+
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: [--target-version=py36]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,6 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
-        args: [--target-version=py36]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,21 @@ Documentation = "https://ome-zarr.readthedocs.io"
 Repository = "https://github.com/ome/ome-zarr-py"
 Changelog = "https://github.com/ome/ome-zarr-py/blob/master/CHANGELOG.md"
 
+[tool.ruff.lint]
+extend-select = [
+    "I",   # isort
+    # "D",    # pydocstyle            # FIXME
+    # "BLE",  # flake8-blind-except   # FIXME
+    "A",   # flake8-builtins
+    # "G",    # flake8-logging-format # FIXME
+]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"ome_zarr/csv.py" = ["A005"]
+"ome_zarr/io.py" = ["A005"]
+"ome_zarr/types.py" = ["A005"]
+"tests/*.py" = ["D"]
+
 [tool.setuptools]
 packages = ["ome_zarr"]
 py-modules = ["ome_zarr"]


### PR DESCRIPTION
I don't think ruff has an equivalent to [flake8-rst-docstrings](https://github.com/peterjc/flake8-rst-docstrings).

Either keep it, or apply ruff rules releated to docs:
* [pydocstyle (D)](https://docs.astral.sh/ruff/rules/#pydocstyle-d)
* [pydoclint (DOC)](https://docs.astral.sh/ruff/rules/#pydoclint-doc)