### PR TITLE
Drop 3.10 for pre-release build

### DIFF
--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - {os: windows-latest, python_Version: '3.11', toxenv: 'py311'}
-          - {os: macos-latest, python_Version: '3.10', toxenv: 'py310'}
+          - {os: macos-latest, python_Version: '3.11', toxenv: 'py311'}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Merge of #413 with a dependency on zarr-python>=3.0.0 which is Python>=3.11 requires dropping the 3.10 build from the pre.yml job.

https://github.com/ome/ome-zarr-py/actions/runs/16799565898/job/47577538690

<img width="1639" height="1188" alt="image" src="https://github.com/user-attachments/assets/396f84ea-7962-4320-b22f-9c1238a4bac9" />
