### PR TITLE
Be more permissive with version 0.5, allowing support for spatial-data ome zarrs

### DIFF
--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -411,6 +411,51 @@ class OMEZarrMultiscaleBase:
 
             if "image-label" in ome_attrs:
                 is_label = True
+        elif version == "0.5-dev-spatialdata":
+            from ome_zarr_models.v05.multiscales import Multiscale as Multiscalev05
+
+            ome_attrs = cast(dict[str, Any], group.attrs.get("ome", {}))
+            metadata_json = ome_attrs.get("multiscales", [None])[0]
+
+            if metadata_json is None:
+                raise ValueError(
+                    "Multiscales metadata not found in group attributes. "
+                    "Opening groups other than multiscales (i.e., HCS, Plates, Wells) "
+                    "is currently not supported."
+                )
+
+            if "coordinateTransformations" in metadata_json:
+                metadata_json["spatialdata_transforms"] = metadata_json[
+                    "coordinateTransformations"
+                ]
+                scale_transform = next(
+                    (
+                        t
+                        for t in metadata_json["coordinateTransformations"]
+                        if t.get("type") == "scale"
+                    ),
+                    None,
+                )
+                if scale_transform:
+                    # Strip non-standard keys ('input', 'output') so Pydantic doesn't throw validation faults
+                    compliant_scale = {
+                        "type": "scale",
+                        "scale": scale_transform["scale"],
+                    }
+                    metadata_json["coordinateTransformations"] = [compliant_scale]
+
+            metadata = Multiscalev05.model_validate(metadata_json)
+
+            if (
+                hasattr(metadata_json, "get")
+                and "spatialdata_transforms" in metadata_json
+            ):
+                metadata.__dict__["spatialdata_transforms"] = metadata_json[
+                    "spatialdata_transforms"
+                ]
+
+            if "image-label" in ome_attrs:
+                is_label = True
 
         else:
             raise ValueError(f"Unsupported OME-Zarr version: {version}")

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -372,7 +372,7 @@ class OMEZarrMultiscaleBase:
         is_label = False
 
         # Handle loading based on version
-        if version.startswith(("0.1", "0.2", "0.3")):
+        if version in ("0.1", "0.2", "0.3"):
             metadata = cls._read_legacy_metadata(group, version)
             if "image-label" in group.attrs:
                 is_label = True

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -377,6 +377,8 @@ class OMEZarrMultiscaleBase:
             if "image-label" in group.attrs:
                 is_label = True
 
+        # allow compatbility with 0.4.dev-spatialdata store
+        # not intended for other/future versions beyond 0.5
         elif version.startswith("0.4"):
             from ome_zarr_models.v04.multiscales import Multiscale as Multiscalev04
 

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -377,7 +377,7 @@ class OMEZarrMultiscaleBase:
             if "image-label" in group.attrs:
                 is_label = True
 
-        # allow compatbility with 0.4.dev-spatialdata store
+        # allow compatibility with 0.4.dev-spatialdata store
         # not intended for other/future versions beyond 0.5
         elif version.startswith("0.4"):
             from ome_zarr_models.v04.multiscales import Multiscale as Multiscalev04

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -396,7 +396,7 @@ class OMEZarrMultiscaleBase:
             if "image-label" in group.attrs:
                 is_label = True
 
-        # allow compatbility with 0.5.dev-spatialdata store
+        # allow compatibility with 0.5.dev-spatialdata store
         # not intended for other/future versions beyond 0.5
         elif version.startswith("0.5"):
             from ome_zarr_models.v05.multiscales import Multiscale as Multiscalev05

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -372,12 +372,12 @@ class OMEZarrMultiscaleBase:
         is_label = False
 
         # Handle loading based on version
-        if version in ("0.1", "0.2", "0.3"):
+        if version.startswith(("0.1", "0.2", "0.3")):
             metadata = cls._read_legacy_metadata(group, version)
             if "image-label" in group.attrs:
                 is_label = True
 
-        elif version == "0.4":
+        elif version.startswith("0.4"):
             from ome_zarr_models.v04.multiscales import Multiscale as Multiscalev04
 
             metadata_json = cast(dict, group.attrs.get("multiscales", [None])[0])
@@ -394,7 +394,7 @@ class OMEZarrMultiscaleBase:
             if "image-label" in group.attrs:
                 is_label = True
 
-        elif version == "0.5":
+        elif version.startswith("0.5"):
             from ome_zarr_models.v05.multiscales import Multiscale as Multiscalev05
 
             ome_attrs = cast(dict[str, Any], group.attrs.get("ome", {}))
@@ -408,51 +408,6 @@ class OMEZarrMultiscaleBase:
                 )
 
             metadata = Multiscalev05.model_validate(metadata_json)
-
-            if "image-label" in ome_attrs:
-                is_label = True
-        elif version == "0.5-dev-spatialdata":
-            from ome_zarr_models.v05.multiscales import Multiscale as Multiscalev05
-
-            ome_attrs = cast(dict[str, Any], group.attrs.get("ome", {}))
-            metadata_json = ome_attrs.get("multiscales", [None])[0]
-
-            if metadata_json is None:
-                raise ValueError(
-                    "Multiscales metadata not found in group attributes. "
-                    "Opening groups other than multiscales (i.e., HCS, Plates, Wells) "
-                    "is currently not supported."
-                )
-
-            if "coordinateTransformations" in metadata_json:
-                metadata_json["spatialdata_transforms"] = metadata_json[
-                    "coordinateTransformations"
-                ]
-                scale_transform = next(
-                    (
-                        t
-                        for t in metadata_json["coordinateTransformations"]
-                        if t.get("type") == "scale"
-                    ),
-                    None,
-                )
-                if scale_transform:
-                    # Strip non-standard keys ('input', 'output') so Pydantic doesn't throw validation faults
-                    compliant_scale = {
-                        "type": "scale",
-                        "scale": scale_transform["scale"],
-                    }
-                    metadata_json["coordinateTransformations"] = [compliant_scale]
-
-            metadata = Multiscalev05.model_validate(metadata_json)
-
-            if (
-                hasattr(metadata_json, "get")
-                and "spatialdata_transforms" in metadata_json
-            ):
-                metadata.__dict__["spatialdata_transforms"] = metadata_json[
-                    "spatialdata_transforms"
-                ]
 
             if "image-label" in ome_attrs:
                 is_label = True

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -394,6 +394,8 @@ class OMEZarrMultiscaleBase:
             if "image-label" in group.attrs:
                 is_label = True
 
+        # allow compatbility with 0.5.dev-spatialdata store
+        # not intended for other/future versions beyond 0.5
         elif version.startswith("0.5"):
             from ome_zarr_models.v05.multiscales import Multiscale as Multiscalev05
 


### PR DESCRIPTION
Hello! I opened another PR #587 a little over a week ago to support zipped SpatialData zarr stores. After some conversation with @will-moore and @jo-mueller about the image class overhaul, I decided to wait on Jo's PR to be merged and redo my work after.

Jo's PR was merged yesterday, so I am excited to move forward with my changes. This will reintroduce SpatialData support to ome-zarr-py by adding handling to accept the `0.5-dev-spatialdata` ome version in SpatialData metadata. 

I tested my changes by using SpatialData's `read_zarr()` method on zipped and unzipped SpatialData zarr stores. The version of `read_zarr()` that I used is a combination of changes from the soon to be merged PR https://github.com/scverse/spatialdata/pull/1107 and [my branch of that PR](https://github.com/hubmapconsortium/spatialdata/tree/pennycuda/zip-store-rework) that accepts ZipStores and works in the new ome-zarr-py image class changes. 

Penny Cuda, she/her, HuBMAP Consortium