### PR TITLE
Remove detected.init_store() in Location.__init__

### DIFF
--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -11,7 +11,7 @@ import dask.array as da
 import zarr
 from zarr.storage import FsspecStore, LocalStore, StoreLike
 
-from .format import CurrentFormat, Format, detect_format
+from .format import CurrentFormat, Format
 from .types import JSONDict
 
 LOGGER = logging.getLogger("ome_zarr.io")
@@ -55,15 +55,6 @@ class ZarrLocation:
             else loader.init_store(self.__path, mode)
         )
         self.__init_metadata()
-        detected = detect_format(self.__metadata, loader)
-        LOGGER.debug("ZarrLocation.__init__ %s detected: %s", path, detected)
-        if detected != fmt:
-            LOGGER.warning(
-                "version mismatch: detected: %s, requested: %s", detected, fmt
-            )
-            self.__fmt = detected
-            self.__store = detected.init_store(self.__path, mode)
-            self.__init_metadata()
 
     def __init_metadata(self) -> None:
         """

--- a/ome_zarr/utils.py
+++ b/ome_zarr/utils.py
@@ -21,7 +21,7 @@ import dask.array as da
 import zarr
 from dask.diagnostics import ProgressBar
 
-from .format import format_from_version
+from .format import CurrentFormat, detect_format
 from .io import parse_url
 from .reader import Multiscales, Node, Reader
 from .types import Any, JSONDict
@@ -339,9 +339,8 @@ def download(input_path: str, output_dir: str = ".") -> None:
         target_path = output_path / Path(*path)
         target_path.mkdir(parents=True)
 
-        # Use version etc...
-        version = node.zarr.version
-        fmt = format_from_version(version)
+        # Use source version...
+        fmt = detect_format(location.zgroup, CurrentFormat())
 
         # store = parse_url(input_path, mode="w", fmt=fmt)
         group_file = "zarr.json"


### PR DESCRIPTION
Fixes #445.

We no-longer need to create a new `store` since #413 the store is the same for all subclasses of `ome_zarr.format.Format`.

Just 1 test failed `test_astronaut_download()` and this was fixed by `download()` using the detected zarr_format for writing.

This is potentially quite a big change (hence the Draft status) - Need to consider if that test failure should be fixed in a better way etc.
Do we need the Format class hierarchy any more? Is there a better way to handle format differences?