### PR TITLE
Update docs for metadata parameter of write_image

### DIFF
--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -632,7 +632,7 @@ def write_image(
         For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     `**metadata` : dict
         Additional metadata to store.
-        Provide a kwarg such as `metadata={"omero": {"name": "My image"}}`.
+        Use the `metadata` kwarg, e.g., `metadata={"omero": {"name": "My image"}}`.
 
     Returns
     -------

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -632,6 +632,7 @@ def write_image(
         For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
     `**metadata` : dict
         Additional metadata to store.
+        Provide a kwarg such as `metadata={"omero": {"name": "My image"}}`.
 
     Returns
     -------


### PR DESCRIPTION
The `**` for the `**metadata` kwarg was confusing to me. It wasn't initially apparent to me via the type anotations or docstring whether I should do `write_image(omero={})` vs `write_image(metadata={"omero":{}})`. Only the latter works.

```py
write_image(
    image=img_arr,
    # other args here
    metadata={
        "omero": {
            "name": img_name,
        }
    }
)
```
