### PR TITLE
parse_url_deprecation

### DIFF
--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -13,16 +13,14 @@ of 2 in the X and Y dimensions.
 Alternatively, the :py:func:`ome_zarr.writer.write_multiscale` can be used, which takes a
 "pyramid" of pre-computed `numpy` arrays.
 
-The default version of OME-NGFF is v0.5, is based on Zarr v3. A zarr v3 store is created
-by `parse_url()` below. To write OME-NGFF v0.4 (Zarr v2), use the `fmt=FormatV04()` argument
-in `parse_url()`, which will create a Zarr v2 store.
+The default version of OME-NGFF is v0.5, is based on Zarr v3. A zarr v3 group and store is created
+by `zarr.open_group()` below. To write OME-NGFF v0.4 (Zarr v2), add the `zarr_format=2` argument.
 
 The following code creates a 3D Image in OME-Zarr::
 
     import numpy as np
     import zarr
 
-    from ome_zarr.io import parse_url
     from ome_zarr.format import FormatV04
     from ome_zarr.writer import write_image, add_metadata
 
@@ -33,9 +31,8 @@ The following code creates a 3D Image in OME-Zarr::
     rng = np.random.default_rng(0)
     data = rng.poisson(lam=10, size=(size_z, size_xy, size_xy)).astype(np.uint8)
 
-    # Use fmt=FormatV04() to write v0.4 format (zarr v2)
-    store = parse_url(path, mode="w").store
-    root = zarr.group(store=store)
+    # Use zarr_format=2 to write v0.4 format (zarr v2)
+    root = zarr.open_group(path, mode="w")
     write_image(image=data, group=root, axes="zyx",
                 storage_options=dict(chunks=(1, size_xy, size_xy)))
 
@@ -49,8 +46,7 @@ Rendering settings
 ------------------
 Rendering settings can be added to an existing zarr group::
 
-    store = parse_url(path, mode="w").store
-    root = zarr.group(store=store)
+    root = zarr.open_group(path, mode="a")
     add_metadata(root, {"omero": {
         "channels": [{
             "color": "00FFFF",
@@ -71,7 +67,6 @@ The following code creates a 3D Image in OME-Zarr with labels::
 
     from skimage.data import binary_blobs
     from ome_zarr.format import FormatV04
-    from ome_zarr.io import parse_url
     from ome_zarr.writer import write_image, add_metadata
 
     path = "test_ngff_image_labels.zarr"
@@ -83,9 +78,8 @@ The following code creates a 3D Image in OME-Zarr with labels::
     rng = np.random.default_rng(0)
     data = rng.poisson(mean_val, size=(size_z, size_xy, size_xy)).astype(np.uint8)
 
-    # Use fmt=FormatV04() to write v0.4 format (zarr v2)
-    store = parse_url(path, mode="w").store
-    root = zarr.group(store=store)
+    # Use zarr_format=2 to write v0.4 format (zarr v2)
+    root = zarr.open_group(path, mode="w")
     write_image(image=data, group=root, axes="zyx",
                 storage_options=dict(chunks=(1, size_xy, size_xy)))
     # optional rendering settings
@@ -135,7 +129,6 @@ This sample code shows how to write a high-content screening dataset (i.e. cultu
     import zarr
 
     from ome_zarr.format import FormatV04
-    from ome_zarr.io import parse_url
     from ome_zarr.writer import write_image, write_plate_metadata, write_well_metadata
 
     path = "test_ngff_plate.zarr"
@@ -154,9 +147,8 @@ This sample code shows how to write a high-content screening dataset (i.e. cultu
     data = rng.poisson(mean_val, size=(num_wells, num_fields, size_z, size_xy, size_xy)).astype(np.uint8)
 
     # write the plate of images and corresponding metadata
-    # Use fmt=FormatV04() in parse_url() to write v0.4 format (zarr v2)
-    store = parse_url(path, mode="w").store
-    root = zarr.group(store=store)
+    # Use zarr_format=2 to write v0.4 format (zarr v2)
+    root = zarr.open_group(path, mode="w")
     write_plate_metadata(root, row_names, col_names, well_paths)
     for wi, wp in enumerate(well_paths):
         row, col = wp.split("/")
@@ -292,8 +284,7 @@ Writing big image from tiles::
     row_count = ceil(shape[-2]/tile_size)
     col_count = ceil(shape[-1]/tile_size)
 
-    store = parse_url("9836842.zarr", mode="w", fmt=fmt).store
-    root = zarr.group(store=store)
+    root = zarr.group("9836842.zarr", mode="w")
 
     # create empty array at root of pyramid
     zarray = root.require_array(
@@ -346,14 +337,11 @@ When that dask data is passed to write_image() the tiles will be loaded on the f
     import zarr
     from dask import delayed
 
-    from ome_zarr.io import parse_url
     from ome_zarr.format import FormatV04
     from ome_zarr.writer import write_image, add_metadata
 
     zarr_name = "test_dask.zarr"
-    # Use fmt=FormatV04() in parse_url() to write v0.4 format (zarr v2)
-    store = parse_url(zarr_name, mode="w").store
-    root = zarr.group(store=store)
+    root = zarr.group(zarr_name, mode="w")
 
     size_xy = 100
     channel_count = 2

--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -31,10 +31,8 @@ The following code creates a 3D Image in OME-Zarr::
     rng = np.random.default_rng(0)
     data = rng.poisson(lam=10, size=(size_z, size_xy, size_xy)).astype(np.uint8)
 
-    # Use zarr_format=2 to write v0.4 format (zarr v2)
-    root = zarr.open_group(path, mode="w")
-    write_image(image=data, group=root, axes="zyx",
-                storage_options=dict(chunks=(1, size_xy, size_xy)))
+    # Add fmt=FormatV04() parameter to write v0.4 format (zarr v2)
+    write_image(data, path, axes="zyx")
 
 
 This image can be viewed in `napari` using the
@@ -46,8 +44,7 @@ Rendering settings
 ------------------
 Rendering settings can be added to an existing zarr group::
 
-    root = zarr.open_group(path, mode="a")
-    add_metadata(root, {"omero": {
+    add_metadata(path, {"omero": {
         "channels": [{
             "color": "00FFFF",
             "window": {"start": 0, "end": 20, "min": 0, "max": 255},

--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -21,7 +21,7 @@ The following code creates a 3D Image in OME-Zarr::
     import numpy as np
     import zarr
 
-    from ome_zarr.format import FormatV04
+    from ome_zarr.format import
     from ome_zarr.writer import write_image, add_metadata
 
     path = "test_ngff_image.zarr"
@@ -31,7 +31,6 @@ The following code creates a 3D Image in OME-Zarr::
     rng = np.random.default_rng(0)
     data = rng.poisson(lam=10, size=(size_z, size_xy, size_xy)).astype(np.uint8)
 
-    # Add fmt=FormatV04() parameter to write v0.4 format (zarr v2)
     write_image(data, path, axes="zyx")
 
 

--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -21,7 +21,6 @@ The following code creates a 3D Image in OME-Zarr::
     import numpy as np
     import zarr
 
-    from ome_zarr.format import
     from ome_zarr.writer import write_image, add_metadata
 
     path = "test_ngff_image.zarr"

--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -249,16 +249,16 @@ Writing big image from tiles::
                 dask_image, tuple(dims), preserve_range=True, anti_aliasing=False
             )
 
-            options = {}
+            zarr_array_kwargs = {}
             if fmt.zarr_format == 2:
-                options["dimension_separator"] = "/"
+                zarr_array_kwargs["chunk_key_encoding"] = {"name": "v2", "separator": "/"}
             else:
-                options["chunk_key_encoding"] = fmt.chunk_key_encoding
-                options["dimension_names"] = [axis["name"] for axis in axes]
+                # zarr_array_kwargs["chunk_key_encoding"] = fmt.chunk_key_encoding
+                zarr_array_kwargs["dimension_names"] = [axis["name"] for axis in axes]
             # write to disk
             da.to_zarr(
                 arr=output, url=img_path, component=path,
-                zarr_format=fmt.zarr_format, **options
+                zarr_format=fmt.zarr_format, zarr_array_kwargs=zarr_array_kwargs
             )
         return paths
 

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -4,7 +4,6 @@ Primary entry point is the :func:`~ome_zarr.io.parse_url` method.
 """
 
 import logging
-import warnings
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -224,9 +223,6 @@ def parse_url(
 
     >>> parse_url('does-not-exist')
     """
-    warnings.warn(
-        "parse_url() is deprecated. Use zarr.open_group() instead.", DeprecationWarning
-    )
 
     loc = ZarrLocation(path, mode=mode, fmt=fmt)
     if "r" in mode and not loc.exists():

--- a/ome_zarr/io.py
+++ b/ome_zarr/io.py
@@ -4,6 +4,7 @@ Primary entry point is the :func:`~ome_zarr.io.parse_url` method.
 """
 
 import logging
+import warnings
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -223,6 +224,10 @@ def parse_url(
 
     >>> parse_url('does-not-exist')
     """
+    warnings.warn(
+        "parse_url() is deprecated. Use zarr.open_group() instead.", DeprecationWarning
+    )
+
     loc = ZarrLocation(path, mode=mode, fmt=fmt)
     if "r" in mode and not loc.exists():
         return None

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -836,7 +836,7 @@ def get_metadata(group: zarr.Group | str) -> dict:
 
 
 def add_metadata(
-    group: zarr.Group, metadata: JSONDict, fmt: Format | None = None
+    group: zarr.Group | str, metadata: JSONDict, fmt: Format | None = None
 ) -> None:
 
     group, fmt = check_group_fmt(group, fmt)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,6 @@ import zarr
 
 from ome_zarr.cli import main
 from ome_zarr.format import CurrentFormat, FormatV04, FormatV05
-from ome_zarr.io import parse_url
 from ome_zarr.utils import find_multiscales, finder, strip_common_prefix, view
 from ome_zarr.writer import write_plate_metadata
 
@@ -205,8 +204,7 @@ class TestCli:
 
         # create a plate
         plate_path = Path(img_dir2.mkdir("plate"))
-        store = parse_url(plate_path, mode="w", fmt=fmt).store
-        root = zarr.group(store=store)
+        root = zarr.open_group(plate_path, mode="w", zarr_format=fmt.zarr_format)
         write_plate_metadata(root, ["A"], ["1"], ["A/1"])
 
         finder(img_dir, 8000, True)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -44,8 +44,9 @@ class TestHCSNode:
     @pytest.fixture(autouse=True)
     def initdir(self, tmpdir):
         self.path = tmpdir.mkdir("data")
-        self.store = parse_url(str(self.path), mode="w", fmt=FormatV04()).store
-        self.root = zarr.group(store=self.store)
+        self.root = zarr.open_group(
+            str(self.path), mode="w", zarr_format=FormatV04().zarr_format
+        )
 
     def test_minimal_plate(self):
         write_plate_metadata(self.root, ["A"], ["1"], ["A/1"], fmt=FormatV01())

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -105,8 +105,9 @@ class TestHCSReader:
     @pytest.fixture(autouse=True)
     def initdir(self, tmpdir):
         self.path = tmpdir.mkdir("data")
-        self.store = parse_url(str(self.path), mode="w", fmt=FormatV04()).store
-        self.root = zarr.group(store=self.store)
+        self.root = zarr.open_group(
+            str(self.path), mode="w", zarr_format=FormatV04().zarr_format
+        )
 
     def test_minimal_plate(self):
         write_plate_metadata(self.root, ["A"], ["1"], ["A/1"])

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -53,7 +53,7 @@ class TestReader:
         rng = np.random.default_rng(0)
         data = rng.poisson(lam=10, size=(10, 128, 128)).astype(np.uint8)
         img_path = str(self.path / "test_read_v05.zarr")
-        root = zarr.group(img_path)
+        root = zarr.open_group(img_path)
         arr = root.create_array(
             name="s0", shape=data.shape, chunks=(10, 10, 10), dtype=data.dtype
         )

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 import zarr
 
-from ome_zarr.io import parse_url
 from ome_zarr.scale import Scaler
 from ome_zarr.writer import write_image
 
@@ -155,8 +154,8 @@ class TestScaler:
     @pytest.mark.parametrize("method", ["gaussian", "laplacian"])
     def test_pyramid_args(self, shape, tmpdir, method):
         path = pathlib.Path(tmpdir.mkdir("data"))
-        store = parse_url(path, mode="w").store
-        group = zarr.group(store=store, overwrite=True)
+        group = zarr.open_group(path, mode="w")
+
         data = self.create_data(shape)
 
         scaler = Scaler(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -165,9 +165,9 @@ class TestWriter:
 
         if version.version == "0.4":
             # Validate with ome-zarr-models-py: only supports v0.4
-            Models04Image.from_zarr(self.group)
+            Models04Image.from_zarr(out)
         elif version.version == "0.5":
-            Models05Image.from_zarr(self.group_v3)
+            Models05Image.from_zarr(out)
 
     def test_mix_zarr_formats(self):
         # check group zarr v2 and v3 matches fmt
@@ -700,10 +700,11 @@ class TestMultiscalesMetadata:
             ValueError,
             match="Expected to find an array at /0, but no array was found there.",
         ):
+            out = zarr.open_group(path)
             if fmt.version == "0.4":
-                Models04Image.from_zarr(self.root)
+                Models04Image.from_zarr(out)
             if fmt.version == "0.5":
-                Models05Image.from_zarr(self.root_v3)
+                Models05Image.from_zarr(out)
 
     @pytest.mark.parametrize("fmt", (FormatV01(), FormatV02(), FormatV03()))
     def test_version(self, fmt):
@@ -1104,7 +1105,8 @@ class TestPlateMetadata:
         ]
         assert "field_count" not in attrs["plate"]
         assert "acquisitions" not in attrs["plate"]
-        Models05HCS.from_zarr(self.root_v3)
+        out = zarr.open_group(self.path_v3)
+        Models05HCS.from_zarr(out)
 
     def test_field_count(self):
         write_plate_metadata(
@@ -1127,7 +1129,8 @@ class TestPlateMetadata:
         write_plate_metadata(
             str(self.path), ["A"], ["1"], ["A/1"], acquisitions=a, fmt=FormatV04()
         )
-        plate_attrs = zarr.open_group(str(self.path), mode="r").attrs
+        out = zarr.open_group(str(self.path), mode="r")
+        plate_attrs = out.attrs
         assert "plate" in dict(plate_attrs)
         assert plate_attrs["plate"]["acquisitions"] == a
         assert plate_attrs["plate"]["columns"] == [{"name": "1"}]
@@ -1138,7 +1141,7 @@ class TestPlateMetadata:
         ]
         assert "name" not in plate_attrs["plate"]
         assert "field_count" not in plate_attrs["plate"]
-        Models04HCS.from_zarr(self.root)
+        Models04HCS.from_zarr(out)
 
     def test_acquisitions_maximal(self):
         a = [

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -420,8 +420,8 @@ class TestWriter:
         # tempdir = TemporaryDirectory(suffix=".ome.zarr")
         # self.path = pathlib.Path(tmpdir.mkdir("data"))
         path = self.path / "test_default_compression"
-        store = parse_url(path, mode="w", fmt=format_version()).store
-        root = zarr.group(store=store)
+        fmt = format_version()
+        root = zarr.open_group(path, mode="w", zarr_format=fmt.zarr_format)
         assert root.info._zarr_format == format_version().zarr_format
         # no compressor options, we are checking default
         write_image(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -349,8 +349,8 @@ class TestWriter:
         data = self.create_data(shape)
         data = array_constructor(data)
         path = self.path / "test_write_image_compressed"
-        store = parse_url(path, mode="w", fmt=format_version()).store
-        root = zarr.group(store=store)
+        fmt = format_version()
+        root = zarr.open_group(path, mode="w", zarr_format=fmt.zarr_format)
         CNAME = "lz4"
         LEVEL = 4
         if format_version().zarr_format == 3:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -624,13 +624,11 @@ class TestMultiscalesMetadata:
     def initdir(self, tmpdir):
         self.path = pathlib.Path(tmpdir.mkdir("data"))
         # create zarr v2 group...
-        self.store = parse_url(self.path, mode="w", fmt=FormatV04()).store
-        self.root = zarr.group(store=self.store)
+        self.root = zarr.open_group(self.path, mode="w", zarr_format=2)
 
         # let's create zarr v3 group too...
         self.path_v3 = self.path / "v3"
-        store_v3 = parse_url(self.path_v3, mode="w").store
-        self.root_v3 = zarr.group(store=store_v3)
+        self.root_v3 = zarr.open_group(self.path_v3, mode="w", zarr_format=3)
 
     @pytest.mark.parametrize("fmt", (FormatV04(), FormatV05()))
     def test_multi_levels_transformations(self, fmt):
@@ -876,12 +874,11 @@ class TestPlateMetadata:
     def initdir(self, tmpdir):
         self.path = pathlib.Path(tmpdir.mkdir("data"))
         # create zarr v2 group...
-        self.store = parse_url(self.path, mode="w", fmt=FormatV04()).store
-        self.root = zarr.group(store=self.store)
+        self.root = zarr.open_group(self.path, mode="w", zarr_format=2)
+
         # create zarr v3 group...
         self.path_v3 = self.path / "v3"
-        store_v3 = parse_url(self.path_v3, mode="w").store
-        self.root_v3 = zarr.group(store=store_v3)
+        self.root_v3 = zarr.open_group(self.path_v3, mode="w", zarr_format=3)
 
     @pytest.mark.parametrize("fmt", (FormatV04(), FormatV05()))
     def test_minimal_plate(self, fmt):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -370,7 +370,9 @@ class TestWriter:
         write_image(
             image=data, group=str(self.path), axes="xyz", storage_options={"chunks": 32}
         )
-        for data in self.group.array_values():
+        test_group = zarr.open_group(self.path)
+        assert len(list(test_group.array_values())) > 0
+        for data in test_group.array_values():
             print(data)
             assert data.chunks == (32, 32, 32)
 
@@ -1476,11 +1478,11 @@ class TestLabelWriter:
             assert node_data[0].shape == shape
 
         if fmt.version not in ("0.1", "0.2", "0.3"):
-            cfs = [
+            cts = [
                 d["coordinateTransformations"]
                 for d in node_metadata["multiscales"][0]["datasets"]
             ]
-            for transf, expected in zip(cfs, transformations):
+            for transf, expected in zip(cts, transformations):
                 assert transf == expected
         assert np.allclose(label_data, node_data[0][...].compute())
 


### PR DESCRIPTION
As discussed at https://github.com/ome/ome-zarr-py/pull/474#issuecomment-3199592248, we have various issues with `parse_url()` as it incompletely wraps `zarr.open_group()`.
See #376, #445, #471, #498. 

This PR updates docs and tests to avoid using `parse_url()`.
Instead of multiple lines for writing, we can now just do:

```
write_image(data, path_or_group, axes="zyx")
```

NB: this is not a breaking change as the `group` argument can be a path `(str)` or a group.

For reading, this is currently less concise than with `parse_url()` since we don't create an itterable `Reader()` - see discussion below...