### PR TITLE
Use consistent version string for zarr lower bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">3.10"
 dependencies = [
     "numpy",
     "dask",
-    "zarr>=v3.0.0",
+    "zarr>=3.0.0",
     "fsspec[s3]>=0.8,!=2021.07.0,!=2023.9.0",
     "aiohttp",
     "requests",


### PR DESCRIPTION
Since support for zarr 3 is still a work in progress across the Python spatial ecosystem (eg spatialdata in https://github.com/scverse/spatialdata/pull/969), the lower bound of `zarr >=3.0.0` for ome-zarr 0.12.0+ is critical.

Currently `pyproject.toml` has a `v` prepended to the version string. While `pip` can properly interpret this version string, conda cannot, which has caused problems when packaging ome-zarr for conda-forge. Since the zarr maintainers do not put a `v` in front of their version strings ([PyPI release history](https://pypi.org/project/zarr/#history)), and none of the other version strings in ome-zarr's `pyproject.toml` include this `v`, would you please consider merging this PR to use a consistent version string for the zarr lower bound? Not only would this help conda-forge maintainers like me, but it would help any other community packaging efforts that rely on automated parsing of `pyproject.toml` to determine the package dependency network.

xref: https://github.com/conda-forge/ome-zarr-feedstock/pull/31, https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1068, https://github.com/conda-forge/ome-zarr-feedstock/pull/28/files#r2301294027