### PR TITLE
Remove distributed from dependencies (unused)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ requires-python = ">3.10"
 dependencies = [
     "numpy",
     "dask",
-    "distributed",
     "zarr>=2.8.1,<3",
     "fsspec[s3]>=0.8,!=2021.07.0,!=2023.9.0",
     # See https://github.com/fsspec/filesystem_spec/issues/819


### PR DESCRIPTION
Hey, thanks for your work here!

I noticed that although `distributed` is listed in the dependencies, as far as I can tell the package is not being used in `ome-zarr-py`. So this PR removes it.

Next to cleaning up the dependencies, this can be useful for using `ome-zarr-py` within WASM-based environments (e.g. jupyter lite), which `distributed` is not compatible with.