### PR TITLE
V06 coordinate systems

### DIFF
--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -21,7 +21,7 @@ The following code creates a 3D Image in OME-Zarr::
     import numpy as np
     import zarr
 
-    from ome_zarr.format import FormatV04
+    from ome_zarr.format import
     from ome_zarr.writer import write_image, add_metadata
 
     path = "test_ngff_image.zarr"
@@ -31,7 +31,6 @@ The following code creates a 3D Image in OME-Zarr::
     rng = np.random.default_rng(0)
     data = rng.poisson(lam=10, size=(size_z, size_xy, size_xy)).astype(np.uint8)
 
-    # Add fmt=FormatV04() parameter to write v0.4 format (zarr v2)
     write_image(data, path, axes="zyx")
 
 

--- a/ome_zarr/axes.py
+++ b/ome_zarr/axes.py
@@ -5,6 +5,7 @@ from typing import Any
 from .format import CurrentFormat, Format
 
 KNOWN_AXES = {"x": "space", "y": "space", "z": "space", "c": "channel", "t": "time"}
+DISCRETE_AXES = ["c", "t"]
 
 
 class Axes:
@@ -18,12 +19,12 @@ class Axes:
 
         Raises ValueError if not valid
         """
+        self.fmt = fmt
         if axes is not None:
             self.axes = self._axes_to_dicts(axes)
         elif fmt.version in ("0.1", "0.2"):
             # strictly 5D
             self.axes = self._axes_to_dicts(["t", "c", "z", "y", "x"])
-        self.fmt = fmt
         self.validate()
 
     def validate(self) -> None:
@@ -45,15 +46,18 @@ class Axes:
             return self._get_names()
         return self.axes
 
-    @staticmethod
-    def _axes_to_dicts(axes: list[str] | list[dict[str, str]]) -> list[dict[str, str]]:
+    def _axes_to_dicts(
+        self, axes: list[str] | list[dict[str, str]]
+    ) -> list[dict[str, str]]:
         """Returns a list of axis dicts with name and type"""
         axes_dicts = []
         for axis in axes:
             if isinstance(axis, str):
-                axis_dict = {"name": axis}
+                axis_dict: dict[str, Any] = {"name": axis}
                 if axis in KNOWN_AXES:
                     axis_dict["type"] = KNOWN_AXES[axis]
+                    if self.fmt.version.startswith("0.6"):
+                        axis_dict["discrete"] = axis in DISCRETE_AXES
                 axes_dicts.append(axis_dict)
             else:
                 axes_dicts.append(axis)

--- a/ome_zarr/axes.py
+++ b/ome_zarr/axes.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from .format import CurrentFormat, Format
+from .format import CurrentFormat, Format, format_from_version
 
 KNOWN_AXES = {"x": "space", "y": "space", "z": "space", "c": "channel", "t": "time"}
 DISCRETE_AXES = ["c", "t"]
@@ -118,3 +118,18 @@ class Axes:
                 raise ValueError("4D data must have axes tzyx or czyx or tcyx")
         elif val_axes != ("t", "c", "z", "y", "x"):
             raise ValueError("5D data must have axes ('t', 'c', 'z', 'y', 'x')")
+
+    @staticmethod
+    def from_multiscales(
+        multiscales: dict[str, Any],
+    ) -> list[str] | list[dict[str, str]]:
+        """Create Axes from the multiscales object"""
+        if "version" in multiscales:
+            fmt = format_from_version(multiscales["version"])
+            axesObj = Axes(multiscales.get("axes", []), fmt=fmt)
+            return axesObj.to_list(fmt=fmt)
+        else:
+            # v0.5 or later - no version on multiscales, so we guess!
+            if "coordinateSystems" in multiscales:
+                return multiscales["coordinateSystems"][0].get("axes", [])
+            return multiscales.get("axes", [])

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -116,7 +116,10 @@ class Format(ABC):
 
     @abstractmethod
     def generate_coordinate_transformations(
-        self, shapes: list[tuple], scale: list[float] | None = None
+        self,
+        shapes: list[tuple],
+        scale: list[float] | None = None,
+        paths: list[str] | None = None,
     ) -> list[list[dict[str, Any]]] | None:  # pragma: no cover
         raise NotImplementedError()
 
@@ -200,7 +203,10 @@ class FormatV01(Format):
                 raise ValueError("%s path must be of %s type", well, key_type)
 
     def generate_coordinate_transformations(
-        self, shapes: list[tuple], scale: list[float] | None = None
+        self,
+        shapes: list[tuple],
+        scale: list[float] | None = None,
+        paths: list[str] | None = None,
     ) -> list[list[dict[str, Any]]] | None:
         return None
 
@@ -297,7 +303,10 @@ class FormatV04(FormatV03):
             raise ValueError("Mismatching column index for %s", well)
 
     def generate_coordinate_transformations(
-        self, shapes: list[tuple], scale: list[float] | None = None
+        self,
+        shapes: list[tuple],
+        scale: list[float] | None = None,
+        paths: list[str] | None = None,
     ) -> list[list[dict[str, Any]]] | None:
         data_shape = shapes[0]
         scale_0 = scale or [1.0] * len(data_shape)
@@ -493,7 +502,10 @@ class FormatV06(FormatV05):
     #                 )
 
     def generate_coordinate_transformations(
-        self, shapes: list[tuple], scale: list[float] | None = None
+        self,
+        shapes: list[tuple],
+        scale: list[float] | None = None,
+        paths: list[str] | None = None,
     ) -> list[list[dict[str, Any]]] | None:
         """
         Returns coordinate_transformations for each dataset
@@ -501,7 +513,9 @@ class FormatV06(FormatV05):
         shapes is a 2D list - (list for each level of pyramid)
         scale is an optional list of floats to use for scaling instead of
         """
-        cts_for_datasets = super().generate_coordinate_transformations(shapes, scale)
+        cts_for_datasets = super().generate_coordinate_transformations(
+            shapes, scale, paths
+        )
         if cts_for_datasets is None:
             raise ValueError("coordinate_transformations must be provided")
         # wrap each list in sequenceTransformation
@@ -510,11 +524,11 @@ class FormatV06(FormatV05):
                 {
                     "type": "sequence",
                     "transformations": ct,
-                    "input": "",
+                    "input": paths[i] if paths else str(i),
                     "output": "physical",
                 }
             ]
-            for ct in cts_for_datasets
+            for i, ct in enumerate(cts_for_datasets)
         ]
         return coordinate_transformations
 

--- a/ome_zarr/format.py
+++ b/ome_zarr/format.py
@@ -137,13 +137,6 @@ class Format(ABC):
     ) -> None:  # pragma: no cover
         raise NotImplementedError()
 
-    @abstractmethod
-    def read_axes(
-        self,
-        multiscales: dict[str, Any],
-    ) -> list:
-        raise NotImplementedError()
-
 
 class FormatV01(Format):
     """
@@ -226,12 +219,6 @@ class FormatV01(Format):
     ) -> None:
         return None
 
-    def read_axes(
-        self,
-        multiscales: dict[str, Any],
-    ) -> list:
-        return []
-
 
 class FormatV02(FormatV01):
     """
@@ -263,15 +250,6 @@ class FormatV03(FormatV02):  # inherits from V02 to avoid code duplication
         axes: list,
     ) -> None:
         multiscales["axes"] = axes
-
-    def read_axes(
-        self,
-        multiscales: dict[str, Any],
-    ) -> list:
-        axes = multiscales.get("axes", [])
-        if not axes:
-            raise ValueError("Missing axes in multiscales")
-        return axes
 
 
 class FormatV04(FormatV03):
@@ -533,20 +511,6 @@ class FormatV06(FormatV05):
         axes: list,
     ) -> None:
         multiscales["coordinateSystems"] = [{"name": "physical", "axes": axes}]
-
-    def read_axes(
-        self,
-        multiscales: dict[str, Any],
-    ) -> list:
-        coordinate_systems = multiscales.get("coordinateSystems", [])
-        if not coordinate_systems:
-            raise ValueError("Missing coordinateSystems in multiscales")
-        if len(coordinate_systems) > 1:
-            raise ValueError("Only one coordinateSystem supported")
-        axes = coordinate_systems[0].get("axes", [])
-        if not axes:
-            raise ValueError("Missing axes in coordinateSystems")
-        return axes
 
 
 CurrentFormat = FormatV06

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Union, cast, overload
 import dask.array as da
 import numpy as np
 
-from .format import FormatV06
+from .axes import Axes
 from .io import ZarrLocation
 from .types import JSONDict
 
@@ -274,16 +274,13 @@ class Multiscales(Spec):
         super().__init__(node)
 
         multiscales = self.lookup("multiscales", [])
+        print("Multiscales(Spec):", multiscales)
         # FIXME: version isn't on multiscales for zarr v3
         # version = multiscales[0].get(
         #     "version", "0.1"
         # )  # should this be matched with Format.version?
         datasets = multiscales[0]["datasets"]
-        if "coordinateSystems" in multiscales[0]:
-            fmt = FormatV06()
-            axes = fmt.read_axes(multiscales[0])
-        else:
-            axes = multiscales[0].get("axes")
+        axes = Axes.from_multiscales(multiscales[0])
         node.metadata["axes"] = axes
         # This will get overwritten by 'omero' metadata if present
         node.metadata["name"] = multiscales[0].get("name")

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -38,6 +38,7 @@ class Node:
 
         # Likely to be updated by specs
         self.metadata: JSONDict = dict()
+        self.dataset_paths: list[str] = []
         self.data: list[da.core.Array] = list()
         self.specs: list[Spec] = []
         self.pre_nodes: list[Node] = []
@@ -285,6 +286,7 @@ class Multiscales(Spec):
         # This will get overwritten by 'omero' metadata if present
         node.metadata["name"] = multiscales[0].get("name")
         paths = [d["path"] for d in datasets]
+        node.dataset_paths = paths
         self.datasets: list[str] = paths
         transformations = [d.get("coordinateTransformations") for d in datasets]
         if any(trans is not None for trans in transformations):
@@ -413,6 +415,7 @@ class Well(Spec):
         self.numpy_type = image_node.data[0].dtype
         self.img_shape = image_node.data[0].shape
         self.img_metadata = image_node.metadata
+        self.dataset_paths = image_node.dataset_paths
         self.img_pyramid_shapes = [d.shape for d in image_node.data]
 
         def get_field(row: int, col: int, level: int) -> da.core.Array:
@@ -493,6 +496,8 @@ class Plate(Spec):
         if well_spec is None:
             raise Exception("Could not find first well")
         self.first_field_path = well_spec.well_data["images"][0]["path"]
+        # need the dataset paths...
+        self.dataset_paths = well_spec.dataset_paths
         self.numpy_type = well_spec.numpy_type
 
         LOGGER.debug("img_pyramid_shapes: %s", well_spec.img_pyramid_shapes)
@@ -517,9 +522,10 @@ class Plate(Spec):
         return image_node.data[0].dtype
 
     def get_tile_path(self, level: int, row: int, col: int) -> str:
+        ds_path = self.dataset_paths[level]
         return (
             f"{self.row_names[row]}/"
-            f"{self.col_names[col]}/{self.first_field_path}/{level}"
+            f"{self.col_names[col]}/{self.first_field_path}/{ds_path}"
         )
 
     def get_stitched_grid(self, level: int, tile_shape: tuple) -> da.core.Array:

--- a/ome_zarr/utils.py
+++ b/ome_zarr/utils.py
@@ -99,7 +99,9 @@ def view(
 
     # open ome-ngff-validator in a web browser...
     url = (
-        f"https://ome.github.io/ome-ngff-validator/"
+        # f"https://ome.github.io/ome-ngff-validator/"
+        # TEMP URL for RFC5 deployment of validator
+        "https://deploy-preview-48--ome-ngff-validator.netlify.app/"
         f"?source=http://localhost:{port}/{image_name}"
     )
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -963,7 +963,7 @@ def write_multiscale_labels(
       Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
     :type coordinate_transformations: list of dict
     :param coordinate_transformations:
-        Deprecated: use 'scale' to specify pixel sizes. coordinate_transformations
+      Deprecated: use 'scale' to specify pixel sizes. coordinate_transformations
       (dataset arrays to physical) will be generated automatically from the scale parameter.
     :type coordinateTransformations: list of dict
     :param coordinateTransformations:

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -222,6 +222,7 @@ def write_multiscale(
     fmt: Format | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
+    scale: list[float] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     name: str | None = None,
     compute: bool | None = True,
@@ -346,7 +347,9 @@ Please use the 'storage_options' argument instead."""
 
     if coordinate_transformations is None:
         shapes = [data.shape for data in pyramid]
-        coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
+        coordinate_transformations = fmt.generate_coordinate_transformations(
+            shapes, scale
+        )
 
     # we validate again later, but this catches length mismatch before zip(datasets...)
     fmt.validate_coordinate_transformations(
@@ -548,6 +551,7 @@ def write_image(
     fmt: Format | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
+    scale: list[float] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     compute: bool | None = True,
     **metadata: str | JSONDict | list[JSONDict],
@@ -585,6 +589,10 @@ def write_image(
     :param coordinate_transformations:
       For each resolution, we have a List of transformation Dicts (not validated).
       Each list of dicts are added to each datasets in order.
+    :type scale: list of float, optional
+    :param scale:
+      Scale of the image. Used to generate coordinate transformations if
+      coordinate_transformations is None.
     :type storage_options: dict or list of dict, optional
     :param storage_options:
         Options to be passed on to the storage backend.
@@ -616,6 +624,7 @@ def write_image(
             fmt=fmt,
             axes=axes,
             coordinate_transformations=coordinate_transformations,
+            scale=scale,
             storage_options=storage_options,
             name=name,
             compute=compute,
@@ -630,6 +639,7 @@ def write_image(
             fmt=fmt,
             axes=axes,
             coordinate_transformations=coordinate_transformations,
+            scale=scale,
             storage_options=storage_options,
             name=name,
             compute=compute,
@@ -660,6 +670,7 @@ def _write_dask_image(
     fmt: Format | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
+    scale: list[float] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     name: str | None = None,
     compute: bool | None = True,
@@ -751,7 +762,9 @@ Please use the 'storage_options' argument instead."""
 
     if coordinate_transformations is None:
         # shapes = [data.shape for data in delayed]
-        coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
+        coordinate_transformations = fmt.generate_coordinate_transformations(
+            shapes, scale
+        )
 
     # we validate again later, but this catches length mismatch before zip(datasets...)
     fmt.validate_coordinate_transformations(
@@ -867,6 +880,7 @@ def write_multiscale_labels(
     fmt: Format | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
+    scale: list[float] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     label_metadata: JSONDict | None = None,
     compute: bool | None = True,
@@ -906,6 +920,10 @@ def write_multiscale_labels(
     :param coordinate_transformations:
       For each resolution, we have a List of transformation Dicts (not validated).
       Each list of dicts are added to each datasets in order.
+    :type scale: list of float, optional
+    :param scale:
+      Scale of the image. Used to generate coordinate transformations if
+      coordinate_transformations is None.
     :type storage_options: dict or list of dict, optional
     :param storage_options:
         Options to be passed on to the storage backend.
@@ -932,6 +950,7 @@ def write_multiscale_labels(
         fmt=fmt,
         axes=axes,
         coordinate_transformations=coordinate_transformations,
+        scale=scale,
         storage_options=storage_options,
         name=name,
         compute=compute,
@@ -956,6 +975,7 @@ def write_labels(
     fmt: Format | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
+    scale: list[float] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     label_metadata: JSONDict | None = None,
     compute: bool | None = True,
@@ -1033,6 +1053,7 @@ def write_labels(
             fmt=fmt,
             axes=axes,
             coordinate_transformations=coordinate_transformations,
+            scale=scale,
             storage_options=storage_options,
             name=name,
             compute=compute,
@@ -1047,6 +1068,7 @@ def write_labels(
             fmt=fmt,
             axes=axes,
             coordinate_transformations=coordinate_transformations,
+            scale=scale,
             storage_options=storage_options,
             name=name,
             compute=compute,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -442,7 +442,8 @@ def write_multiscales_metadata(
     if len(metadata.get("metadata", {})) > 0:
         multiscales[0]["metadata"] = metadata["metadata"]
     if axes is not None:
-        multiscales[0]["axes"] = axes
+        # multiscales[0]["axes"] = axes
+        fmt.write_axes(multiscales[0], axes)
 
     if fmt.version in ("0.1", "0.2", "0.3", "0.4"):
         multiscales[0]["version"] = fmt.version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">3.10"
 
 dependencies = [
     "numpy",
-    "dask>=2025.12.0",
+    "dask==2026.1.1",
     "zarr>=3.0.0",
     "fsspec[s3]>=0.8,!=2021.07.0,!=2023.9.0",
     "aiohttp",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,14 +87,14 @@ class TestCli:
             assert directory_items(Path(out) / "data-3") == [
                 Path(".zattrs"),
                 Path(".zgroup"),
-                Path("0"),
-                Path("1"),
-                Path("2"),
-                Path("3"),
-                Path("4"),
                 Path("labels"),
+                Path("s0"),
+                Path("s1"),
+                Path("s2"),
+                Path("s3"),
+                Path("s4"),
             ]
-            assert directory_items(Path(out) / "data-3" / "1") == [
+            assert directory_items(Path(out) / "data-3" / "s1") == [
                 Path(".zarray"),
                 Path(".zattrs"),  # empty '{}'
                 Path("0"),
@@ -103,15 +103,15 @@ class TestCli:
             ]
         else:
             assert directory_items(Path(out) / "data-3") == [
-                Path("0"),
-                Path("1"),
-                Path("2"),
-                Path("3"),
-                Path("4"),
                 Path("labels"),
+                Path("s0"),
+                Path("s1"),
+                Path("s2"),
+                Path("s3"),
+                Path("s4"),
                 Path("zarr.json"),
             ]
-            assert directory_items(Path(out) / "data-3" / "1") == [
+            assert directory_items(Path(out) / "data-3" / "s1") == [
                 Path("c"),
                 Path("zarr.json"),
             ]

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -8,7 +8,7 @@ from ome_zarr.utils import download, info
 
 
 def log_strings(idx, c, y, x, cc, cy, cx, dtype):
-    yield f"resolution: {idx}"
+    yield f"resolution: s{idx}"
     yield f" - shape ('c', 'y', 'x') = ({c}, {y}, {x})"
     yield f" - chunks =  ['{cc}', '{cx}', '{cy}']"
     yield f" - dtype = {dtype}"

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -9,8 +9,6 @@ from ome_zarr.format import FormatV04
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Node, Plate, Reader, Well
 from ome_zarr.writer import (
-    add_metadata,
-    get_metadata,
     write_image,
     write_plate_metadata,
     write_well_metadata,
@@ -81,24 +79,6 @@ class TestReader:
         assert len(nodes) == 1
         image_node = nodes[0]
         assert np.allclose(data, image_node.data[0])
-
-
-class TestInvalid:
-    @pytest.fixture(autouse=True)
-    def initdir(self, tmpdir):
-        self.path = tmpdir.mkdir("data")
-
-    def test_invalid_version(self):
-        grp = create_zarr(str(self.path))
-        # update version to something invalid
-        attrs = get_metadata(grp)
-        attrs["multiscales"][0]["version"] = "invalid"
-        add_metadata(grp, attrs)
-        # should raise exception
-        with pytest.raises(ValueError) as exe:
-            reader = Reader(parse_url(str(self.path)))
-            assert len(list(reader())) == 2
-        assert str(exe.value) == "Version invalid not recognized"
 
 
 class TestHCSReader:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -165,7 +165,7 @@ class TestWriter:
         print("node.metadata", node_metadata)
         if version.version not in ("0.1", "0.2", "0.3"):
             transformations = []
-            for dataset_transfs in TRANSFORMATIONS:
+            for i, dataset_transfs in enumerate(TRANSFORMATIONS):
                 transf0 = dataset_transfs[0]
                 transf1 = dataset_transfs[1]
                 # e.g. slice [1, 1, z, x, y] -> [z, x, y] for 3D
@@ -183,7 +183,7 @@ class TestWriter:
                             {
                                 "type": "sequence",
                                 "transformations": [scale_transform, trans_transform],
-                                "input": "",
+                                "input": f"s{i}",
                                 "output": "physical",
                             }
                         ]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -427,8 +427,8 @@ class TestWriter:
                 # if shape smaller than chunk, dask writer uses chunk == shape
                 # so we only compare larger resolutions
                 assert filecmp.cmp(
-                    f"{grp_path}/temp/to_dask/{level}/{zarr_array}",
-                    f"{grp_path}/{level}/{zarr_array}",
+                    f"{grp_path}/temp/to_dask/{paths[level]}/{zarr_array}",
+                    f"{grp_path}/{paths[level]}/{zarr_array}",
                     shallow=False,
                 )
 
@@ -495,7 +495,7 @@ class TestWriter:
             storage_options={"compressor": compressor},
         )
         group = zarr.open(f"{path}")
-        for ds in ["0", "1"]:
+        for ds in ["s0", "s1"]:
             assert len(group[ds].info._compressors) > 0
             comp = group[ds].info._compressors[0]
             if format_version().zarr_format == 3:
@@ -559,7 +559,7 @@ class TestWriter:
 
         # check chunk: multiscale level 0, 4D chunk at (0, 0, 0, 0)
         c = ""
-        for ds in ["0", "1"]:
+        for ds in ["s0", "s1"]:
             if format_version().zarr_format == 3:
                 assert (path / "zarr.json").exists()
                 assert (path / ds / "zarr.json").exists()
@@ -583,7 +583,7 @@ class TestWriter:
                     "shuffle": 1,
                 }
 
-        chunk_size = (path / f"0/{c}0/0/0/0").stat().st_size
+        chunk_size = (path / f"s0/{c}0/0/0/0").stat().st_size
         assert chunk_size < 4e6
 
     @pytest.mark.parametrize(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -370,7 +370,9 @@ class TestWriter:
         write_image(
             image=data, group=str(self.path), axes="xyz", storage_options={"chunks": 32}
         )
-        for data in self.group.array_values():
+        test_group = zarr.open_group(self.path)
+        assert len(list(test_group.array_values())) > 0
+        for data in test_group.array_values():
             print(data)
             assert data.chunks == (32, 32, 32)
 
@@ -1476,11 +1478,11 @@ class TestLabelWriter:
             assert node_data[0].shape == shape
 
         if fmt.version not in ("0.1", "0.2", "0.3"):
-            cfs = [
+            cts = [
                 d["coordinateTransformations"]
                 for d in node_metadata["multiscales"][0]["datasets"]
             ]
-            for transf, expected in zip(cfs, transformations):
+            for transf, expected in zip(cts, transformations):
                 assert transf == expected
         assert np.allclose(label_data, node_data[0][...].compute())
 


### PR DESCRIPTION
Work in progress...

NB: This is on top of #476

To test:

# Basic conversion

The generated image has `datasets.coordinateTransformations` of `scale` and `translate` nested into a `sequence` transform with `"output": "physical"` and the axes are stored within a `coordinateSystem` named "physical".
 
```
import zarr
from ome_zarr.writer import write_image, get_metadata

url = "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0033A/BR00109990_C2.zarr/0/"

read_group = zarr.open_group(url, mode='r')
# copy the data locally
data = read_group['0'][:,:,:]

multiscales = get_metadata(read_group)["multiscales"][0]
axes = multiscales["axes"]
scale = multiscales["datasets"][0]["coordinateTransformations"][0]["scale"]

print("axes:", axes)
print("scale:", scale)
print("data shape:", data.shape)

write_image(data, "idr0033_v0.6dev2.zarr", axes=axes, scale=scale)
```

Then, to open with validator with RFC5 support from https://github.com/ome/ome-ngff-validator/pull/48

```
$ ome_zarr view idr0033_v0.6dev2.zarr
```

# Rotation

The script includes commented-out code for creating the rotation matrix using the `Affine` class from `napari`, but if `napari` isn't required for the code below as the `rotation_matrix` is hard-coded.

```
import zarr
# from napari.utils.transforms import Affine

from ome_zarr.writer import write_image, get_metadata

url = "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0033A/BR00109990_C2.zarr/0/"

read_group = zarr.open_group(url, mode='r')
# copy the data locally
data = read_group['0'][:,:,:]

multiscales = get_metadata(read_group)["multiscales"][0]
axes = multiscales["axes"]
scale = multiscales["datasets"][0]["coordinateTransformations"][0]["scale"]

# create a rotation matrix using napari Affine
# rotation_aff = Affine(rotate=30)    # 3 x 3 matrix for 2D image
# extra_dims = data.ndim - 2
# if extra_dims > 0:
#     rotation_aff = rotation_aff.expand_dims(list(range(extra_dims)))
# # RFC-5 rotation matrix is the upper-left N x N part of the affine matrix
# rotation_matrix = rotation_aff.affine_matrix[:-1, :-1].tolist()

rotation_matrix = [[1.0, 0.0, 0.0], [0.0, 0.8660254037844387, -0.49999999999999994], [0.0, 0.49999999999999994, 0.8660254037844387]]

# NB: "input" is automatically set to "physical" to correspond to the default coordinatSystem
coordinateTransformations = [
    {
        "type": "rotation",
        "rotation": rotation_matrix,
        "output": "rotated"
    }
]

write_image(data, "idr0033_rot_v0.6dev2.zarr", axes=axes, scale=scale,
            coordinateTransformations=coordinateTransformations)
```

Then view this with https://github.com/will-moore/napari-ome-zarr/pull/2 installed:

```
$ napari --plugin napari-ome-zarr idr0033_rot_v0.6dev2.zarr
```

<img width="1036" height="687" alt="Screenshot 2025-11-04 at 09 50 38" src="https://github.com/user-attachments/assets/e29c527c-8b3b-4cf2-b76d-8e5ab03f6c2c" />


