### PR TITLE
Bump requires-python from >3.10 to >3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description="Implementation of images in Zarr files."
 license = "BSD-2-Clause"
 license-files = ["LICENSE"]
 
-requires-python = ">3.10"
+requires-python = ">3.11"
 
 dependencies = [
     "numpy",


### PR DESCRIPTION
A tiny one:
Needed for `uv sync` to work with latest ome-zarr-models (and that's a dependency that seems important to support the latest version of 😄)