### PR TITLE
don't pass storage options when writing images

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -302,8 +302,6 @@ Please use the 'storage_options' argument instead."""
                 arr=data,
                 url=group.store,
                 component=str(Path(group.path, str(path))),
-                # IF we pass storage_options then dask NEEDS url to be a string
-                storage_options=None,
                 compute=compute,
                 zarr_format=zarr_format,
                 **options,
@@ -714,7 +712,6 @@ Please use the 'storage_options' argument instead."""
                 arr=image,
                 url=group.store,
                 component=str(Path(group.path, str(path))),
-                # storage_options=options,
                 compute=False,
                 zarr_format=zarr_format,
                 **kwargs,


### PR DESCRIPTION
This PR removes passing on `storage_options` to `da.to_zarr` when writing `dask_image` or `multiscale`.

In `SpatialData` we currently cannot write either `images` or `labels` to remote. The reason is that `storage_options` get passed despite an actual store being passed in `da.to_zarr`. Storage options only make sense to be passed on if we were to pass a `str` as url. In case we already have a `store`, `storage_options` does nothing, except cause an error when writing to remote as for example `chunks` is an invalid keyword argument when creating a store. The latter is done by dask when you actually pass on `storage_options`.

