### PR TITLE
V0.11.1 storage options

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -251,12 +251,13 @@ Please use the 'storage_options' argument instead."""
             if chunks_opt is not None:
                 data = da.array(data).rechunk(chunks=chunks_opt)
                 options["chunks"] = chunks_opt
+            compressor = options.pop("compressor", zarr.storage.default_compressor)
             da_delayed = da.to_zarr(
                 arr=data,
                 url=group.store,
                 component=str(Path(group.path, str(path))),
-                storage_options=options,
-                compressor=options.get("compressor", zarr.storage.default_compressor),
+                storage_options=options if len(options) > 0 else None,
+                compressor=compressor,
                 dimension_separator=group._store._dimension_separator,
                 compute=compute,
             )
@@ -609,14 +610,15 @@ Please use the 'storage_options' argument instead."""
         LOGGER.debug(
             "write dask.array to_zarr shape: %s, dtype: %s", image.shape, image.dtype
         )
+        compressor = options.get("compressor", zarr.storage.default_compressor)
         delayed.append(
             da.to_zarr(
                 arr=image,
                 url=group.store,
                 component=str(Path(group.path, str(path))),
-                storage_options=options,
+                storage_options=options if len(options) > 0 else None,
                 compute=False,
-                compressor=options.get("compressor", zarr.storage.default_compressor),
+                compressor=compressor,
                 dimension_separator=group._store._dimension_separator,
             )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ requires-python = ">3.10"
 
 dependencies = [
     "numpy",
-    "dask",
+    "dask!=2025.12.0,!=2026.1.0,!=2026.1.1,!=2026.1.2",
+    # See https://github.com/dask/dask/issues/12232
+    # https://github.com/dask/dask/issues/12265
     "zarr>=2.8.1,<3",
     "fsspec[s3]>=0.8,!=2021.07.0,!=2023.9.0",
     # See https://github.com/fsspec/filesystem_spec/issues/819


### PR DESCRIPTION
ome-zarr==0.11.1 (the last version that supports zarr<3) has issues writing arrays for dask>2025.11.0. For users that have not upgraded from zarr 2 to 3, maintaining this version is important for latest dask versions. 

This fix has been tested against dask==2026.3.0 and dask==2025.11.0

Example of writing with dask==2026.3.0 and zarr < 3 failing silently using S3 URL
```
import sys

import dask.array as da
import zarr
from zarr.storage import FSStore

url = sys.argv[1] # e.g. s3://foo

image = da.ones((10, 10)).rechunk((2, 2))

storage_options = {}
root = zarr.open(url, mode="a")

# works if url is a local URL
# completes successfully without writing array if url is S3 URL
# writes successfully if storage_options is None instead of empty dict

da.to_zarr(
    arr=image,
    url=root.store,
    component="foo",
    storage_options=storage_options,
)

# works with local and S3 URL
da.to_zarr(
    arr=image,
    url=FSStore(url, **storage_options),
    component="foo2",
)

```