### PR TITLE
update codespell github action

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Codespell
-        uses: codespell-project/actions-codespell@v1
+        uses: codespell-project/actions-codespell@v2


### PR DESCRIPTION
This updates codespell to v2. We could alternatively also avoid it all together by just running it as a step rather than as a github action. This would in turn prevent potential docker authentication issues.