### PR TITLE
Fix ruff warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
           - --autofix
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.2
+    rev: v0.14.2
     hooks:
     - id: ruff-check
       args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ ignore = [
     "PLR09",   # too-many-...
     "PLR2004", # magic-value-comparison
     "PLW1641", # eq-without-hash  # FIXME
-    "UP038",   # non-pep604-isinstance
     "RUF005",  # collection-literal-concatenation
 ]
 


### PR DESCRIPTION
```
warning: The following rules have been removed and ignoring them has no effect:
    - UP038
```