### PR TITLE
feat: reverse-populate OMEZarrMultiscale class with omero metadata on read

### DIFF
--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -1041,35 +1041,37 @@ class OMEZarrMultiscale(OMEZarrMultiscaleBase):
                 self._omero = Omero.model_validate(omero_dict)
 
                 # reverse-populate channel_names, channel_colors, contrast_limits from omero metadata
-                if self._omero.channels is not None:
-                    channel_names = [
-                        ch.label if ch.label is not None else f"Channel {i}"
-                        for i, ch in enumerate(self._omero.channels)
-                    ]
-                    channel_colors = [
-                        (
-                            ch.color
-                            if ch.color is not None
-                            else DEFAULT_COLORS[i % len(DEFAULT_COLORS)]
-                        )
-                        for i, ch in enumerate(self._omero.channels)
-                    ]
-                    contrast_limits = [
-                        (
-                            ch.window.start if ch.window.start is not None else 0,
-                            (
-                                ch.window.end
-                                if ch.window.end is not None
-                                else self._images[0].data.dtype.itemsize * 255
-                            ),
-                        )
-                        for i, ch in enumerate(self._omero.channels)
-                    ]
+                channel_names: list[str] = []
+                channel_colors: list[str] = []
+                contrast_limits: list[tuple[float, float]] = []
 
-                    for img in self._images:
-                        img.channel_names = channel_names
-                        img.channel_colors = channel_colors
-                        img.contrast_limits = contrast_limits
+                if self._omero.channels is not None and len(self._omero.channels) > 0:
+                    for i, ch in enumerate(self._omero.channels):
+                        channel_names.append(getattr(ch, "label", f"Channel {i}"))
+
+                        ch_color = getattr(ch, "color", None)
+                        if ch_color is not None:
+                            channel_colors.append(ch_color)
+                        else:
+                            channel_colors.append(DEFAULT_COLORS[i % len(DEFAULT_COLORS)])
+
+                        ch_window = getattr(ch, "window", None)
+                        if ch_window is not None:
+                            start = getattr(ch_window, "start", 0)
+                            end = getattr(
+                                ch_window,
+                                "end",
+                                self._images[0].data.dtype.itemsize * 255,
+                            )
+                            contrast_limits.append((start, end))
+                        else:
+                            contrast_limits.append(
+                                (0, self._images[0].data.dtype.itemsize * 255)
+                            )
+
+                self.channel_names = channel_names
+                self.channel_colors = channel_colors
+                self.contrast_limits = contrast_limits
             except ValidationError as e:
                 warnings.warn(f"Invalid Omero metadata: {e}")
 

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -1039,6 +1039,29 @@ class OMEZarrMultiscale(OMEZarrMultiscaleBase):
         if omero_dict is not None:
             try:
                 self._omero = Omero.model_validate(omero_dict)
+
+                # reverse-populate channel_names, channel_colors, contrast_limits from omero metadata
+                if self._omero.channels is not None:
+                    channel_names = [
+                        ch.label if ch.label is not None else f"Channel {i}"
+                        for i, ch in enumerate(self._omero.channels)
+                    ]
+                    channel_colors = [
+                        ch.color if ch.color is not None else DEFAULT_COLORS[i % len(DEFAULT_COLORS)]
+                        for i, ch in enumerate(self._omero.channels)
+                    ]
+                    contrast_limits = [
+                        (
+                            ch.window.start if ch.window.start is not None else 0,
+                            ch.window.end if ch.window.end is not None else self._images[0].data.dtype.itemsize * 255,
+                        )
+                        for i, ch in enumerate(self._omero.channels)
+                    ]
+
+                    for img in self._images:
+                        img.channel_names = channel_names
+                        img.channel_colors = channel_colors
+                        img.contrast_limits = contrast_limits
             except ValidationError as e:
                 warnings.warn(f"Invalid Omero metadata: {e}")
 

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -1045,7 +1045,11 @@ class OMEZarrMultiscale(OMEZarrMultiscaleBase):
                 channel_colors: list[str] = []
                 contrast_limits: list[tuple[float, float]] = []
 
-                if self._omero.channels is not None and len(self._omero.channels) > 0:
+                if (
+                    self._omero is not None
+                    and self._omero.channels is not None
+                    and len(self._omero.channels) > 0
+                ):
                     for i, ch in enumerate(self._omero.channels):
                         channel_names.append(getattr(ch, "label", f"Channel {i}"))
 

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -1047,13 +1047,21 @@ class OMEZarrMultiscale(OMEZarrMultiscaleBase):
                         for i, ch in enumerate(self._omero.channels)
                     ]
                     channel_colors = [
-                        ch.color if ch.color is not None else DEFAULT_COLORS[i % len(DEFAULT_COLORS)]
+                        (
+                            ch.color
+                            if ch.color is not None
+                            else DEFAULT_COLORS[i % len(DEFAULT_COLORS)]
+                        )
                         for i, ch in enumerate(self._omero.channels)
                     ]
                     contrast_limits = [
                         (
                             ch.window.start if ch.window.start is not None else 0,
-                            ch.window.end if ch.window.end is not None else self._images[0].data.dtype.itemsize * 255,
+                            (
+                                ch.window.end
+                                if ch.window.end is not None
+                                else self._images[0].data.dtype.itemsize * 255
+                            ),
                         )
                         for i, ch in enumerate(self._omero.channels)
                     ]

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -1053,7 +1053,9 @@ class OMEZarrMultiscale(OMEZarrMultiscaleBase):
                         if ch_color is not None:
                             channel_colors.append(ch_color)
                         else:
-                            channel_colors.append(DEFAULT_COLORS[i % len(DEFAULT_COLORS)])
+                            channel_colors.append(
+                                DEFAULT_COLORS[i % len(DEFAULT_COLORS)]
+                            )
 
                         ch_window = getattr(ch, "window", None)
                         if ch_window is not None:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -266,7 +266,7 @@ def test_class_reader():
     assert image.channel_colors == ["0000FF", "FFFF00"]
     assert hasattr(image, "contrast_limits")
     assert len(image.contrast_limits) == 2
-    assert image.contrast_limits == [(0., 1500.), (0., 1500.)]
+    assert image.contrast_limits == [(0.0, 1500.0), (0.0, 1500.0)]
 
     # image is known to have one labels image of name "0"
     assert len(image.labels) == 1

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -256,6 +256,18 @@ def test_class_reader():
     assert isinstance(image.omero, Omero)
     assert hasattr(image.omero, "channels")
 
+    # make sure we got the expected attributes from the omero metadata
+    # introspect at https://ome.github.io/ome-ngff-validator/?source=https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr/zarr.json
+    assert hasattr(image, "channel_names")
+    assert len(image.channel_names) == 2
+    assert image.channel_names == ["LaminB1", "Dapi"]
+    assert hasattr(image, "channel_colors")
+    assert len(image.channel_colors) == 2
+    assert image.channel_colors == ["0000FF", "FFFF00"]
+    assert hasattr(image, "contrast_limits")
+    assert len(image.contrast_limits) == 2
+    assert image.contrast_limits == [(0., 1500.), (0., 1500.)]
+
     # image is known to have one labels image of name "0"
     assert len(image.labels) == 1
     assert "0" in image.labels


### PR DESCRIPTION
Small PR to make sure that we can extract OMERO Metadata via the `OMEZarrMultiscale` classes. For context:

In the write direction, we can pass `contrast_limits`, `channel_names`, `channel_colors` arguments to the `OMEZarrMultiscale` class, which are translated into appropriate `omero` metadata entries. On read, this isn't possible, though. This PR adds minimal translation to the reader path of the `OMEZarrMultiscale` class.

TODO:

- [x] testing