### PR TITLE
refactor: write scales to zarr group s<idx>

### DIFF
--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -425,7 +425,7 @@ class Well(Spec):
                 # handle e.g. 2x2 grid with only 3 images/fields
                 if field_index < len(image_paths):
                     image_path = image_paths[field_index]
-                    path = f"{image_path}/{level}"
+                    path = f"{image_path}/s{level}"
                     data = self.zarr.load(path)
             except ValueError:
                 LOGGER.error("Failed to load %s", path)
@@ -521,7 +521,7 @@ class Plate(Spec):
     def get_tile_path(self, level: int, row: int, col: int) -> str:
         return (
             f"{self.row_names[row]}/"
-            f"{self.col_names[col]}/{self.first_field_path}/{level}"
+            f"{self.col_names[col]}/{self.first_field_path}/s{level}"
         )
 
     def get_stitched_grid(self, level: int, tile_shape: tuple) -> da.core.Array:

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -410,6 +410,9 @@ class Well(Spec):
         # shapes etc.
         image_zarr = self.zarr.create(image_paths[0])
         image_node = Node(image_zarr, node)
+        self.ds_paths = [
+            d["path"] for d in image_zarr.root_attrs["multiscales"][0]["datasets"]
+        ]
         x_index = len(image_node.metadata["axes"]) - 1
         y_index = len(image_node.metadata["axes"]) - 2
         self.numpy_type = image_node.data[0].dtype
@@ -425,7 +428,7 @@ class Well(Spec):
                 # handle e.g. 2x2 grid with only 3 images/fields
                 if field_index < len(image_paths):
                     image_path = image_paths[field_index]
-                    path = f"{image_path}/s{level}"
+                    path = f"{image_path}/{self.ds_paths[level]}"
                     data = self.zarr.load(path)
             except ValueError:
                 LOGGER.error("Failed to load %s", path)
@@ -495,6 +498,11 @@ class Plate(Spec):
         if well_spec is None:
             raise Exception("Could not find first well")
         self.first_field_path = well_spec.well_data["images"][0]["path"]
+        img0 = self.zarr.create(f"{self.well_paths[0]}/{self.first_field_path}")
+        self.img_paths = [
+            d["path"] for d in img0.root_attrs["multiscales"][0]["datasets"]
+        ]
+
         self.numpy_type = well_spec.numpy_type
 
         LOGGER.debug("img_pyramid_shapes: %s", well_spec.img_pyramid_shapes)
@@ -521,7 +529,7 @@ class Plate(Spec):
     def get_tile_path(self, level: int, row: int, col: int) -> str:
         return (
             f"{self.row_names[row]}/"
-            f"{self.col_names[col]}/{self.first_field_path}/s{level}"
+            f"{self.col_names[col]}/{self.first_field_path}/{self.img_paths[level]}"
         )
 
     def get_stitched_grid(self, level: int, tile_shape: tuple) -> da.core.Array:

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -754,12 +754,12 @@ def _write_pyramid_to_zarr(
             da.to_zarr(
                 arr=level_image,
                 url=group.store,
-                component=str(Path(group.path, f"scale{idx}")),
+                component=str(Path(group.path, f"s{idx}")),
                 compute=False,
                 zarr_array_kwargs=zarr_array_kwargs,
             )
         )
-        datasets.append({"path": f"scale{idx}"})
+        datasets.append({"path": f"s{idx}"})
 
     # Computing delayed jobs if necessary
     if compute:

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -754,12 +754,12 @@ def _write_pyramid_to_zarr(
             da.to_zarr(
                 arr=level_image,
                 url=group.store,
-                component=str(Path(group.path, str(idx))),
+                component=str(Path(group.path, f"scale{idx}")),
                 compute=False,
                 zarr_array_kwargs=zarr_array_kwargs,
             )
         )
-        datasets.append({"path": str(idx)})
+        datasets.append({"path": f"scale{idx}"})
 
     # Computing delayed jobs if necessary
     if compute:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,37 +84,16 @@ class TestCli:
         main(["info", f"{out}/{basename}"])
 
         if fmt is not None and fmt.zarr_format == 2:
-            assert directory_items(Path(out) / basename) == [
-                Path(".zattrs"),
-                Path(".zgroup"),
-                Path("0"),
-                Path("1"),
-                Path("2"),
-                Path("3"),
-                Path("4"),
-                Path("labels"),
-            ]
-            assert directory_items(Path(out) / basename / "1") == [
-                Path(".zarray"),
-                Path(".zattrs"),  # empty '{}'
-                Path("0"),
-                Path("1"),
-                Path("2"),
-            ]
+            for item in [".zattrs", ".zgroup", "labels", "s0", "s1", "s2", "s3", "s4"]:
+                assert (Path(out) / basename / item).exists()
+
+            for item in [".zarray", ".zattrs", "0", "1", "2"]:
+                assert (Path(out) / basename / "s1" / item).exists()
         else:
-            assert directory_items(Path(out) / basename) == [
-                Path("0"),
-                Path("1"),
-                Path("2"),
-                Path("3"),
-                Path("4"),
-                Path("labels"),
-                Path("zarr.json"),
-            ]
-            assert directory_items(Path(out) / basename / "1") == [
-                Path("c"),
-                Path("zarr.json"),
-            ]
+            for item in ["labels", "s0", "s1", "s2", "s3", "s4", "zarr.json"]:
+                assert (Path(out) / basename / item).exists()
+            for item in ["c", "zarr.json"]:
+                assert (Path(out) / basename / "s1" / item).exists()
 
     def test_s3_info(self, s3_address):
         main(["info", s3_address])

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -8,7 +8,7 @@ from ome_zarr.utils import download, info
 
 
 def log_strings(idx, c, y, x, cc, cy, cx, dtype):
-    yield f"resolution: {idx}"
+    yield f"resolution: s{idx}"
     yield f" - shape ('c', 'y', 'x') = ({c}, {y}, {x})"
     yield f" - chunks =  ['{cc}', '{cx}', '{cy}']"
     yield f" - dtype = {dtype}"

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -155,6 +155,8 @@ class TestHCSReader:
         # if we compute(), expect to get numpy array
         result = pyramid[0].compute()
         assert isinstance(result, np.ndarray)
+        print("result.max()", result.max())
+        assert result.max() > 0, "Expected non-zero values in the array"
 
         # Get the plate node's array. It should be fused from the first field of all
         # well arrays (which in this test are non-zero), with zero values for wells
@@ -174,3 +176,4 @@ class TestHCSReader:
         assert isinstance(pyramid[0], da.Array)
         result = pyramid[0].compute()
         assert isinstance(result, np.ndarray)
+        assert result.max() > 0, "Expected non-zero values in the array"

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -215,7 +215,7 @@ class TestScaler:
 
         # read back the pyramid to check it was written correctly
         pyramid = [
-            da.from_array(zarr.open_group(str(tmpdir), mode="r")[f"{i}"])
+            da.from_array(zarr.open_group(str(tmpdir), mode="r")[f"s{i}"])
             for i in range(len(scale_factors) + 1)
         ]
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -352,8 +352,8 @@ class TestWriter:
                 # if shape smaller than chunk, dask writer uses chunk == shape
                 # so we only compare larger resolutions
                 assert filecmp.cmp(
-                    f"{grp_path}/temp/to_dask/{level}/{zarr_array}",
-                    f"{grp_path}/{level}/{zarr_array}",
+                    f"{grp_path}/temp/to_dask/scale{level}/{zarr_array}",
+                    f"{grp_path}/scale{level}/{zarr_array}",
                     shallow=False,
                 )
 
@@ -422,7 +422,7 @@ class TestWriter:
             storage_options={"compressor": compressor},
         )
         group = zarr.open(f"{path}")
-        for ds in ["0", "1"]:
+        for ds in ["scale0", "scale1"]:
             assert len(group[ds].info._compressors) > 0
             comp = group[ds].info._compressors[0]
             if format_version().zarr_format == 3:
@@ -486,7 +486,7 @@ class TestWriter:
 
         # check chunk: multiscale level 0, 4D chunk at (0, 0, 0, 0)
         c = ""
-        for ds in ["0", "1"]:
+        for ds in ["scale0", "scale1"]:
             if format_version().zarr_format == 3:
                 assert (path / "zarr.json").exists()
                 assert (path / ds / "zarr.json").exists()
@@ -511,7 +511,7 @@ class TestWriter:
                     "shuffle": 1,
                 }
 
-        chunk_size = (path / f"0/{c}0/0/0/0").stat().st_size
+        chunk_size = (path / f"scale0/{c}0/0/0/0").stat().st_size
         assert chunk_size < 4e6
 
     @pytest.mark.parametrize(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -352,8 +352,8 @@ class TestWriter:
                 # if shape smaller than chunk, dask writer uses chunk == shape
                 # so we only compare larger resolutions
                 assert filecmp.cmp(
-                    f"{grp_path}/temp/to_dask/scale{level}/{zarr_array}",
-                    f"{grp_path}/scale{level}/{zarr_array}",
+                    f"{grp_path}/temp/to_dask/s{level}/{zarr_array}",
+                    f"{grp_path}/s{level}/{zarr_array}",
                     shallow=False,
                 )
 
@@ -422,7 +422,7 @@ class TestWriter:
             storage_options={"compressor": compressor},
         )
         group = zarr.open(f"{path}")
-        for ds in ["scale0", "scale1"]:
+        for ds in ["s0", "s1"]:
             assert len(group[ds].info._compressors) > 0
             comp = group[ds].info._compressors[0]
             if format_version().zarr_format == 3:
@@ -486,7 +486,7 @@ class TestWriter:
 
         # check chunk: multiscale level 0, 4D chunk at (0, 0, 0, 0)
         c = ""
-        for ds in ["scale0", "scale1"]:
+        for ds in ["s0", "s1"]:
             if format_version().zarr_format == 3:
                 assert (path / "zarr.json").exists()
                 assert (path / ds / "zarr.json").exists()
@@ -511,7 +511,7 @@ class TestWriter:
                     "shuffle": 1,
                 }
 
-        chunk_size = (path / f"scale0/{c}0/0/0/0").stat().st_size
+        chunk_size = (path / f"s0/{c}0/0/0/0").stat().st_size
         assert chunk_size < 4e6
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Hi @will-moore ,

small refactoring PR to change the names of the zarr groups to which the multiscales are written from `0, 1, 2, ...` to `s0, s1, s2, ...`.