### PR TITLE
Coordinate transformations length

### DIFF
--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -296,6 +296,7 @@ class FormatV04(FormatV03):
         Validates that a list of dicts contains a 'scale' transformation
 
         Raises ValueError if no 'scale' found or doesn't match ndim.
+        Raises ValueError if len(coordinate_transformations) < nlevels.
 
         :param ndim: Number of image dimensions.
         """
@@ -303,7 +304,10 @@ class FormatV04(FormatV03):
         if coordinate_transformations is None:
             raise ValueError("coordinate_transformations must be provided")
         ct_count = len(coordinate_transformations)
-        if ct_count != nlevels:
+
+        # If MORE transformations than levels, we just ignore the extra ones
+        # but we do require at least as many as levels
+        if ct_count < nlevels:
             raise ValueError(
                 f"coordinate_transformations count: {ct_count} must match "
                 f"datasets {nlevels}"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -454,9 +454,15 @@ class TestWriter:
         ]
         fmt.validate_coordinate_transformations(2, 2, transformations)
 
+        # We allow the number of transformations to be greater than
+        # the number of levels... (extra transformations are ignored)
+        levels = 1
+        fmt.validate_coordinate_transformations(2, levels, transformations)
+
         with pytest.raises(ValueError):
-            # transformations different length than levels
-            fmt.validate_coordinate_transformations(2, 1, transformations)
+            # ...but not fewer
+            levels = 3
+            fmt.validate_coordinate_transformations(2, levels, transformations)
 
         with pytest.raises(ValueError):
             transf = [[{"type": "scale", "scale": ("1", 1)}]]


### PR DESCRIPTION
This is a small change that makes the checking of `coordinate_transformations` a bit less strict for
e.g. `write_image(image, group, coordinate_transformations)`.

We only need to ensure that the number of `coordinate_transformations` is long enough to cover all the levels that will be generated by `2x` downsampling of the `image` BUT it's actually a bit of a pain to know exactly how many levels will be created.

I came across this issue with a script for cropping a zarr image to a smaller image (see below).

Without this PR, the script fails.

```

import argparse
import sys

import zarr
import dask.array as da
from ome_zarr.writer import write_image, add_metadata


def crop_zarr(path, x, y, width, height):
    """Crop a region from a Zarr dataset and save to a new Zarr dataset.

    Args:
        path (str): Path to the input Zarr dataset.
        x (int): X coordinate of the top-left corner of the crop region.
        y (int): Y coordinate of the top-left corner of the crop region.
        width (int): Width of the crop region.
        height (int): Height of the crop region.
    """
    # Open the input Zarr dataset
    input_zarr = zarr.open_group(path)

    zarr_attrs = input_zarr.attrs.asdict()
    if "ome" in zarr_attrs:
        zarr_attrs = zarr_attrs["ome"]

    multiscales = zarr_attrs["multiscales"][0]
    axes = multiscales["axes"]
    omero_attrs = zarr_attrs.get("omero")

    array_path_0 = multiscales["datasets"][0]["path"]
    data = da.from_zarr(input_zarr[array_path_0])

    # Create a new Zarr dataset for the cropped region
    output_path = path.replace('.zarr', f'_cropped_{x}_{y}_{width}_{height}.zarr')
    # output_zarr = zarr.open(output_path, mode='w', shape=(input_zarr.shape[0], height, width), dtype=input_zarr.dtype)

    # Perform the cropping operation
    slices = tuple([slice(None) for _ in range(data.ndim - 2)] + [slice(y, y + height), slice(x, x + width)])
    cropped_data = data[slices]

    print("Cropped data:", cropped_data)

    print(f"Cropped region saved to: {output_path}")
    # for top-resolution, assume first transformation is scale
    # e.g. "coordinateTransformations": [ { "type": "scale", "scale": [1.0, 1.0, 1.0] }...
    orig_scale = multiscales["datasets"][0]["coordinateTransformations"][0]["scale"]
    scale_x = orig_scale[-1]
    scale_y = orig_scale[-2]

    # After scaling each resolution to full size, we then translate by x * scale_x, y * scale_y
    # This is the same for each resolution
    full_size_translation = [0] * (cropped_data.ndim - 2) + [y * scale_y, x * scale_x]

    coord_trnsfms = []
    coord_trnsfms.append([{
        "type": "scale",
        "scale": orig_scale
    }, {
        "type": "translation",
        "translation": full_size_translation
    }])

    # We don't know how many levels will be in new image, but we can assume
    # same number as original image. If croped image has FEWER levels, that
    # is OK, the extra cood_trnsfms will be ignored.
    for _ in range(1, len(multiscales["datasets"])):
        previous_scale = coord_trnsfms[-1][0]["scale"]
        curr_scale = previous_scale[:]
        curr_scale[-1] *= 2
        curr_scale[-2] *= 2
        coord_trnsfms.append([{
            "type": "scale",
            "scale": curr_scale
        }, {
            "type": "translation",
            "translation": full_size_translation
        }])

    out_root = zarr.open_group(output_path, mode="w", zarr_format=3)
    write_image(image=cropped_data, group=out_root, coordinate_transformations=coord_trnsfms, axes=axes)

    if omero_attrs:
        add_metadata(out_root, {"omero": omero_attrs})


def main(argv):
    parser = argparse.ArgumentParser()
    parser.add_argument('path', help='Path to the Zarr dataset')
    parser.add_argument('xywh', help='Crop region: x,y,width,height')

    args = parser.parse_args(argv)

    # Parse the xywh argument
    x, y, width, height = map(int, args.xywh.split(','))

    # Call the crop function (to be implemented)
    crop_zarr(args.path, x, y, width, height)


if __name__ == '__main__':
    main(sys.argv[1:])

```