### PR TITLE
Remove unused field `tools.setuptools.dynamic`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tools.setuptools.dynamic]
-version = {attr = "ome_zarr.__version__"}
-
 [project]
 name = "ome-zarr"
 readme = "README.rst"


### PR DESCRIPTION
While working on the conda-forge feedstock for ome-zarr, I noticed that setuptools throws the warning `_ToolsTypoInMetadata: Ignoring [tools.setuptools] in pyproject.toml, did you mean [tool.setuptools]?`. It's ok that this field is ignored though, since it is no longer needed. According to the latest [setuptools-scm usage docs](https://setuptools-scm.readthedocs.io/en/stable/usage/), it is sufficient to have `dynamic = ["version"]` under `[project]`.

xref: https://github.com/ome/ome-zarr-py/pull/346, https://github.com/conda-forge/ome-zarr-feedstock/pull/24, https://github.com/conda-forge/ome-zarr-feedstock/pull/26

Below is the code I ran to demonstrate that the version string is still automatically generated without this field:

```sh
python --version
## Python 3.11.13

git log -n 1 --pretty=reference
## ba98c05 (Merge pull request #450 from will-moore/changelog_0.11.1, 2025-04-23)

python -m venv venv-ome-zarr
source ./venv-ome-zarr/bin/activate
pip install build

python -m build .
##
## /tmp/build-env-qtd5fud6/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:72: _ToolsTypoInMetadata: Ignoring [tools.setuptools] in pyproject.toml, did you mean [tool.setuptools]?
##  config = read_configuration(filepath, True, ignore_option_errors, dist)
##
## Successfully built ome_zarr-0.11.1.tar.gz and ome_zarr-0.11.1-py3-none-any.whl
ls dist/
## ome_zarr-0.11.1-py3-none-any.whl  ome_zarr-0.11.1.tar.gz
tar xzf dist/ome_zarr-0.11.1.tar.gz
tail -n 2 ome_zarr-0.11.1/ome_zarr/_version.py
## __version__ = version = '0.11.1'
## __version_tuple__ = version_tuple = (0, 11, 1)

git checkout -b remove-setuptools-field
# manually removed the field from pyproject.toml
rm -r dist/ ome_zarr-0.11.1/

python -m build .
## Successfully built ome_zarr-0.11.2.dev0+gba98c05.d20250611.tar.gz and ome_zarr-0.11.2.dev0+gba98c05.d20250611-py3-none-any.whl
ls dist/
## ome_zarr-0.11.2.dev0+gba98c05.d20250611-py3-none-any.whl  ome_zarr-0.11.2.dev0+gba98c05.d20250611.tar.gz
tar xzf dist/ome_zarr-0.11.2.dev0+gba98c05.d20250611.tar.gz
tail -n 2 ome_zarr-0.11.2.dev0+gba98c05.d20250611/ome_zarr/_version.py
## __version__ = version = '0.11.2.dev0+gba98c05.d20250611'
## __version_tuple__ = version_tuple = (0, 11, 2, 'dev0', 'gba98c05.d20250611')
```