### PR TITLE
Pypi release v1

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -17,6 +17,6 @@ jobs:
           python -m build
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/README.rst
+++ b/README.rst
@@ -34,20 +34,14 @@ To enable pre-commit code validation::
 Release process
 ---------------
 
-This repository uses `bump2version <https://pypi.org/project/bump2version/>`_ to manage version numbers.
-To tag a release run::
+This repository uses `setuptools_scm` to manage version numbers.
 
-    $ bumpversion release
+Go to https://github.com/ome/ome-zarr-py/releases and click on `Draft a new release`.
 
-This will remove the ``.dev0`` suffix from the current version, commit, and tag the release.
+Under `Choose a tag`, type the new version number (e.g. `0.1.0`) and choose
+`Create a new tag on publish` from the dropdown.
 
-To switch back to a development version run::
-
-    $ bumpversion --no-tag [major|minor|patch]
-
-specifying ``major``, ``minor`` or ``patch`` depending on whether the development branch will be a `major, minor or patch release <https://semver.org/>`_. This will also add the ``.dev0`` suffix.
-
-Remember to ``git push`` all commits and tags.
+Click on `Generate release notes` to create a changelog and `Publish release` to publish the release.
 
 License
 -------


### PR DESCRIPTION
Aims to fix publish to pypi as at https://github.com/ome/omero-py/pull/456
Last attempt failed at https://github.com/ome/ome-zarr-py/actions/runs/14590677576

Also updates release steps in README.

