### PR TITLE
Ensure that laplacian and gaussian scaling preserves dtype

### DIFF
--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -204,25 +204,25 @@ class Scaler:
 
     def gaussian(self, base: np.ndarray) -> list[np.ndarray]:
         """Downsample using :func:`skimage.transform.pyramid_gaussian`."""
-        return list(
-            pyramid_gaussian(
-                base,
-                downscale=self.downscale,
-                max_layer=self.max_layer,
-                channel_axis=None,
-            )
+        dtype = base.dtype
+        pyramid = pyramid_gaussian(
+            base,
+            downscale=self.downscale,
+            max_layer=self.max_layer,
+            channel_axis=None,
         )
+        return [level.astype(dtype) for level in pyramid]
 
     def laplacian(self, base: np.ndarray) -> list[np.ndarray]:
         """Downsample using :func:`skimage.transform.pyramid_laplacian`."""
-        return list(
-            pyramid_laplacian(
-                base,
-                downscale=self.downscale,
-                max_layer=self.max_layer,
-                channel_axis=None,
-            )
+        dtype = base.dtype
+        pyramid = pyramid_laplacian(
+            base,
+            downscale=self.downscale,
+            max_layer=self.max_layer,
+            channel_axis=None,
         )
+        return [level.astype(dtype) for level in pyramid]
 
     def local_mean(self, base: np.ndarray) -> list[np.ndarray]:
         """Downsample using :func:`skimage.transform.downscale_local_mean`."""

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -26,20 +26,21 @@ class TestScaler:
         rng = np.random.default_rng(0)
         return rng.poisson(mean_val, size=shape).astype(dtype)
 
-    def check_downscaled(self, downscaled, shape, scale_factor=2):
-        expected_shape = shape
-        for data in downscaled:
-            assert data.shape == expected_shape
-            assert data.dtype == downscaled[0].dtype
-            expected_shape = expected_shape[:-2] + tuple(
-                sh // scale_factor for sh in expected_shape[-2:]
-            )
+    def check_downscaled(self, downscaled, data, scale_factor=2):
+        expected_shape = data.shape
+        for level in downscaled:
+            assert level.dtype == data.dtype
+            if scale_factor is not None:
+                assert level.shape == expected_shape
+                expected_shape = expected_shape[:-2] + tuple(
+                    sh // scale_factor for sh in expected_shape[-2:]
+                )
 
     def test_nearest(self, shape):
         data = self.create_data(shape)
         scaler = Scaler()
         downscaled = scaler.nearest(data)
-        self.check_downscaled(downscaled, shape)
+        self.check_downscaled(downscaled, data)
 
     def test_nearest_via_method(self, shape):
         data = self.create_data(shape)
@@ -49,7 +50,7 @@ class TestScaler:
 
         scaler.method = "nearest"
         downscaled = scaler.func(data)
-        self.check_downscaled(downscaled, shape)
+        self.check_downscaled(downscaled, data)
 
         assert (
             np.sum(
@@ -61,27 +62,27 @@ class TestScaler:
             == 0
         )
 
-    # this fails because of wrong channel dimension; need to fix in follow-up PR
-    @pytest.mark.xfail
+    # NB: gaussian downscales ALL dimensions, not just YX
+    # so we SKIP the check on shape
     def test_gaussian(self, shape):
         data = self.create_data(shape)
         scaler = Scaler()
         downscaled = scaler.gaussian(data)
-        self.check_downscaled(downscaled, shape)
+        self.check_downscaled(downscaled, data, scale_factor=None)
 
-    # this fails because of wrong channel dimension; need to fix in follow-up PR
-    @pytest.mark.xfail
+    # NB: laplacian downscales ALL dimensions, not just YX
+    # so we SKIP the check on shape
     def test_laplacian(self, shape):
         data = self.create_data(shape)
         scaler = Scaler()
         downscaled = scaler.laplacian(data)
-        self.check_downscaled(downscaled, shape)
+        self.check_downscaled(downscaled, data, scale_factor=None)
 
     def test_local_mean(self, shape):
         data = self.create_data(shape)
         scaler = Scaler()
         downscaled = scaler.local_mean(data)
-        self.check_downscaled(downscaled, shape)
+        self.check_downscaled(downscaled, data)
 
     def test_local_mean_via_method(self, shape):
         data = self.create_data(shape)
@@ -91,7 +92,7 @@ class TestScaler:
 
         scaler.method = "local_mean"
         downscaled = scaler.func(data)
-        self.check_downscaled(downscaled, shape)
+        self.check_downscaled(downscaled, data)
 
         assert (
             np.sum(
@@ -108,7 +109,7 @@ class TestScaler:
         data = self.create_data(shape)
         scaler = Scaler()
         downscaled = scaler.zoom(data)
-        self.check_downscaled(downscaled, shape)
+        self.check_downscaled(downscaled, data)
 
     def test_scale_dask(self, shape):
         data = self.create_data(shape)


### PR DESCRIPTION
Fixes #495 

The gaussian and laplacian scaler functions don't preserve dtype - see issue above.

I looked at tests and there's 2 issues...

 - The check_downscaled function https://github.com/ome/ome-zarr-py/blob/b49986e420dbc306aa3d9d994b3c9a7156151874/tests/test_scaler.py#L29 only checks that various levels of the pyramid have the same dype as the new 0 level of the same pyramid - but this is NOT the same as the input dtype. In the bug above, ALL levels of the pyramid were `float64` when the input was int16 - Fixed this test in the 2nd commit below.

 - The tests https://github.com/ome/ome-zarr-py/blob/b49986e420dbc306aa3d9d994b3c9a7156151874/tests/test_scaler.py#L74 and https://github.com/ome/ome-zarr-py/blob/b49986e420dbc306aa3d9d994b3c9a7156151874/tests/test_scaler.py#L66 were marked as "fail" because the test asserts that pyramids ONLY get downsampled in X and Y, whereas both these methods downsample in ALL dimensions. - I removed the `xfail` flag. These 2 tests check dtype now, but not shape.