### PR TITLE
Fix zarr.group() to zarr.open_group() in test_read_v05

### DIFF
--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -53,7 +53,7 @@ class TestReader:
         rng = np.random.default_rng(0)
         data = rng.poisson(lam=10, size=(10, 128, 128)).astype(np.uint8)
         img_path = str(self.path / "test_read_v05.zarr")
-        root = zarr.group(img_path)
+        root = zarr.open_group(img_path)
         arr = root.create_array(
             name="s0", shape=data.shape, chunks=(10, 10, 10), dtype=data.dtype
         )


### PR DESCRIPTION
Don't know how this failing test got merged, but it's causing failures at https://github.com/ome/ome-zarr-py/pull/487 etc.

Tests probably started failing due to release yesterday https://zarr.readthedocs.io/en/stable/release-notes.html#id1 but I don't see anything obvious in release notes.