### PR TITLE
release dask version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">3.10"
 
 dependencies = [
     "numpy",
-    "dask==2026.1.1",
+    "dask>=2025.12.0, <=2026.1.1",
     "zarr>=3.0.0",
     "fsspec[s3]>=0.8,!=2021.07.0,!=2023.9.0",
     "aiohttp",


### PR DESCRIPTION
Title. Releases dask version requirements to these possible versions:

- `2026.1.0`
- `2026.1.1`
- `2025.12.0`