### PR TITLE
Streamline writing

### DIFF
--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -9,7 +9,7 @@ import warnings
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import dask.array as da
 import numpy as np
@@ -402,13 +402,15 @@ def _build_pyramid(
     if isinstance(scale_factors, list | tuple) and all(
         isinstance(s, int) for s in scale_factors
     ):
-        scales = []
+        scales: list[dict[str, int]] = []
         for i in range(1, len(scale_factors) + 1):
             scale = {d: 2**i if d in SPATIAL_DIMS else 1 for d in dims}
             if "z" in dims:
                 scale["z"] = 1
             scales.append(scale)
         scale_factors = scales
+    else:
+        scale_factors = cast(list[dict[str, int]], scale_factors)
 
     images: list[da.Array] = [image]
 

--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -404,6 +404,12 @@ def _build_pyramid(
     else:
         scale_factors = cast(list[dict[str, int]], scale_factors)
 
+    # Make sure scale_factors are represented in the same order as dims
+    # and that dimensions that haven't been explicitly passed via the `scale_factors` argument
+    # are set to a default of 1 (i.e. not downsampled)
+    for i, level in enumerate(scale_factors):
+        scale_factors[i] = {d: level.get(d, 1) for d in dims}
+
     images: list[da.Array] = [image]
 
     for idx, factor in enumerate(scale_factors):

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, List, TypeAlias, cast
+from typing import Any, TypeAlias
 
 import dask
 import dask.array as da
@@ -317,11 +317,9 @@ def write_multiscale(
     axes = _get_valid_axes(dims, axes, fmt)
 
     pyramid = [
-        da.from_array(level)
-        if not isinstance(level, da.Array)
-        else level
+        da.from_array(level) if not isinstance(level, da.Array) else level
         for level in pyramid
-        ]
+    ]
     dask_delayed = _write_pyramid_to_zarr(
         pyramid,
         group,
@@ -573,9 +571,7 @@ def write_image(
         The 'scaler' argument is deprecated and will be removed in version 0.13.0.
         Please use the 'scale_factors' argument instead.
         """
-        scale_factors = tuple(
-            2**i for i in range(1, scaler.max_layer + 1)
-            )
+        scale_factors = tuple(2**i for i in range(1, scaler.max_layer + 1))
         warnings.warn(msg, DeprecationWarning)
 
     if method is None:
@@ -599,7 +595,6 @@ def write_image(
 
     if method is None:
         method = Methods.RESIZE
-
 
     # Create the pyramid
     pyramid = _build_pyramid(
@@ -643,7 +638,7 @@ def _resolve_storage_options(
 
 
 def _write_pyramid_to_zarr(
-    pyramid: List[da.Array],
+    pyramid: list[da.Array],
     group: zarr.Group | str,
     fmt: Format | None = None,
     axes: AxesType = None,
@@ -902,12 +897,10 @@ def write_multiscale_labels(
 
     # Ensure pyramid is all dask arrays
     pyramid = [
-        da.from_array(level)
-        if not isinstance(level, da.Array)
-        else level
+        da.from_array(level) if not isinstance(level, da.Array) else level
         for level in pyramid
     ]
-    
+
     dask_delayed_jobs = _write_pyramid_to_zarr(
         pyramid,
         sub_group,
@@ -1003,9 +996,7 @@ def write_labels(
         The 'scaler' argument is deprecated and will be removed in version 0.13.0.
         Please use the 'scale_factors' argument instead.
         """
-        scale_factors = tuple(
-            2**i for i in range(1, scaler.max_layer + 1)
-            )
+        scale_factors = tuple(2**i for i in range(1, scaler.max_layer + 1))
         warnings.warn(msg, DeprecationWarning)
 
     group, fmt = check_group_fmt(group, fmt)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -681,13 +681,6 @@ def _write_pyramid_to_zarr(
 
     group, fmt = check_group_fmt(group, fmt)
 
-    if scaler is not None:
-        msg = """
-        The 'scaler' argument is deprecated and will be removed in version 0.13.0.
-        Please use the 'scale_factors' argument instead.
-        """
-        warnings.warn(msg, DeprecationWarning)
-
     # Set up common kwargs for da.to_zarr
     # zarr_array_kwargs needs dask 2025.12.0 or later
     zarr_array_kwargs: dict[str, Any] = {}

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -599,7 +599,7 @@ def write_image(
 
     # parse scale_factors
     # if scaler is provided, we ignore scale_factors and infer the scale_factors
-    # from the Scaler attrbutes instead.
+    # from the Scaler attributes instead.
     if scaler is not None:
         msg = """
         The 'scaler' argument is deprecated and will be removed in version 0.13.0.

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, TypeAlias, cast
+from typing import Any, TypeAlias
 
 import dask
 import dask.array as da
@@ -1029,7 +1029,7 @@ def write_labels(
 
     axes = _get_valid_axes(len(labels.shape), axes, fmt)
     dims = _extract_dims_from_axes(axes)
-    
+
     if scaler is not None:
         msg = """
         The 'scaler' argument is deprecated and will be removed in version 0.13.0.

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -640,7 +640,7 @@ def _resolve_storage_options(
 def _write_pyramid_to_zarr(
     pyramid: list[da.Array],
     group: zarr.Group | str,
-    fmt: Format | None = None,
+    fmt: Format,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -639,7 +639,7 @@ def _resolve_storage_options(
 
 def _write_pyramid_to_zarr(
     pyramid: list[da.Array],
-    group: zarr.Group | str,
+    group: zarr.Group,
     fmt: Format,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, TypeAlias, cast
+from typing import Any, List, TypeAlias, cast
 
 import dask
 import dask.array as da
@@ -315,84 +315,24 @@ def write_multiscale(
     group, fmt = check_group_fmt(group, fmt)
     dims = len(pyramid[0].shape)
     axes = _get_valid_axes(dims, axes, fmt)
-    dask_delayed = []
 
-    datasets: list[dict] = []
-    for path, data in enumerate(pyramid):
-        options = _resolve_storage_options(storage_options, path)
-
-        # ensure that the chunk dimensions match the image dimensions
-        # (which might have been changed for versions 0.1 or 0.2)
-        # if chunks are explicitly set in the storage options
-        chunks_opt = options.pop("chunks", None)
-        if chunks_opt is not None:
-            chunks_opt = _retuple(chunks_opt, data.shape)
-            options["chunks"] = chunks_opt
-
-        options["chunk_key_encoding"] = fmt.chunk_key_encoding
-        zarr_format = fmt.zarr_format
-        compressor = options.pop("compressor", None)
-        if zarr_format == 2:
-            # by default we use Blosc with zstd compression
-            # Don't need this for zarr v3 as it has a default compressor
-            if compressor is None:
-                compressor = _blosc_compressor()
-            options["compressor"] = compressor
-        else:
-            if compressor is not None:
-                options["compressors"] = [compressor]
-            if axes is not None:
-                # the array zarr.json also contains axes names
-                # TODO: check if this is written by da.to_zarr
-                options["dimension_names"] = [
-                    axis["name"] for axis in axes if isinstance(axis, dict)
-                ]
-        if zarr_format == 2:
-            # options["dimension_separator"] = "/"
-            del options["chunk_key_encoding"]
-
-        level_image = data
-
-        # handle any 'chunks' option from storage_options
-        if not isinstance(data, da.Array):
-            level_image = da.from_array(data)
-        if chunks_opt is not None:
-            level_image = level_image.rechunk(chunks=chunks_opt)
-        da_delayed = da.to_zarr(
-            arr=level_image,
-            url=group.store,
-            component=str(Path(group.path, str(path))),
-            compute=compute,
-            zarr_format=zarr_format,
-            zarr_array_kwargs=options,
-        )
-
-        if not compute:
-            dask_delayed.append(da_delayed)
-
-        datasets.append({"path": str(path)})
-
-    if coordinate_transformations is None:
-        shapes = [data.shape for data in pyramid]
-        coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
-
-    # we validate again later, but this catches length mismatch before zip(datasets...)
-    fmt.validate_coordinate_transformations(
-        dims, len(pyramid), coordinate_transformations
-    )
-    if coordinate_transformations is not None:
-        for dataset, transform in zip(datasets, coordinate_transformations):
-            dataset["coordinateTransformations"] = transform
-
-    if len(dask_delayed) > 0 and not compute:
-        write_multiscales_metadata_delayed = dask.delayed(write_multiscales_metadata)
-        return dask_delayed + [
-            bind(write_multiscales_metadata_delayed, dask_delayed)(
-                group, datasets, fmt, axes, name, **metadata
-            )
+    pyramid = [
+        da.from_array(level)
+        if not isinstance(level, da.Array)
+        else level
+        for level in pyramid
         ]
-    else:
-        write_multiscales_metadata(group, datasets, fmt, axes, name, **metadata)
+    dask_delayed = _write_pyramid_to_zarr(
+        pyramid,
+        group,
+        fmt=fmt,
+        axes=axes,
+        coordinate_transformations=coordinate_transformations,
+        storage_options=storage_options,
+        name=name,
+        compute=compute,
+        **metadata,
+    )
 
     return dask_delayed
 
@@ -626,11 +566,16 @@ def write_image(
     The `scaler` argument is deprecated and will be removed in a future version. Use
     `scale_factors` and `method` for all new code.
     """
+    from .scale import _build_pyramid
+
     if scaler is not None:
         msg = """
         The 'scaler' argument is deprecated and will be removed in version 0.13.0.
         Please use the 'scale_factors' argument instead.
         """
+        scale_factors = tuple(
+            2**i for i in range(1, scaler.max_layer + 1)
+            )
         warnings.warn(msg, DeprecationWarning)
 
     if method is None:
@@ -649,17 +594,29 @@ def write_image(
         # TODO: Better way to get chunksize in type-safe manner?
         axes = ["t", "c", "z", "y", "x"]
 
+    axes = _get_valid_axes(len(image.shape), axes, fmt)
+    dims = _extract_dims_from_axes(axes)
+
+    if method is None:
+        method = Methods.RESIZE
+
+
+    # Create the pyramid
+    pyramid = _build_pyramid(
+        image,
+        list(scale_factors),
+        dims=dims,
+        method=method,
+    )
+
     name = metadata.pop("name", None)
     name = str(name) if name is not None else None
 
     dask_delayed_jobs = []
 
-    dask_delayed_jobs = _write_dask_image(
-        cast(da.Array, image),
+    dask_delayed_jobs = _write_pyramid_to_zarr(
+        pyramid,
         group,
-        scale_factors,
-        method,
-        scaler,
         fmt=fmt,
         axes=axes,
         coordinate_transformations=coordinate_transformations,
@@ -685,12 +642,9 @@ def _resolve_storage_options(
     return options
 
 
-def _write_dask_image(
-    image: da.Array,
+def _write_pyramid_to_zarr(
+    pyramid: List[da.Array],
     group: zarr.Group | str,
-    scale_factors: tuple[int, ...] = (2, 4, 8, 16),
-    method: Methods | None = Methods.RESIZE,
-    scaler: Scaler | None = None,
     fmt: Format | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
@@ -699,26 +653,6 @@ def _write_dask_image(
     compute: bool | None = True,
     **metadata: str | JSONDict | list[JSONDict],
 ) -> list:
-    from .scale import _build_pyramid
-
-    group, fmt = check_group_fmt(group, fmt)
-
-    if scaler is not None:
-        msg = """
-        The 'scaler' argument is deprecated and will be removed in version 0.13.0.
-        Please use the 'scale_factors' argument instead.
-        """
-        warnings.warn(msg, DeprecationWarning)
-
-    axes = _get_valid_axes(len(image.shape), axes, fmt)
-    dims = _extract_dims_from_axes(axes)
-
-    # for path, data in enumerate(pyramid):
-    if scaler is not None:
-        scale_factors = tuple(2**i for i in range(1, scaler.max_layer + 1))
-
-    if method is None:
-        method = Methods.RESIZE
 
     # Set up common kwargs for da.to_zarr
     # zarr_array_kwargs needs dask 2025.12.0 or later
@@ -743,14 +677,6 @@ def _write_dask_image(
             # ValueError: compressor cannot be used for arrays with zarr_format 3.
             # Use bytes-to-bytes codecs instead.
             zarr_array_kwargs["compressor"] = options.pop("compressor")
-
-    # Create the pyramid
-    pyramid = _build_pyramid(
-        image,
-        list(scale_factors),
-        dims=dims,
-        method=method,
-    )
 
     shapes = []
     datasets: list[dict] = []
@@ -810,7 +736,7 @@ def _write_dask_image(
 
     # we validate again later, but this catches length mismatch before zip(datasets...)
     fmt.validate_coordinate_transformations(
-        len(image.shape), len(datasets), coordinate_transformations
+        len(pyramid[0].shape), len(datasets), coordinate_transformations
     )
     if coordinate_transformations is not None:
         for dataset, transform in zip(datasets, coordinate_transformations):
@@ -973,7 +899,16 @@ def write_multiscale_labels(
     """
     group, fmt = check_group_fmt(group, fmt)
     sub_group = group.require_group(f"labels/{name}")
-    dask_delayed_jobs = write_multiscale(
+
+    # Ensure pyramid is all dask arrays
+    pyramid = [
+        da.from_array(level)
+        if not isinstance(level, da.Array)
+        else level
+        for level in pyramid
+    ]
+    
+    dask_delayed_jobs = _write_pyramid_to_zarr(
         pyramid,
         sub_group,
         fmt=fmt,
@@ -1061,11 +996,16 @@ def write_labels(
     `scale_factors` and `method` for all new code. Labels downsampling should avoid interpolation;
     nearest-neighbor is recommended.
     """
+    from .scale import _build_pyramid
+
     if scaler is not None:
         msg = """
         The 'scaler' argument is deprecated and will be removed in version 0.13.0.
         Please use the 'scale_factors' argument instead.
         """
+        scale_factors = tuple(
+            2**i for i in range(1, scaler.max_layer + 1)
+            )
         warnings.warn(msg, DeprecationWarning)
 
     group, fmt = check_group_fmt(group, fmt)
@@ -1077,22 +1017,27 @@ def write_labels(
     if not isinstance(labels, da.Array):
         labels = da.from_array(labels)
 
+    axes = _get_valid_axes(len(labels.shape), axes, fmt)
+    dims = _extract_dims_from_axes(axes)
+    pyramid = _build_pyramid(
+        labels,
+        list(scale_factors),
+        dims=dims,
+        method=method,
+    )
+
     # for 0.1 and 0.2 we need to ensure 5D shape
     if type(fmt) in (FormatV01, FormatV02):
         while len(labels.shape) < 5:
             labels = labels[None, :]
 
-        # TODO: Better way to get chunksize in type-safe manner?
         axes = ["t", "c", "z", "y", "x"]
 
     dask_delayed_jobs = []
 
-    dask_delayed_jobs = _write_dask_image(
-        cast(da.Array, labels),
+    dask_delayed_jobs = _write_pyramid_to_zarr(
+        pyramid,
         sub_group,
-        scale_factors,
-        method,
-        scaler,
         fmt=fmt,
         axes=axes,
         coordinate_transformations=coordinate_transformations,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -602,16 +602,35 @@ def write_image(
     # parse scale_factors
     # if scaler is provided, we ignore scale_factors and infer the scale_factors
     # from the Scaler attributes instead.
+    # for path, data in enumerate(pyramid):
     if scaler is not None:
         msg = """
-        The 'scaler' argument is deprecated and will be removed in version 0.13.0.
-        Please use the 'scale_factors' argument instead.
-        """
+            The 'scaler' argument is deprecated and will be removed in a future version.
+            Please use the 'scale_factors' argument instead.
+            """
+        warnings.warn(msg, DeprecationWarning)
+
         scale_factors = [
             {d: 2**i if d in SPATIAL_DIMS else 1 for d in dims}
             for i in range(1, scaler.max_layer + 1)
         ]
-        warnings.warn(msg, DeprecationWarning)
+        if scaler.method == "local_mean":
+            method = Methods.LOCAL_MEAN
+        elif scaler.method == "nearest":
+            method = Methods.NEAREST
+        elif scaler.method == "resize_image":
+            method = Methods.RESIZE
+        elif scaler.method == "laplacian":
+            method = Methods.RESIZE
+            warnings.warn(
+                "Laplacian downsampling is not supported anymore."
+                "Falling back to `resize`",
+                UserWarning,
+            )
+        elif scaler.method == "zoom":
+            method = Methods.ZOOM
+        else:
+            method = Methods.RESIZE
 
     if method is None:
         method = Methods.RESIZE


### PR DESCRIPTION
Fixes #530 
Built on #516 

This PR consolidates the writing logic_
- pyramid serialization with `da.to_zarr`
- metadata generation
- metadata serialization

into a single shared function (`_write_pyramid_to_zarr`). Previously, this function was duplicated in the `_write_dask_image` and `write_multiscales` functions. With this change, all of the following functions:

- `write_image`
- `write_multiscales`
- `write_labels`
- `write_multiscale_labels`

become just slightly different entrypoints into the same shared functionality. This is going to make implementations of new ome-zarr versions much easier.

cc @melonora @will-moore @lorenzocerrone