### PR TITLE
feat: add `scale` argument to entrypoints

### DIFF
--- a/docs/source/basic/write_image.ipynb
+++ b/docs/source/basic/write_image.ipynb
@@ -28,7 +28,18 @@
           "shell.execute_reply": "2026-04-21T14:22:47.852515Z"
         }
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[]"
+            ]
+          },
+          "execution_count": 2,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "import numpy as np\n",
         "\n",
@@ -41,7 +52,10 @@
         "rng = np.random.default_rng(0)\n",
         "data = rng.poisson(lam=10, size=(size_z, size_xy, size_xy)).astype(np.uint8)\n",
         "\n",
-        "write_image(data, path, axes=\"zyx\")"
+        "write_image(\n",
+        "    data, path, axes=\"zyx\",scale={\"z\": 1.0, \"y\": 0.5, \"x\": 0.5},\n",
+        "    axes_units={\"z\": \"micrometer\", \"y\": \"micrometer\", \"x\": \"micrometer\"},\n",
+        "    )"
       ]
     },
     {
@@ -84,12 +98,6 @@
       "source": [
         "To view the image, see tutorial on [viewing images](basic:view_images)."
       ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1f8a602d",
-      "metadata": {},
-      "source": []
     }
   ],
   "metadata": {
@@ -108,7 +116,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.13.13"
+      "version": "3.12.12"
     }
   },
   "nbformat": 4,

--- a/ome_zarr/axes.py
+++ b/ome_zarr/axes.py
@@ -1,16 +1,72 @@
 """Axes class for validating and transforming axes"""
 
+import warnings
 from typing import Any
 
 from .format import CurrentFormat, Format
 
 KNOWN_AXES = {"x": "space", "y": "space", "z": "space", "c": "channel", "t": "time"}
+KNOWN_SPATIAL_UNITS = [
+    "angstrom",
+    "attometer",
+    "femtometer",
+    "picometer",
+    "nanometer",
+    "millimeter",
+    "micrometer",
+    "centimeter",
+    "decimeter",
+    "meter",
+    "kilometer",
+    "megameter",
+    "hectometer",
+    "gigameter",
+    "terameter",
+    "petameter",
+    "exameter",
+    "inch",
+    "foot",
+    "mile",
+    "yard",
+    "parsec",
+    "yoctometer",
+    "yottameter",
+    "zeptometer",
+    "zettameter",
+]
+
+KNOWN_TEMPORAL_UNITS = [
+    "attosecond",
+    "centisecond",
+    "day",
+    "decisecond",
+    "exasecond",
+    "femtosecond",
+    "gigasecond",
+    "hectosecond",
+    "hour",
+    "kilosecond",
+    "megasecond",
+    "microsecond",
+    "millisecond",
+    "minute",
+    "nanosecond",
+    "petasecond",
+    "picosecond",
+    "second",
+    "terasecond",
+    "yoctosecond",
+    "yottasecond",
+    "zeptosecond",
+    "zettasecond",
+]
 
 
 class Axes:
     def __init__(
         self,
         axes: list[str] | list[dict[str, str]],
+        axes_units: dict[str, str] | None = None,
         fmt: Format = CurrentFormat(),
     ) -> None:
         """
@@ -23,6 +79,18 @@ class Axes:
         elif fmt.version in ("0.1", "0.2"):
             # strictly 5D
             self.axes = self._axes_to_dicts(["t", "c", "z", "y", "x"])
+
+        for ax in self.axes:
+            if axes_units and ax["name"] in axes_units:
+                ax["unit"] = axes_units[ax["name"]]
+                if ax.get("type") == "space" and ax["unit"] not in KNOWN_SPATIAL_UNITS:
+                    warnings.warn(
+                        f"Unit {ax['unit']} for axis {ax['name']} is not a known spatial unit"
+                    )
+                if ax.get("type") == "time" and ax["unit"] not in KNOWN_TEMPORAL_UNITS:
+                    warnings.warn(
+                        f"Unit {ax['unit']} for axis {ax['name']} is not a known temporal unit"
+                    )
         self.fmt = fmt
         self.validate()
 

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -282,7 +282,7 @@ class Multiscales(Spec):
         axes = multiscales[0].get("axes")
         fmt = format_from_version(version)
         # Raises ValueError if not valid
-        axes_obj = Axes(axes, fmt)
+        axes_obj = Axes(axes, fmt=fmt)
         node.metadata["axes"] = axes_obj.to_list()
         # This will get overwritten by 'omero' metadata if present
         node.metadata["name"] = multiscales[0].get("name")

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -264,14 +264,14 @@ def check_format(
 def write_multiscale(
     pyramid: ListOfArrayLike,
     group: zarr.Group,
-    scale: dict[str, float] | None = None,
     fmt: Format | None = None,
     axes: AxesType = None,
-    axes_units: dict[str, str] | None = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     name: str | None = None,
     compute: bool | None = True,
+    scale: dict[str, float] | None = None,
+    axes_units: dict[str, str] | None = None,
     **metadata: str | JSONDict | list[JSONDict],
 ) -> list:
     """
@@ -283,11 +283,6 @@ def write_multiscale(
         5-dimensional with dimensions ordered (t, c, z, y, x)
     :type group: :class:`zarr.Group`
     :param group: The group within the zarr store to store the data in
-    :type scale: dict of str to float, optional
-    :param scale:
-        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
-        The pixel sizes for every resolution level are calculated directly from the defined `scale` and
-        `scale_factors` for each level.
     :type chunks: int or tuple of ints, optional
     :param chunks:
         The size of the saved chunks to store the image.
@@ -303,9 +298,6 @@ def write_multiscale(
     :param axes:
         List of axes dicts, or names. Not needed for v0.1 or v0.2 or if 2D. Otherwise
         this must be provided
-    :param axes_units:
-        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     :type coordinate_transformations: 2Dlist of dict, optional
     :param coordinate_transformations:
         List of transformations for each path.
@@ -331,6 +323,15 @@ def write_multiscale(
     :param compute:
         If true compute immediately otherwise a list of :class:`dask.delayed.Delayed`
         is returned.
+    :type scale: dict of str to float, optional
+    :param scale:
+        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
+        For each additional resolution level, the pixel sizes are derived from this
+        base `scale` and the relative shapes of the arrays provided in `pyramid`.
+    :type axes_units: dict of str to str, optional
+    :param axes_units:
+        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     :return:
         Empty list if the compute flag is True, otherwise it returns a list of
         :class:`dask.delayed.Delayed` representing the value to be computed by
@@ -340,8 +341,21 @@ def write_multiscale(
     dims = len(pyramid[0].shape)
     axes = _get_valid_axes(dims, axes, axes_units=axes_units, fmt=fmt)
 
-    if not scale:
+    if scale is None:
         scale = dict.fromkeys(_extract_dims_from_axes(axes), 1.0)
+
+    if coordinate_transformations is not None:
+        msg = (
+            "The 'coordinate_transformations' argument is deprecated and will "
+            "be removed in a future version. Please use the `scale` argument "
+            "to specify the physical pixel size for each dimension instead. "
+            "When `coordinate_transformations` is provided, it takes "
+            "precedence over `scale`, so `scale` is not applied. When "
+            "`coordinate_transformations` is not provided, the pixel sizes "
+            "for every resolution level are calculated from `scale` and "
+            "`scale_factors`."
+        )
+        warnings.warn(msg, DeprecationWarning)
 
     pyramid = [
         da.from_array(level) if not isinstance(level, da.Array) else level
@@ -542,9 +556,7 @@ def write_well_metadata(
 def write_image(
     image: ArrayLike,
     group: zarr.Group | str,
-    scale: dict[str, float] | None = None,
     scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] = (2, 4, 8, 16),
-    axes_units: dict[str, str] | None = None,
     method: Methods | None = Methods.RESIZE,
     scaler: Scaler | None = None,
     fmt: Format | None = None,
@@ -552,6 +564,8 @@ def write_image(
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     compute: bool | None = True,
+    scale: dict[str, float] | None = None,
+    axes_units: dict[str, str] | None = None,
     **metadata: str | JSONDict | list[JSONDict],
 ) -> list:
     """
@@ -565,8 +579,6 @@ def write_image(
         dimensions ordered (t, c, z, y, x). Can be a NumPy or Dask array.
     group : zarr.Group or str
         The zarr group to write the metadata, or a path to create
-    scale : dict of str to float, optional
-        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
     scale_factors : list of int or list of dict, optional
         The downsampling factors for each pyramid level. Default: [2, 4, 8, 16].
         Passing a list of integers (i.e., [2, 4, 8]) will apply the downsampling in all
@@ -575,10 +587,6 @@ def write_image(
         `[{"z": 2, "y": 2, "x": 2}, {"z": 4, "y": 4, "x": 4}, {"z": 8, "y": 8, "x": 8}]`.
         If dimensions are omitted in this dictionary,
         the downsampling factor for that dimension will default to 1.
-    axes_units : dict of str to str, optional
-        The physical units for each dimension,
-        e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     method : ome_zarr.scale.Methods, optional
         Downsampling method to use.
         Available methods are:
@@ -616,6 +624,12 @@ def write_image(
         `None` and no sharding is provided.
     compute : bool, optional
         If True, compute immediately; otherwise, return a list of dask.delayed.Delayed objects.
+    scale : dict of str to float, optional
+        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
+    axes_units : dict of str to str, optional
+        The physical units for each dimension,
+        e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     `**metadata` : dict
         Additional metadata to store.
 
@@ -652,12 +666,16 @@ def write_image(
         scale = dict.fromkeys(dims, 1.0)
 
     if coordinate_transformations is not None:
-        msg = """
-            The 'coordinate_transformations' argument is deprecated and will be removed in a future version.
-            Please use the `scale` argument to specify the physical pixel size for each dimension instead.
-            The pixel sizes for every resolution level are calculated directly from the defined `scale` and
-            `scale_factors` for each level.
-            """
+        msg = (
+            "The 'coordinate_transformations' argument is deprecated and will "
+            "be removed in a future version. Please use the `scale` argument "
+            "to specify the physical pixel size for each dimension instead. "
+            "When `coordinate_transformations` is provided, it takes "
+            "precedence over `scale`, so `scale` is not applied. When "
+            "`coordinate_transformations` is not provided, the pixel sizes "
+            "for every resolution level are calculated from `scale` and "
+            "`scale_factors`."
+        )
         warnings.warn(msg, DeprecationWarning)
 
     # parse scale_factors
@@ -755,9 +773,8 @@ def _write_pyramid_to_zarr(
     _axes = _get_valid_axes(len(pyramid[0].shape), axes, axes_units=axes_units, fmt=fmt)
     dims = _extract_dims_from_axes(_axes)
 
-    # make sure every axis is represented in `scale`;
-    # coerce to 1.0 if not provided
-    # but don't allow missing axes to avoid silent errors
+    # Normalize `scale` so every axis in `dims` is represented.
+    # Missing axes are allowed and default to 1.0.
     scale = {d: scale.get(d, 1.0) for d in dims}
 
     # Set up common kwargs for da.to_zarr
@@ -902,7 +919,15 @@ def _write_pyramid_to_zarr(
         for dataset, transform in zip(datasets, coordinate_transformations):
             dataset["coordinateTransformations"] = transform
 
-    write_multiscales_metadata(group, datasets, fmt, axes, name, **metadata)
+    write_multiscales_metadata(
+        group,
+        datasets=datasets,
+        fmt=fmt,
+        axes=axes,
+        name=name,
+        axes_units=axes_units,
+        **metadata,
+    )
     return delayed
 
 
@@ -997,13 +1022,13 @@ def write_multiscale_labels(
     pyramid: list,
     group: zarr.Group | str,
     name: str,
-    scale: dict[str, float] | None = None,
     fmt: Format | None = None,
     axes: AxesType = None,
-    axes_units: dict[str, str] | None = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     label_metadata: JSONDict | None = None,
+    scale: dict[str, float] | None = None,
+    axes_units: dict[str, str] | None = None,
     compute: bool | None = True,
     **metadata: JSONDict,
 ) -> list:
@@ -1022,11 +1047,6 @@ def write_multiscale_labels(
     :param group: The zarr group or path to write the metadata in.
     :type name: str, optional
     :param name: The name of this labels data.
-    :type scale: dict of str to float, optional
-    :param scale:
-        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
-        The pixel sizes for every resolution level are calculated directly from the defined `scale` and
-        `scale_factors` for each level.
     :type chunks: int or tuple of ints, optional
     :type fmt: :class:`ome_zarr.format.Format`, optional
     :param fmt:
@@ -1036,10 +1056,6 @@ def write_multiscale_labels(
     :param axes:
       The names of the axes. e.g. ["t", "c", "z", "y", "x"].
       Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
-    :type axes_units: dict of str to str, optional
-    :param axes_units:
-        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     :type coordinate_transformations: list of dict
     :param coordinate_transformations:
       For each resolution, we have a List of transformation Dicts (not validated).
@@ -1068,6 +1084,15 @@ def write_multiscale_labels(
     :param compute:
         If true compute immediately otherwise a list of :class:`dask.delayed.Delayed`
         is returned.
+    :type scale: dict of str to float, optional
+    :param scale:
+        The physical pixel size for each dimension at the highest-resolution level,
+        e.g. {"z": 0.1, "y": 0.1, "x": 0.5}. Pixel sizes for lower-resolution
+        levels are inferred from the shapes of the arrays in `pyramid`.
+    :type axes_units: dict of str to str, optional
+    :param axes_units:
+        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     :return:
         Empty list if the compute flag is True, otherwise it returns a list of
         :class:`dask.delayed.Delayed` representing the value to be computed by
@@ -1087,6 +1112,19 @@ def write_multiscale_labels(
             len(pyramid[0].shape), axes, axes_units=axes_units, fmt=fmt
         )
         scale = dict.fromkeys(_extract_dims_from_axes(_axes), 1.0)
+
+    if coordinate_transformations is not None:
+        msg = (
+            "The 'coordinate_transformations' argument is deprecated and will "
+            "be removed in a future version. Please use the `scale` argument "
+            "to specify the physical pixel size for each dimension instead. "
+            "When `coordinate_transformations` is provided, it takes "
+            "precedence over `scale`, so `scale` is not applied. When "
+            "`coordinate_transformations` is not provided, the pixel sizes "
+            "for every resolution level are calculated from `scale` and "
+            "`scale_factors`."
+        )
+        warnings.warn(msg, DeprecationWarning)
 
     dask_delayed_jobs = _write_pyramid_to_zarr(
         pyramid,
@@ -1118,13 +1156,14 @@ def write_labels(
     scale: dict[str, float] | None = None,
     scaler: Scaler | None = Scaler(order=0),
     scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] = (2, 4, 8, 16),
-    axes_units: dict[str, str] | None = None,
     method: Methods = Methods.NEAREST,
     fmt: Format | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     label_metadata: JSONDict | None = None,
+    scale: dict[str, float] | None = None,
+    axes_units: dict[str, str] | None = None,
     compute: bool | None = True,
     **metadata: JSONDict,
 ) -> list:
@@ -1142,7 +1181,7 @@ def write_labels(
         The group within the zarr store to write the metadata in.
     scale: dict of str to float, optional
         The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
-        THe pixel sizes for every resolution level are calculated directly from the defined `scale` and
+        The pixel sizes for every resolution level are calculated directly from the defined `scale` and
         `scale_factors` for each level.
     name : str
         The name of this labels data.
@@ -1172,7 +1211,8 @@ def write_labels(
         Required for version 0.3 or greater.
     coordinate_transformations : list of list of dict, optional
         [DEPRECATED] For each resolution, a list of transformation dicts (not validated). Each list of dicts
-        is added to each dataset in order.
+        is added to each dataset in order. When provided, this metadata takes precedence over the
+        `scale`-derived transformations, so `scale` is ignored.
     storage_options : dict or list of dict, optional
         Options to be passed on to the storage backend. A list must match the number of datasets
         in a multiresolution pyramid. Allows different chunk sizes for each level.
@@ -1192,6 +1232,12 @@ def write_labels(
         Image label metadata. See :meth:`write_label_metadata` for details.
     compute : bool, optional
         If True, compute immediately; otherwise, return a list of dask.delayed.Delayed objects.
+    scale : dict of str to float, optional
+        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
+    axes_units : dict of str to str, optional
+        The physical units for each dimension,
+        e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     `**metadata` : dict
         Additional metadata to store.
 
@@ -1232,6 +1278,19 @@ def write_labels(
             {d: 2 ** i if d in ("y", "x") else 1 for d in dims}
             for i in range(1, scaler.max_layer + 1)
         ]
+        warnings.warn(msg, DeprecationWarning)
+
+    if coordinate_transformations is not None:
+        msg = (
+            "The 'coordinate_transformations' argument is deprecated and will "
+            "be removed in a future version. Please use the `scale` argument "
+            "to specify the physical pixel size for each dimension instead. "
+            "When `coordinate_transformations` is provided, it takes "
+            "precedence over `scale`, so `scale` is not applied. When "
+            "`coordinate_transformations` is not provided, the pixel sizes "
+            "for every resolution level are calculated from `scale` and "
+            "`scale_factors`."
+        )
         warnings.warn(msg, DeprecationWarning)
 
     if method is None:

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -263,6 +263,7 @@ def check_format(
 def write_multiscale(
     pyramid: ListOfArrayLike,
     group: zarr.Group,
+    scale: dict[str, float] | None = None,
     fmt: Format | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
@@ -280,6 +281,11 @@ def write_multiscale(
         5-dimensional with dimensions ordered (t, c, z, y, x)
     :type group: :class:`zarr.Group`
     :param group: The group within the zarr store to store the data in
+    :type scale: dict of str to float, optional
+    :param scale:
+        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
+        The pixel sizes for every resolution level are calculated directly from the defined `scale` and
+        `scale_factors` for each level.
     :type chunks: int or tuple of ints, optional
     :param chunks:
         The size of the saved chunks to store the image.
@@ -329,6 +335,9 @@ def write_multiscale(
     dims = len(pyramid[0].shape)
     axes = _get_valid_axes(dims, axes, fmt)
 
+    if not scale:
+        scale = dict.fromkeys(_extract_dims_from_axes(axes), 1.0)
+
     pyramid = [
         da.from_array(level) if not isinstance(level, da.Array) else level
         for level in pyramid
@@ -337,6 +346,7 @@ def write_multiscale(
         pyramid,
         group,
         fmt=fmt,
+        scale=scale,
         axes=axes,
         coordinate_transformations=coordinate_transformations,
         storage_options=storage_options,
@@ -521,6 +531,7 @@ def write_well_metadata(
 def write_image(
     image: ArrayLike,
     group: zarr.Group | str,
+    scale: dict[str, float] | None = None,
     scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] = (2, 4, 8, 16),
     method: Methods | None = Methods.RESIZE,
     scaler: Scaler | None = None,
@@ -542,6 +553,8 @@ def write_image(
         dimensions ordered (t, c, z, y, x). Can be a NumPy or Dask array.
     group : zarr.Group or str
         The zarr group to write the metadata, or a path to create
+    scale : dict of str to float, optional
+        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
     scale_factors : list of int or list of dict, optional
         The downsampling factors for each pyramid level. Default: [2, 4, 8, 16].
         Passing a list of integers (i.e., [2, 4, 8]) will apply the downsampling in all
@@ -568,8 +581,8 @@ def write_image(
         The names of the axes, e.g. ["t", "c", "z", "y", "x"]. Ignored for versions 0.1 and 0.2.
         Required for version 0.3 or greater.
     coordinate_transformations : list of list of dict, optional
-        For each resolution, a list of transformation dicts (not validated). Each list of dicts
-        is added to each dataset in order.
+        [Deprecated] For each resolution, a list of transformation dicts (not validated).
+        Each list of dicts is added to each dataset in order.
     storage_options : dict or list of dict, optional
         Options to be passed on to the storage backend. A list must match the number of datasets
         in a multiresolution pyramid. Allows different chunk sizes for each level.
@@ -618,6 +631,18 @@ def write_image(
 
     axes = _get_valid_axes(len(image.shape), axes, fmt)
     dims = _extract_dims_from_axes(axes)
+
+    if scale is None:
+        scale = dict.fromkeys(dims, 1.0)
+
+    if coordinate_transformations is not None:
+        msg = """
+            The 'coordinate_transformations' argument is deprecated and will be removed in a future version.
+            Please use the `scale` argument to specify the physical pixel size for each dimension instead.
+            The pixel sizes for every resolution level are calculated directly from the defined `scale` and
+            `scale_factors` for each level.
+            """
+        warnings.warn(msg, DeprecationWarning)
 
     # parse scale_factors
     # if scaler is provided, we ignore scale_factors and infer the scale_factors
@@ -670,6 +695,7 @@ def write_image(
         pyramid,
         group,
         fmt=fmt,
+        scale=scale,
         axes=axes,
         coordinate_transformations=coordinate_transformations,
         storage_options=storage_options,
@@ -698,6 +724,7 @@ def _write_pyramid_to_zarr(
     pyramid: list[da.Array],
     group: zarr.Group,
     fmt: Format,
+    scale: dict[str, float],
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
@@ -707,6 +734,12 @@ def _write_pyramid_to_zarr(
 ) -> list:
 
     group, fmt = check_group_fmt(group, fmt)
+    dims = _extract_dims_from_axes(axes)
+
+    # make sure every axis is represented in `scale`;
+    # coerce to 1.0 if not provided
+    # but don't allow missing axes to avoid silent errors
+    scale = {d: scale.get(d, 1.0) for d in dims}
 
     # Set up common kwargs for da.to_zarr
     # zarr_array_kwargs needs dask 2025.12.0 or later
@@ -835,6 +868,13 @@ def _write_pyramid_to_zarr(
         # shapes = [data.shape for data in delayed]
         coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
 
+        if coordinate_transformations:
+            for idx, transform in enumerate(coordinate_transformations):
+                transform[0]["scale"] = [
+                    transform[0]["scale"][i] * scale.get(d, 1.0)
+                    for i, d in enumerate(dims)
+                ]
+
     # we validate again later, but this catches length mismatch before zip(datasets...)
     fmt.validate_coordinate_transformations(
         len(pyramid[0].shape), len(datasets), coordinate_transformations
@@ -938,6 +978,7 @@ def write_multiscale_labels(
     pyramid: list,
     group: zarr.Group | str,
     name: str,
+    scale: dict[str, float] | None = None,
     fmt: Format | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
@@ -961,6 +1002,11 @@ def write_multiscale_labels(
     :param group: The zarr group or path to write the metadata in.
     :type name: str, optional
     :param name: The name of this labels data.
+    :type scale: dict of str to float, optional
+    :param scale:
+        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
+        The pixel sizes for every resolution level are calculated directly from the defined `scale` and
+        `scale_factors` for each level.
     :type chunks: int or tuple of ints, optional
     :type fmt: :class:`ome_zarr.format.Format`, optional
     :param fmt:
@@ -1012,10 +1058,15 @@ def write_multiscale_labels(
         for level in pyramid
     ]
 
+    if scale is None:
+        _axes = _get_valid_axes(len(pyramid[0].shape), axes, fmt)
+        scale = dict.fromkeys(_extract_dims_from_axes(_axes), 1.0)
+
     dask_delayed_jobs = _write_pyramid_to_zarr(
         pyramid,
         sub_group,
         fmt=fmt,
+        scale=scale,
         axes=axes,
         coordinate_transformations=coordinate_transformations,
         storage_options=storage_options,
@@ -1037,7 +1088,8 @@ def write_labels(
     labels: np.ndarray | da.Array,
     group: zarr.Group | str,
     name: str,
-    scaler: Scaler | None = None,
+    scale: dict[str, float] | None = None,
+    scaler: Scaler | None = Scaler(order=0),
     scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] = (2, 4, 8, 16),
     method: Methods = Methods.NEAREST,
     fmt: Format | None = None,
@@ -1060,6 +1112,10 @@ def write_labels(
         dimensions ordered (t, c, z, y, x).
     group : zarr.Group
         The group within the zarr store to write the metadata in.
+    scale: dict of str to float, optional
+        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
+        THe pixel sizes for every resolution level are calculated directly from the defined `scale` and
+        `scale_factors` for each level.
     name : str
         The name of this labels data.
     scaler : ome_zarr.scale.Scaler, optional
@@ -1082,7 +1138,7 @@ def write_labels(
         The names of the axes, e.g. ["t", "c", "z", "y", "x"]. Ignored for versions 0.1 and 0.2.
         Required for version 0.3 or greater.
     coordinate_transformations : list of list of dict, optional
-        For each resolution, a list of transformation dicts (not validated). Each list of dicts
+        [DEPRECATED] For each resolution, a list of transformation dicts (not validated). Each list of dicts
         is added to each dataset in order.
     storage_options : dict or list of dict, optional
         Options to be passed on to the storage backend. A list must match the number of datasets
@@ -1131,6 +1187,9 @@ def write_labels(
     axes = _get_valid_axes(len(labels.shape), axes, fmt)
     dims = _extract_dims_from_axes(axes)
 
+    if scale is None:
+        scale = dict.fromkeys(dims, 1.0)
+
     if scaler is not None:
         msg = """
         The 'scaler' argument is deprecated and will be removed in version 0.13.0.
@@ -1161,6 +1220,7 @@ def write_labels(
         pyramid,
         sub_group,
         fmt=fmt,
+        scale=scale,
         axes=axes,
         coordinate_transformations=coordinate_transformations,
         storage_options=storage_options,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -30,6 +30,7 @@ SPATIAL_DIMS = ("x", "y", "z")
 def _get_valid_axes(
     ndim: int | None = None,
     axes: AxesType = None,
+    axes_units: dict[str, str] | None = None,
     fmt: Format = CurrentFormat(),
 ) -> list[str] | list[dict[str, str]] | None:
     """Returns list of axes valid for fmt.version or raise exception if invalid"""
@@ -62,7 +63,7 @@ def _get_valid_axes(
         )
 
     # validates on init
-    axes_obj = Axes(axes, fmt)
+    axes_obj = Axes(axes, axes_units, fmt)
 
     return axes_obj.to_list(fmt)
 
@@ -266,6 +267,7 @@ def write_multiscale(
     scale: dict[str, float] | None = None,
     fmt: Format | None = None,
     axes: AxesType = None,
+    axes_units: dict[str, str] | None = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     name: str | None = None,
@@ -301,6 +303,9 @@ def write_multiscale(
     :param axes:
         List of axes dicts, or names. Not needed for v0.1 or v0.2 or if 2D. Otherwise
         this must be provided
+    :param axes_units:
+        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     :type coordinate_transformations: 2Dlist of dict, optional
     :param coordinate_transformations:
         List of transformations for each path.
@@ -333,7 +338,7 @@ def write_multiscale(
     """
     group, fmt = check_group_fmt(group, fmt)
     dims = len(pyramid[0].shape)
-    axes = _get_valid_axes(dims, axes, fmt)
+    axes = _get_valid_axes(dims, axes, axes_units=axes_units, fmt=fmt)
 
     if not scale:
         scale = dict.fromkeys(_extract_dims_from_axes(axes), 1.0)
@@ -348,6 +353,7 @@ def write_multiscale(
         fmt=fmt,
         scale=scale,
         axes=axes,
+        axes_units=axes_units,
         coordinate_transformations=coordinate_transformations,
         storage_options=storage_options,
         name=name,
@@ -363,6 +369,7 @@ def write_multiscales_metadata(
     datasets: list[dict],
     fmt: Format | None = None,
     axes: AxesType = None,
+    axes_units: dict[str, str] | None = None,
     name: str | None = None,
     **metadata: str | JSONDict | list[JSONDict],
 ) -> None:
@@ -384,6 +391,10 @@ def write_multiscales_metadata(
     :param axes:
       The names of the axes. e.g. ["t", "c", "z", "y", "x"].
       Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
+    :type axes_units: dict of str to str, optional
+    :param axes_units:
+      The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+      For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     """
 
     group, fmt = check_group_fmt(group, fmt)
@@ -393,7 +404,7 @@ def write_multiscales_metadata(
             LOGGER.info("axes ignored for version 0.1 or 0.2")
             axes = None
         else:
-            axes = _get_valid_axes(axes=axes, fmt=fmt)
+            axes = _get_valid_axes(axes=axes, axes_units=axes_units, fmt=fmt)
             if axes is not None:
                 ndim = len(axes)
     if (
@@ -533,6 +544,7 @@ def write_image(
     group: zarr.Group | str,
     scale: dict[str, float] | None = None,
     scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] = (2, 4, 8, 16),
+    axes_units: dict[str, str] | None = None,
     method: Methods | None = Methods.RESIZE,
     scaler: Scaler | None = None,
     fmt: Format | None = None,
@@ -563,6 +575,10 @@ def write_image(
         `[{"z": 2, "y": 2, "x": 2}, {"z": 4, "y": 4, "x": 4}, {"z": 8, "y": 8, "x": 8}]`.
         If dimensions are omitted in this dictionary,
         the downsampling factor for that dimension will default to 1.
+    axes_units : dict of str to str, optional
+        The physical units for each dimension,
+        e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     method : ome_zarr.scale.Methods, optional
         Downsampling method to use.
         Available methods are:
@@ -629,7 +645,7 @@ def write_image(
             f"Writing ome-zarr v{fmt.version} is deprecated and has been removed in version 0.15.0."
         )
 
-    axes = _get_valid_axes(len(image.shape), axes, fmt)
+    axes = _get_valid_axes(len(image.shape), axes, axes_units=axes_units, fmt=fmt)
     dims = _extract_dims_from_axes(axes)
 
     if scale is None:
@@ -696,6 +712,7 @@ def write_image(
         group,
         fmt=fmt,
         scale=scale,
+        axes_units=axes_units,
         axes=axes,
         coordinate_transformations=coordinate_transformations,
         storage_options=storage_options,
@@ -725,6 +742,7 @@ def _write_pyramid_to_zarr(
     group: zarr.Group,
     fmt: Format,
     scale: dict[str, float],
+    axes_units: dict[str, str] | None = None,
     axes: AxesType = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
@@ -734,7 +752,7 @@ def _write_pyramid_to_zarr(
 ) -> list:
 
     group, fmt = check_group_fmt(group, fmt)
-    _axes = _get_valid_axes(len(pyramid[0].shape), axes, fmt)
+    _axes = _get_valid_axes(len(pyramid[0].shape), axes, axes_units=axes_units, fmt=fmt)
     dims = _extract_dims_from_axes(_axes)
 
     # make sure every axis is represented in `scale`;
@@ -982,6 +1000,7 @@ def write_multiscale_labels(
     scale: dict[str, float] | None = None,
     fmt: Format | None = None,
     axes: AxesType = None,
+    axes_units: dict[str, str] | None = None,
     coordinate_transformations: list[list[dict[str, Any]]] | None = None,
     storage_options: JSONDict | list[JSONDict] | None = None,
     label_metadata: JSONDict | None = None,
@@ -1017,6 +1036,10 @@ def write_multiscale_labels(
     :param axes:
       The names of the axes. e.g. ["t", "c", "z", "y", "x"].
       Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
+    :type axes_units: dict of str to str, optional
+    :param axes_units:
+        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     :type coordinate_transformations: list of dict
     :param coordinate_transformations:
       For each resolution, we have a List of transformation Dicts (not validated).
@@ -1060,7 +1083,9 @@ def write_multiscale_labels(
     ]
 
     if scale is None:
-        _axes = _get_valid_axes(len(pyramid[0].shape), axes, fmt)
+        _axes = _get_valid_axes(
+            len(pyramid[0].shape), axes, axes_units=axes_units, fmt=fmt
+        )
         scale = dict.fromkeys(_extract_dims_from_axes(_axes), 1.0)
 
     dask_delayed_jobs = _write_pyramid_to_zarr(
@@ -1069,6 +1094,7 @@ def write_multiscale_labels(
         fmt=fmt,
         scale=scale,
         axes=axes,
+        axes_units=axes_units,
         coordinate_transformations=coordinate_transformations,
         storage_options=storage_options,
         name=name,
@@ -1092,6 +1118,7 @@ def write_labels(
     scale: dict[str, float] | None = None,
     scaler: Scaler | None = Scaler(order=0),
     scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] = (2, 4, 8, 16),
+    axes_units: dict[str, str] | None = None,
     method: Methods = Methods.NEAREST,
     fmt: Format | None = None,
     axes: AxesType = None,
@@ -1130,6 +1157,11 @@ def write_labels(
         To apply downsampling to the z-dimension, pass the scale factors as a list of dicts, e.g.
         `[{"z": 1, "y": 2, "x": 2}, {"z": 1, "y": 4, "x": 4}, {"z": 1, "y": 8, "x": 8}]`.
         This default behavior may change in future versions.
+    axes_units : dict of str to str, optional
+        The physical units for each dimension,
+        e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        For a list of recommended units,
+        see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     method : ome_zarr.scale.Methods, optional
         Downsampling method to use. Default: Methods.NEAREST (recommended for labels).
         See also `ome_zarr.scale.Methods` for available methods.
@@ -1185,7 +1217,7 @@ def write_labels(
             f"Writing ome-zarr v{fmt.version} is deprecated and has been removed in version 0.15.0."
         )
 
-    axes = _get_valid_axes(len(labels.shape), axes, fmt)
+    axes = _get_valid_axes(len(labels.shape), axes, axes_units=axes_units, fmt=fmt)
     dims = _extract_dims_from_axes(axes)
 
     if scale is None:
@@ -1222,6 +1254,7 @@ def write_labels(
         sub_group,
         fmt=fmt,
         scale=scale,
+        axes_units=axes_units,
         axes=axes,
         coordinate_transformations=coordinate_transformations,
         storage_options=storage_options,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -734,7 +734,8 @@ def _write_pyramid_to_zarr(
 ) -> list:
 
     group, fmt = check_group_fmt(group, fmt)
-    dims = _extract_dims_from_axes(axes)
+    _axes = _get_valid_axes(len(pyramid[0].shape), axes, fmt)
+    dims = _extract_dims_from_axes(_axes)
 
     # make sure every axis is represented in `scale`;
     # coerce to 1.0 if not provided

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -1153,7 +1153,6 @@ def write_labels(
     labels: np.ndarray | da.Array,
     group: zarr.Group | str,
     name: str,
-    scale: dict[str, float] | None = None,
     scaler: Scaler | None = Scaler(order=0),
     scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] = (2, 4, 8, 16),
     method: Methods = Methods.NEAREST,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -888,7 +888,7 @@ def _write_pyramid_to_zarr(
         coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
 
         if coordinate_transformations:
-            for idx, transform in enumerate(coordinate_transformations):
+            for transform in coordinate_transformations:
                 transform[0]["scale"] = [
                     transform[0]["scale"][i] * scale.get(d, 1.0)
                     for i, d in enumerate(dims)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -200,6 +200,77 @@ class TestWriter:
         elif fmt.version == "0.5":
             Models05Image.from_zarr(out)
 
+    @pytest.mark.parametrize(
+        "format_version",
+        (
+            pytest.param(FormatV04, id="V04"),
+            pytest.param(FormatV05, id="V05"),
+        ),
+    )
+    def test_writer_with_scale(
+        self,
+        shape,
+        format_version,
+    ):
+        """
+        This test checks whether the `scale` parameter is converted to the correct
+        values for all subsequent pyramid levels
+        """
+        version = format_version()
+
+        if version.version == "0.5":
+            grp_path = self.path_v3 / "test"
+        else:
+            grp_path = self.path / "test"
+
+        data = self.create_data(shape)
+        axes = "tczyx"[-len(shape) :]
+        scale = {d: 0.5 if d in ["y", "x"] else 1.0 for d in axes}
+
+        write_image(
+            image=data,
+            group=str(grp_path),
+            fmt=version,
+            scale=scale,
+            axes=axes,
+        )
+
+        # Verify
+        out = zarr.open_group(grp_path)
+        node_metadata = out.attrs
+        if "ome" in node_metadata:
+            node_metadata = node_metadata["ome"]
+        assert "multiscales" in node_metadata
+        paths = [d["path"] for d in node_metadata["multiscales"][0]["datasets"]]
+        node_data = [da.from_zarr(out[path]) for path in paths]
+        if version.version in ("0.1", "0.2"):
+            # v0.1 and v0.2 MUST be 5D
+            assert node_data[0].ndim == 5
+        else:
+            assert node_data[0].shape == shape
+        print("node.metadata", node_metadata)
+        if version.version not in ("0.1", "0.2", "0.3"):
+            datasets = node_metadata["multiscales"][0]["datasets"]
+            for idx, (level, ds) in enumerate(zip(node_data, datasets)):
+                transforms = ds["coordinateTransformations"][0]
+                if idx == 0:
+                    assert transforms["scale"] == list(scale.values())
+                else:
+                    relative_scale = [
+                        node_data[idx].shape[i] / node_data[idx - 1].shape[i]
+                        for i in range(len(shape))
+                    ]
+                    scale = {
+                        d: scale[d] / relative_scale[i] for i, d in enumerate(axes)
+                    }
+                    assert transforms["scale"] == list(scale.values())
+
+        if version.version == "0.4":
+            # Validate with ome-zarr-models-py: only supports v0.4
+            Models04Image.from_zarr(out)
+        elif version.version == "0.5":
+            Models05Image.from_zarr(out)
+
     def test_mix_zarr_formats(self):
         # check group zarr v2 and v3 matches fmt
         data = self.create_data((64, 64, 64))
@@ -1877,3 +1948,7 @@ class TestLabelWriter:
         assert "labels" in attrs
         assert len(attrs["labels"]) == len(label_names)
         assert all(label_name in attrs["labels"] for label_name in label_names)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -132,6 +132,15 @@ class TestWriter:
         data = self.create_data(shape)
         data = array_constructor(data)
         axes = "tczyx"[-len(shape) :]
+
+        # add some units
+        axes_units = {}
+        for ax in axes:
+            if ax == "t":
+                axes_units[ax] = "second"
+            elif ax == "z" or ax in ("y", "x"):
+                axes_units[ax] = "micrometer"
+
         transformations = []
         for dataset_transfs in TRANSFORMATIONS:
             transf = dataset_transfs[0]
@@ -160,6 +169,7 @@ class TestWriter:
             group=str(grp_path),
             fmt=fmt,
             axes=axes,
+            axes_units=axes_units,
             coordinate_transformations=transformations,
             storage_options=storage_options,
         )
@@ -177,6 +187,11 @@ class TestWriter:
             assert node_data[0].ndim == 5
         else:
             assert node_data[0].shape == shape
+
+        for ax in node_metadata["multiscales"][0].get("axes"):
+            if ax["name"] in axes_units:
+                assert ax.get("unit") == axes_units[ax["name"]]
+
         print("node.metadata", node_metadata)
         if fmt.version not in ("0.1", "0.2", "0.3"):
             cts = [
@@ -1948,7 +1963,3 @@ class TestLabelWriter:
         assert "labels" in attrs
         assert len(attrs["labels"]) == len(label_names)
         assert all(label_name in attrs["labels"] for label_name in label_names)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])


### PR DESCRIPTION
Fixes https://github.com/ome/ome-zarr-py/issues/532
Partially solves https://github.com/ome/ome-zarr-py/issues/501

## Key features

This PR adds a new kwarg `scale` to all the writer functions (i.e., `write_image`, `write_labels`, etc) that will replace passing a pre-generated list of `coordinateTransformations` to the function. I marked the later keyword as deprecated; for now, it will be used instead of `scale` under the hood if passed.

## TODO

- [x] Document
- [x] Tests