### PR TITLE
Changelog 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+# 0.11.1 (April 2025)
+
+- Use release/v1 PyPA action branch for publishing to PyPI ([#449](https://github.com/ome/ome-zarr-py/pull/449))
+
 # 0.11.0 (April 2025)
 
 - Browse collection of local OME-Zarr in BioFile Finder ([#436](https://github.com/ome/ome-zarr-py/pull/436))


### PR DESCRIPTION
No change in released code, but I think the bump (and new tag) is still needed to trigger publishing to Pypi?