### PR TITLE
PEP 735 compliance: dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ authors = [
 [project.entry-points."console_scripts"]
 ome_zarr = "ome_zarr.cli:main"
 
-[project.optional-dependencies]
+[dependency-groups]
 tests = [
     "pytest",
 ]


### PR DESCRIPTION
Only for development and build time dependencies, not run time depdendencies that are meant to be published with the package.