### PR TITLE
feat: do not delay writing metadata

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -774,16 +774,9 @@ def _write_pyramid_to_zarr(
     if coordinate_transformations is not None:
         for dataset, transform in zip(datasets, coordinate_transformations):
             dataset["coordinateTransformations"] = transform
-    if not compute:
-        write_multiscales_metadata_delayed = dask.delayed(write_multiscales_metadata)
-        return delayed + [
-            bind(write_multiscales_metadata_delayed, delayed)(
-                group, datasets, fmt, axes, name, **metadata
-            )
-        ]
-    else:
-        write_multiscales_metadata(group, datasets, fmt, axes, name, **metadata)
-        return delayed
+
+    write_multiscales_metadata(group, datasets, fmt, axes, name, **metadata)
+    return delayed
 
 
 def write_label_metadata(

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -6,11 +6,9 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, TypeAlias
 
-import dask
 import dask.array as da
 import numpy as np
 import zarr
-from dask.graph_manipulation import bind
 from numcodecs import Blosc
 
 from .axes import Axes


### PR DESCRIPTION
@will-moore Another small PR in the wake of #515 :) I realized that some tests were failing there for an unrelated reason: In #515, I use the existing code in `_write_pyramid_to_zarr` to write the metadata, but it's effectively later overwritten by the metadata dump from the ome-zarr-models-py classes.

*However*, if writing the metadata is *delayed* inside the `_write_pyramid_to_zarr` function, it will overwrite the metadata dump from ozmp 🤦‍♂️ . Simple fix: I am chosing to always write metadata right away here. The performance-impact of writing a bit of json should be manageable.

It's not strictly related to #515 so I'm sending it as a breakout-PR.