### PR TITLE
feat: Accept pyramids

### DIFF
--- a/docs/source/basic/write_image.ipynb
+++ b/docs/source/basic/write_image.ipynb
@@ -137,7 +137,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "id": "f87d36fa",
       "metadata": {},
       "outputs": [
@@ -156,7 +156,7 @@
         "from ome_zarr.writer import write_image\n",
         "\n",
         "path = \"test_ngff_image.ome.zarr\"\n",
-        "write_image(data, \"test_ngff2.ome.zarr\", axes=\"czyx\")"
+        "write_image(data, path, axes=\"czyx\")"
       ]
     },
     {

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -156,7 +156,7 @@ class OMEZarrMultiscaleBase:
 
     def __init__(
         self,
-        image: OMEZarrImage,
+        image: OMEZarrImage | list[OMEZarrImage] | None,
         scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] | None = None,
         coordinate_transformations: (
             tuple[AnyTransform, ...] | list[dict[str, Any]] | None
@@ -167,70 +167,86 @@ class OMEZarrMultiscaleBase:
     ):
         from ome_zarr.scale import _build_pyramid
 
-        if scale_factors is None:
-            scale_factors = (2, 4, 8, 16)
+        # image param accepts OMEZarrImage (builds pyramid)
+        # or list[OMEZarrImage] (prebuilt)
+        if isinstance(image, list):
+            # Prebuilt pyramid: ignore scale_factors and method
+            if not image:
+                raise ValueError("images list cannot be empty")
+            pyramid_images = image
+            self.name = pyramid_images[0].name
 
-        self.name = image.name
+        # Build pyramid from single image
+        # instead of a list of pre-computed images
+        elif isinstance(image, OMEZarrImage):
+            if scale_factors is None:
+                scale_factors = (2, 4, 8, 16)
 
-        if isinstance(method, Methods):
-            method = str(method.value)
-        elif method is None:
-            method = str(Methods.RESIZE.value)
+            self.name = image.name
 
-        # Build the pyramid data
-        pyramid = _build_pyramid(
-            image=image.data,
-            dims=image.axes,
-            scale_factors=scale_factors,
-            method=method,
-        )
+            if isinstance(method, Methods):
+                method = str(method.value)
+            elif method is None:
+                method = str(Methods.RESIZE.value)
 
-        # build scales for each level based on the original image shape
-        # and the pyramid level shapes
-        scales = []
-        # image.scale is guaranteed to be a dict after NgffImage.__post_init__
-        image_scale = image.scale
-        if not isinstance(image_scale, dict):
-            raise ValueError("Expected image.scale to be a dict after initialization")
+            # Build the pyramid data
+            pyramid = _build_pyramid(
+                image=image.data,
+                dims=image.axes,
+                scale_factors=scale_factors,
+                method=method,
+            )
 
-        for shape in [d.shape for d in pyramid]:
-            scale = [full / level for full, level in zip(image.data.shape, shape)]
-            scales.append(
-                {
+            # image.scale is guaranteed to be a dict after NgffImage.__post_init__
+            image_scale = image.scale
+            if not isinstance(image_scale, dict):
+                raise ValueError("Expected image.scale to be a dict after initialization")
+
+            # Create Image instances for each pyramid level
+            pyramid_images = []
+            for idx, level_data in enumerate(pyramid):
+                scale = [
+                    full / level
+                    for full, level
+                    in zip(pyramid[0].shape, level_data.shape)
+                    ]
+                level_scale = {
                     d: s * image_scale[d] if d in image_scale else 1.0
                     for d, s in zip(image.axes, scale)
                 }
-            )
-
-        translations = [
-            {d: (scale[d] / 2) - (scales[0][d] / 2) for d in image.axes}
-            for scale in scales
-        ]
-
-        # Create Image instances for each pyramid level
-        images = []
-        datasets = []
-        for idx, (level_data, level_scale) in enumerate(zip(pyramid, scales)):
-
-            images.append(
-                OMEZarrImage(
-                    data=level_data,
-                    axes=image.axes,
-                    scale=level_scale,
-                    axes_units=image.axes_units,
-                    name=image.name,
-                    axes_types=image.axes_types,
+                pyramid_images.append(
+                    OMEZarrImage(
+                        data=level_data,
+                        axes=image.axes,
+                        scale=level_scale,
+                        axes_units=image.axes_units,
+                        name=image.name,
+                        axes_types=image.axes_types,
+                    )
                 )
-            )
+        else:
+            raise ValueError("Provide 'image' as OMEZarrImage or list[OMEZarrImage]")
 
+        self._images = pyramid_images
+        # translations = [
+        #     {d: (scale[d] / 2) - (scales[0][d] / 2) for d in image.axes}
+        #     for scale in [img.scale for img in self._images]
+        # ]
+
+        # Build datasets for all cases (translation only exists in built case)
+        datasets = []
+        for idx, image in enumerate(self._images):
+            translation = {
+                d: (image.scale[d] - self._images[0].scale[d]) / 2
+                for d in image.axes
+            }
+            tforms = [
+                Scale(scale=tuple(image.scale.values())),
+                Translation(translation=tuple(translation.values())),
+                ]
+            
             transforms = TransformSequence(
-                transformations=(
-                    Scale(type="scale", scale=tuple(level_scale.values())),
-                    Translation(
-                        type="translation",
-                        translation=tuple(translations[idx].values()),
-                    ),
-                ),
+                transformations=tuple(tforms),
                 input=CoordinateSystemIdentifier(path=f"s{idx}"),
                 output=CoordinateSystemIdentifier(name=default_coordinate_system_name),
             )
@@ -238,23 +254,23 @@ class OMEZarrMultiscaleBase:
                 Dataset(path=f"s{idx}", coordinateTransformations=(transforms,)),
             )
 
-        self._images = images
-
-        # Build axes metadata
-        if image.axes_units is None:
-            image.axes_units = {}
+        # Build axes metadata from first image
+        # (works for both cases, prebuilt and built pyramid)
+        ref_image = self._images[0]
+        if ref_image.axes_units is None:
+            ref_image.axes_units = {}
 
         axes = []
-        for d in image.axes:
-            if image.axes_types.get(d) in DISCRETE_DIMS:
+        for d in ref_image.axes:
+            if ref_image.axes_types.get(d) in DISCRETE_DIMS:
                 discrete = True
             else:
                 discrete = False
             axes.append(
                 Axis(
                     name=d,
-                    type=image.axes_types.get(d),
-                    unit=image.axes_units.get(d),
+                    type=ref_image.axes_types.get(d),
+                    unit=ref_image.axes_units.get(d),
                     discrete=discrete,
                 )
             )
@@ -335,7 +351,7 @@ class OMEZarrMultiscaleBase:
         self.metadata = MultiscaleV06(
             coordinateSystems=tuple(coordinate_systems),
             datasets=tuple(datasets),
-            name=image.name,
+            name=self.name,
             coordinateTransformations=transforms,
         )
 
@@ -588,17 +604,11 @@ class OMEZarrMultiscaleBase:
                 )
             )
 
-        return_cls: type[OMEZarrLabels | OMEZarrMultiscale]
         if is_label:
-            return_cls = OMEZarrLabels
+            instance = OMEZarrLabels(image=images)
         else:
-            return_cls = OMEZarrMultiscale
-
-        # Create instance without calling __init__
-        instance = return_cls.__new__(return_cls)
-        instance._images = images
-        instance.metadata = metadata
-        instance.name = str(metadata.name) if metadata.name else "image"
+            instance = OMEZarrMultiscale(image=images)
+        instance.metadata = cast(MultiscaleV06, metadata)
 
         # Let derived classes read their specific metadata
         instance._read_additional_metadata(group, version)
@@ -736,13 +746,15 @@ class OMEZarrMultiscale(OMEZarrMultiscaleBase):
 
     Parameters
     ----------
-    image : OMEZarrImage
+    image : OMEZarrImage | list[OMEZarrImage]
         The OMEZarrImage instance from which to build the multi-resolution levels.
     scale_factors : list[int] | tuple[int, ...] | list[dict[str, int]] | None
         Scale factors for each pyramid level. If a list of ints or tuple is provided,
         it is applied uniformly across all spatial axes. If a list of dicts is provided,
         each dict should specify scale factors for each axis, e.g. {'x': 2, 'y': 2, 'z': 1}.
         Default is (2, 4, 8, 16).
+        If a list of OMEZarrImage instances is provided for the `image` parameter,
+        this argument is ignored, and the provided images are used as-is for the pyramid levels.
     method : ome_zarr.scale.Methods | str | None
         Rescaling method to use when generating pyramid levels. Default is Methods.RESIZE.
     coordinate_transformations : list[ome_zarr_models.v05.multiscales.AnyTransform] | list[dict[str, Any]] | None
@@ -806,7 +818,7 @@ class OMEZarrMultiscale(OMEZarrMultiscaleBase):
 
     def __init__(
         self,
-        image: OMEZarrImage,
+        image: OMEZarrImage | list[OMEZarrImage] | None,
         scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] | None = None,
         method: str | Methods | None = Methods.RESIZE,
         coordinate_transformations: (
@@ -1081,12 +1093,14 @@ class OMEZarrLabels(OMEZarrMultiscaleBase):
 
     Parameters
     ----------
-    image : OMEZarrImage
+    image : OMEZarrImage | list[OMEZarrImage]
     scale_factors : list[int] | tuple[int, ...] | list[dict[str, int]] | None, optional
         Scale factors for each pyramid level. If a list of ints or tuple is provided,
         it is applied uniformly across all spatial axes. If a list of dicts is provided,
         each dict should specify scale factors for each axis, e.g. {'x': 2, 'y': 2, 'z': 1}.
         Default is (2, 4, 8, 16).
+        If a list of OMEZarrImage instances is provided for the `image` parameter,
+        this argument is ignored, and the provided images are used as-is for the pyramid levels.
     method : str | ome_zarr.scale.Methods, optional
         Rescaling method to use when generating pyramid levels. Default is Methods.NEAREST,
         since these are labels.
@@ -1111,7 +1125,7 @@ class OMEZarrLabels(OMEZarrMultiscaleBase):
 
     def __init__(
         self,
-        image: OMEZarrImage,
+        image: OMEZarrImage | list[OMEZarrImage] | None,
         scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] | None = None,
         method: str | Methods | None = Methods.NEAREST,
         auto_parse_labels: bool = True,

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -1184,9 +1184,11 @@ class OMEZarrLabels(OMEZarrMultiscaleBase):
 
         if self._image_label is not None and isinstance(self._image_label, Label):
             if version == "0.4":
-                group.attrs["image-label"] = _recursive_pop_nones(
+                meta = _recursive_pop_nones(
                     self._image_label.model_dump(by_alias=True)
                 )
+                meta["version"] = version
+                group.attrs["image-label"] = meta
             elif version == "0.5":
                 ome = cast(dict, group.attrs.get("ome", {}))
                 ome["image-label"] = _recursive_pop_nones(

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -228,20 +228,19 @@ class OMEZarrMultiscaleBase:
         else:
             raise ValueError("Provide 'image' as OMEZarrImage or list[OMEZarrImage]")
 
-        self._images = pyramid_images
-        # translations = [
-        #     {d: (scale[d] / 2) - (scales[0][d] / 2) for d in image.axes}
-        #     for scale in [img.scale for img in self._images]
-        # ]
+        self._images: list[OMEZarrImage] = pyramid_images
 
         # Build datasets for all cases (translation only exists in built case)
         datasets = []
-        for idx, image in enumerate(self._images):
+        for idx, level_image in enumerate(self._images):
+            if level_image.scale is None or self._images[0].scale is None:
+                raise ValueError("Scale must be defined for all images in the pyramid")
             translation = {
-                d: (image.scale[d] - self._images[0].scale[d]) / 2 for d in image.axes
+                d: (level_image.scale[d] - self._images[0].scale[d]) / 2
+                for d in level_image.axes
             }
             tforms = [
-                Scale(scale=tuple(image.scale.values())),
+                Scale(scale=tuple(level_image.scale.values())),
                 Translation(translation=tuple(translation.values())),
             ]
 
@@ -604,6 +603,7 @@ class OMEZarrMultiscaleBase:
                 )
             )
 
+        instance: OMEZarrMultiscale | OMEZarrLabels
         if is_label:
             instance = OMEZarrLabels(image=images)
         else:

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -200,16 +200,17 @@ class OMEZarrMultiscaleBase:
             # image.scale is guaranteed to be a dict after NgffImage.__post_init__
             image_scale = image.scale
             if not isinstance(image_scale, dict):
-                raise ValueError("Expected image.scale to be a dict after initialization")
+                raise ValueError(
+                    "Expected image.scale to be a dict after initialization"
+                )
 
             # Create Image instances for each pyramid level
             pyramid_images = []
             for idx, level_data in enumerate(pyramid):
                 scale = [
                     full / level
-                    for full, level
-                    in zip(pyramid[0].shape, level_data.shape)
-                    ]
+                    for full, level in zip(pyramid[0].shape, level_data.shape)
+                ]
                 level_scale = {
                     d: s * image_scale[d] if d in image_scale else 1.0
                     for d, s in zip(image.axes, scale)
@@ -237,14 +238,13 @@ class OMEZarrMultiscaleBase:
         datasets = []
         for idx, image in enumerate(self._images):
             translation = {
-                d: (image.scale[d] - self._images[0].scale[d]) / 2
-                for d in image.axes
+                d: (image.scale[d] - self._images[0].scale[d]) / 2 for d in image.axes
             }
             tforms = [
                 Scale(scale=tuple(image.scale.values())),
                 Translation(translation=tuple(translation.values())),
-                ]
-            
+            ]
+
             transforms = TransformSequence(
                 transformations=tuple(tforms),
                 input=CoordinateSystemIdentifier(path=f"s{idx}"),
@@ -1184,9 +1184,7 @@ class OMEZarrLabels(OMEZarrMultiscaleBase):
 
         if self._image_label is not None and isinstance(self._image_label, Label):
             if version == "0.4":
-                meta = _recursive_pop_nones(
-                    self._image_label.model_dump(by_alias=True)
-                )
+                meta = _recursive_pop_nones(self._image_label.model_dump(by_alias=True))
                 meta["version"] = version
                 group.attrs["image-label"] = meta
             elif version == "0.5":

--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -1,7 +1,7 @@
 """Functions for generating synthetic data."""
 
 from collections.abc import Callable
-
+from typing import cast, Literal
 import dask.array as da
 import numpy as np
 import zarr
@@ -156,7 +156,7 @@ def create_zarr(
     image.labels = {label.name: label}
     image.to_ome_zarr(
         zarr_directory,
-        version=fmt.version,
+        version=cast(Literal["0.6.dev4", "0.5", "0.4"], fmt.version),
         overwrite=True,
     )
 

--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -1,22 +1,18 @@
 """Functions for generating synthetic data."""
 
 from collections.abc import Callable
-from random import randrange
 
 import dask.array as da
 import numpy as np
 import zarr
-from scipy.ndimage import zoom
 from skimage import data
 from skimage.filters import threshold_otsu
 from skimage.measure import label
 from skimage.segmentation import clear_border
 
-from .format import CurrentFormat, Format
-from .io import parse_url
-from .scale import Scaler
-from .writer import add_metadata, write_multiscale
 from ome_zarr import OMEZarrImage, OMEZarrLabels, OMEZarrMultiscale
+
+from .format import CurrentFormat, Format
 
 CHANNEL_DIMENSION = 1
 
@@ -43,8 +39,12 @@ def coins() -> tuple[OMEZarrMultiscale, OMEZarrLabels]:
     label_image = np.asarray(label(cleared))
     chunks = [s // 8 if s > 8 else 1 for s in image.shape]
 
-    img = OMEZarrImage(data=da.from_array(image, chunks=chunks), axes="yx", name="coins")
-    lbl = OMEZarrImage(data=da.from_array(label_image, chunks=chunks), axes="yx", name="coins")
+    img = OMEZarrImage(
+        data=da.from_array(image, chunks=chunks), axes="yx", name="coins"
+    )
+    lbl = OMEZarrImage(
+        data=da.from_array(label_image, chunks=chunks), axes="yx", name="coins"
+    )
 
     img_ms = OMEZarrMultiscale(
         image=img,
@@ -83,14 +83,21 @@ def astronaut() -> tuple[OMEZarrMultiscale, OMEZarrLabels]:
     chunks = [s // 8 if s > 8 else 1 for s in pixels.shape]
     chunks_labels = [s // 8 if s > 8 else 1 for s in label.shape]
 
-    img = OMEZarrImage(data=da.from_array(pixels, chunks=chunks), axes="cyx", name="astronaut")
-    lbl = OMEZarrImage(data=da.from_array(label, chunks=chunks_labels), axes="yx", name="astronaut_labels")
+    img = OMEZarrImage(
+        data=da.from_array(pixels, chunks=chunks), axes="cyx", name="astronaut"
+    )
+    lbl = OMEZarrImage(
+        data=da.from_array(label, chunks=chunks_labels),
+        axes="yx",
+        name="astronaut_labels",
+    )
 
     img_ms = OMEZarrMultiscale(
         image=img,
         contrast_limits=[(0, 255), (0, 255), (0, 255)],
         channel_colors=["FF0000", "00FF00", "0000FF"],
-        channel_names=["Red", "Green", "Blue"],)
+        channel_names=["Red", "Green", "Blue"],
+    )
     lbl_ms = OMEZarrLabels(image=lbl)
 
     return img_ms, lbl_ms

--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -1,7 +1,8 @@
 """Functions for generating synthetic data."""
 
 from collections.abc import Callable
-from typing import cast, Literal
+from typing import Literal, cast
+
 import dask.array as da
 import numpy as np
 import zarr

--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -161,4 +161,4 @@ def create_zarr(
         overwrite=True,
     )
 
-    return zarr.open(zarr_directory, mode="r")
+    return zarr.open(zarr_directory, mode="a")

--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from random import randrange
 
+import dask.array as da
 import numpy as np
 import zarr
 from scipy.ndimage import zoom
@@ -15,20 +16,21 @@ from .format import CurrentFormat, Format
 from .io import parse_url
 from .scale import Scaler
 from .writer import add_metadata, write_multiscale
+from ome_zarr import OMEZarrImage, OMEZarrLabels, OMEZarrMultiscale
 
 CHANNEL_DIMENSION = 1
 
 
-def coins() -> tuple[list, list]:
+def coins() -> tuple[OMEZarrMultiscale, OMEZarrLabels]:
     """
     Sample data from skimage.
 
     Returns
     -------
-    pyramids :
-        List of pyramid arrays.
-    labels :
-        List of labels.
+    image : OMEZarrMultiscale
+        Image array.
+    labels : OMEZarrLabels
+        Label array.
     """
     from skimage.morphology import closing, footprint_rectangle, remove_small_objects
 
@@ -38,15 +40,23 @@ def coins() -> tuple[list, list]:
     thresh = threshold_otsu(image)
     bw = closing(image > thresh, footprint_rectangle((4, 4)))
     cleared = remove_small_objects(clear_border(bw), max_size=20)
-    label_image = label(cleared)
+    label_image = np.asarray(label(cleared))
+    chunks = [s // 8 if s > 8 else 1 for s in image.shape]
 
-    pyramid = list(reversed([zoom(image, 2**i, order=3) for i in range(4)]))
-    labels = list(reversed([zoom(label_image, 2**i, order=0) for i in range(4)]))
+    img = OMEZarrImage(data=da.from_array(image, chunks=chunks), axes="yx", name="coins")
+    lbl = OMEZarrImage(data=da.from_array(label_image, chunks=chunks), axes="yx", name="coins")
 
-    return pyramid, labels
+    img_ms = OMEZarrMultiscale(
+        image=img,
+        contrast_limits=[(0, 255)],
+        channel_colors=["FF0000"],
+    )
+    lbl_ms = OMEZarrLabels(image=lbl)
+
+    return img_ms, lbl_ms
 
 
-def astronaut() -> tuple[list, list]:
+def astronaut() -> tuple[OMEZarrMultiscale, OMEZarrLabels]:
     """
     Sample data from skimage.
 
@@ -57,24 +67,33 @@ def astronaut() -> tuple[list, list]:
     labels :
         List of labels.
     """
-    scaler = Scaler()
-
     astro = data.astronaut()
     red = astro[:, :, 0]
     green = astro[:, :, 1]
     blue = astro[:, :, 2]
     astro = np.array([red, green, blue])
     pixels = np.tile(astro, (1, 2, 2))
-    pyramid = scaler.nearest(pixels)
 
-    shape = list(pyramid[0].shape)
+    shape = list(pixels.shape)
     _c, y, x = shape
     label = np.zeros((y, x), dtype=np.int8)
     make_circle(100, 100, 1, label[200:300, 200:300])
     make_circle(150, 150, 2, label[250:400, 250:400])
-    labels = scaler.nearest(label)
 
-    return pyramid, labels
+    chunks = [s // 8 if s > 8 else 1 for s in pixels.shape]
+    chunks_labels = [s // 8 if s > 8 else 1 for s in label.shape]
+
+    img = OMEZarrImage(data=da.from_array(pixels, chunks=chunks), axes="cyx", name="astronaut")
+    lbl = OMEZarrImage(data=da.from_array(label, chunks=chunks_labels), axes="yx", name="astronaut_labels")
+
+    img_ms = OMEZarrMultiscale(
+        image=img,
+        contrast_limits=[(0, 255), (0, 255), (0, 255)],
+        channel_colors=["FF0000", "00FF00", "0000FF"],
+        channel_names=["Red", "Green", "Blue"],)
+    lbl_ms = OMEZarrLabels(image=lbl)
+
+    return img_ms, lbl_ms
 
 
 def make_circle(h: int, w: int, value: int, target: np.ndarray) -> None:
@@ -120,112 +139,18 @@ def rgb_to_5d(pixels: np.ndarray) -> list:
 
 def create_zarr(
     zarr_directory: str,
-    method: Callable[..., tuple[list, list]] = coins,
+    method: Callable[..., tuple[OMEZarrMultiscale, OMEZarrLabels]] = coins,
     label_name: str = "coins",
     fmt: Format = CurrentFormat(),
     chunks: tuple | list | None = None,
 ) -> zarr.Group:
     """Generate a synthetic image pyramid with labels."""
-    pyramid, labels = method()
-
-    loc = parse_url(zarr_directory, mode="w", fmt=fmt)
-    assert loc
-    grp = zarr.group(loc.store)
-    axes = None
-    if fmt.version not in ("0.1", "0.2"):
-        if pyramid[0].ndim == 3:
-            axes = "cyx"
-            size_c = 3
-        else:
-            axes = "tczyx"[-pyramid[0].ndim :]
-            size_c = 1
-    else:
-        # v0.1 and v0.2 must be 5D
-        pyramid = [rgb_to_5d(layer) for layer in pyramid]
-        if labels:
-            labels = [rgb_to_5d(layer) for layer in labels]
-        size_c = pyramid[0].shape[CHANNEL_DIMENSION]
-
-    if chunks is None:
-        # Use smallest pyramid as chunk size...
-        chunks = list(pyramid[-1].shape)
-        # setting any z, c, t sizes to 1
-        for zct in range(3):
-            if zct + 2 < len(chunks):
-                chunks[zct] = 1
-
-    storage_options = dict(chunks=tuple(chunks))
-
-    if size_c == 1:
-        image_data = {
-            "channels": [
-                {
-                    "window": {"start": 0, "end": 255, "min": 0, "max": 255},
-                    "color": "FF0000",
-                    "active": True,
-                }
-            ],
-            "rdefs": {"model": "greyscale"},
-        }
-    else:
-        image_data = {
-            "channels": [
-                {
-                    "color": "FF0000",
-                    "window": {"start": 0, "end": 255, "min": 0, "max": 255},
-                    "label": "Red",
-                    "active": True,
-                },
-                {
-                    "color": "00FF00",
-                    "window": {"start": 0, "end": 255, "min": 0, "max": 255},
-                    "label": "Green",
-                    "active": True,
-                },
-                {
-                    "color": "0000FF",
-                    "window": {"start": 0, "end": 255, "min": 0, "max": 255},
-                    "label": "Blue",
-                    "active": True,
-                },
-            ],
-            "rdefs": {"model": "color"},
-        }
-    write_multiscale(
-        pyramid,
-        grp,
-        axes=axes,
-        storage_options=storage_options,
-        metadata={"omero": image_data},
-        fmt=fmt,
+    image, label = method()
+    image.labels = {label.name: label}
+    image.to_ome_zarr(
+        zarr_directory,
+        version=fmt.version,
+        overwrite=True,
     )
 
-    if labels:
-        labels_grp = grp.create_group("labels")
-        add_metadata(labels_grp, {"labels": [label_name]})
-
-        label_grp = labels_grp.create_group(label_name)
-        if axes is not None:
-            # remove channel axis for masks
-            axes = axes.replace("c", "")
-        write_multiscale(labels, label_grp, axes=axes, fmt=fmt)
-
-        colors = []
-        properties = []
-        for x in range(1, 9):
-            rgba = [randrange(0, 256) for i in range(4)]
-            colors.append({"label-value": x, "rgba": rgba})
-            properties.append({"label-value": x, "class": f"class {x}"})
-        add_metadata(
-            label_grp,
-            {
-                "image-label": {
-                    "version": fmt.version,
-                    "colors": colors,
-                    "properties": properties,
-                    "source": {"image": "../../"},
-                }
-            },
-        )
-
-    return grp
+    return zarr.open(zarr_directory, mode="r")

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -272,7 +272,6 @@ def write_multiscale(
     compute: bool = True,
     scale: dict[str, float] | None = None,
     axes_units: dict[str, str] | None = None,
-    **metadata: str | JSONDict | list[JSONDict],
 ) -> list:
     """
     Write a pyramid with multiscale metadata to disk.
@@ -345,6 +344,7 @@ def write_multiscale(
         :class:`dask.delayed.Delayed` representing the value to be computed by
         dask.
     """
+    from ome_zarr import OMEZarrImage, OMEZarrMultiscale
     group, fmt = check_group_fmt(group, fmt)
     dims = len(pyramid[0].shape)
     axes = _get_valid_axes(dims, axes, axes_units=axes_units, fmt=fmt)
@@ -365,113 +365,35 @@ def write_multiscale(
         )
         warnings.warn(msg, DeprecationWarning)
 
-    pyramid = [
-        da.from_array(level) if not isinstance(level, da.Array) else level
-        for level in pyramid
-    ]
-    dask_delayed = _write_pyramid_to_zarr(
-        pyramid,
+    images = []
+    for level in pyramid:
+        relative_factor = np.asarray(level.shape) / np.asarray(pyramid[0].shape)
+        level_scale = {d: s * relative_factor[i] for i, (d, s) in enumerate(scale.items())}
+        img = OMEZarrImage(
+            data=level,
+            axes=list(scale.keys()),
+            scale=level_scale,
+            axes_units=axes_units,
+            name=name
+        )
+        images.append(img)
+
+    ms = OMEZarrMultiscale(
+        image=images,
+        )
+
+    if fmt.version not in ("0.4", "0.5", "0.6.dev4"):
+        raise ValueError(f"Unsupported format version: {fmt.version}")
+    
+    dask_delayed = ms.to_ome_zarr(
         group,
-        fmt=fmt,
-        scale=scale,
-        axes=list(scale.keys()),
-        axes_units=axes_units,
-        coordinate_transformations=coordinate_transformations,
-        storage_options=storage_options,
-        name=name,
+        version=fmt.version,
         compute=compute,
-        **metadata,
-    )
+        storage_options=storage_options,
+        overwrite=True,
+        )
 
     return dask_delayed
-
-
-def write_multiscales_metadata(
-    group: zarr.Group | str,
-    datasets: list[dict],
-    fmt: Format | None = None,
-    axes: AxesType = None,
-    axes_units: dict[str, str] | None = None,
-    name: str | None = None,
-    **metadata: str | JSONDict | list[JSONDict],
-) -> None:
-    """
-    Write the multiscales metadata in the group.
-
-    :type group: :class:`zarr.Group`
-    :param group: The zarr group or path.
-    :type datasets: list of dicts
-    :param datasets:
-      The list of datasets (dicts) for this multiscale image.
-      Each dict must include 'path' and a 'coordinateTransformations'
-      list for version 0.4 or later that must include a 'scale' transform.
-    :type fmt: :class:`ome_zarr.format.Format`, optional
-    :param fmt:
-      The format of the ome_zarr data which should be used.
-      Defaults to the most current.
-    :type axes: list of str or list of dicts, optional
-    :param axes:
-      The names of the axes. e.g. ["t", "c", "z", "y", "x"].
-      Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
-    :type axes_units: dict of str to str, optional
-    :param axes_units:
-      The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-      For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
-    """
-
-    group, fmt = check_group_fmt(group, fmt)
-    ndim = -1
-    if axes is not None:
-        if fmt.version in ("0.1", "0.2"):
-            LOGGER.info("axes ignored for version 0.1 or 0.2")
-            axes = None
-        else:
-            axes = _get_valid_axes(axes=axes, axes_units=axes_units, fmt=fmt)
-            if axes is not None:
-                ndim = len(axes)
-    if (
-        isinstance(metadata, dict)
-        and metadata.get("metadata")
-        and isinstance(metadata["metadata"], dict)
-        and "omero" in metadata["metadata"]
-    ):
-        omero_metadata = metadata["metadata"].pop("omero")
-        if omero_metadata is None:
-            raise KeyError("If `'omero'` is present, value cannot be `None`.")
-        for c in omero_metadata["channels"]:
-            if "color" in c:  # noqa: SIM102
-                if not isinstance(c["color"], str) or len(c["color"]) != 6:
-                    raise TypeError("`'color'` must be a hex code string.")
-            if "window" in c:
-                if not isinstance(c["window"], dict):
-                    raise TypeError("`'window'` must be a dict.")
-                for p in ["min", "max", "start", "end"]:
-                    if p not in c["window"]:
-                        raise KeyError(f"`'{p}'` not found in `'window'`.")
-                    if not isinstance(c["window"][p], (int, float)):
-                        raise TypeError(f"`'{p}'` must be an int or float.")
-
-        add_metadata(group, {"omero": omero_metadata})
-
-    # note: we construct the multiscale metadata via dict(), rather than {}
-    # to avoid duplication of protected keys like 'version' in **metadata
-    # (for {} this would silently over-write it, with dict() it explicitly fails)
-    multiscales = [
-        dict(datasets=_validate_datasets(datasets, ndim, fmt), name=name or group.name)
-    ]
-    if len(metadata.get("metadata", {})) > 0:
-        multiscales[0]["metadata"] = metadata["metadata"]
-    if axes is not None:
-        multiscales[0]["axes"] = axes
-
-    if fmt.version in ("0.1", "0.2", "0.3", "0.4"):
-        multiscales[0]["version"] = fmt.version
-    else:
-        # Zarr v3 top-level version
-        add_metadata(group, {"version": fmt.version})
-
-    add_metadata(group, {"multiscales": multiscales})
-
 
 def write_plate_metadata(
     group: zarr.Group | str,
@@ -907,85 +829,7 @@ def _write_pyramid_to_zarr(
         da.compute(*delayed)
         delayed = []
 
-    if coordinate_transformations is None:
-        # shapes = [data.shape for data in delayed]
-        coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
-
-        if coordinate_transformations:
-            for transform in coordinate_transformations:
-                transform[0]["scale"] = [
-                    transform[0]["scale"][i] * scale.get(d, 1.0)
-                    for i, d in enumerate(axes)
-                ]
-
-    # we validate again later, but this catches length mismatch before zip(datasets...)
-    fmt.validate_coordinate_transformations(
-        len(pyramid[0].shape), len(datasets), coordinate_transformations
-    )
-    if coordinate_transformations is not None:
-        for dataset, transform in zip(datasets, coordinate_transformations):
-            dataset["coordinateTransformations"] = transform
-
-    write_multiscales_metadata(
-        group,
-        datasets=datasets,
-        fmt=fmt,
-        axes=list(axes),
-        name=name,
-        axes_units=axes_units,
-        **metadata,
-    )
     return delayed
-
-
-def write_label_metadata(
-    group: zarr.Group | str,
-    name: str,
-    colors: list[JSONDict] | None = None,
-    properties: list[JSONDict] | None = None,
-    fmt: Format | None = None,
-    **metadata: list[JSONDict] | JSONDict | str,
-) -> None:
-    """
-    Write image-label metadata to the group.
-
-    The label data must have been written to a sub-group,
-    with the same name as the second argument.
-
-    :type group: :class:`zarr.Group`
-    :param group: The zarr group or path to write the metadata in.
-    :type name: str
-    :param name: The name of the label sub-group.
-    :type colors: list of JSONDict, optional
-    :param colors:
-      Fixed colors for (a subset of) the label values.
-      Each dict specifies the color for one label and must contain the fields
-      "label-value" and "rgba".
-    :type properties: list of JSONDict, optional
-    :param properties:
-      Additional properties for (a subset of) the label values.
-      Each dict specifies additional properties for one label.
-      It must contain the field "label-value"
-      and may contain arbitrary additional properties.
-    :type fmt: :class:`ome_zarr.format.Format`, optional
-    :param fmt:
-      The format of the ome_zarr data which should be used.
-      Defaults to the most current.
-    """
-    group, fmt = check_group_fmt(group, fmt)
-    label_group = group[name]
-    image_label_metadata = {**metadata}
-    if colors is not None:
-        image_label_metadata["colors"] = colors
-    if properties is not None:
-        image_label_metadata["properties"] = properties
-    image_label_metadata["version"] = fmt.version
-
-    label_list = get_metadata(group).get("labels", [])
-    label_list.append(name)
-
-    add_metadata(group, {"labels": label_list}, fmt=fmt)
-    add_metadata(label_group, {"image-label": image_label_metadata}, fmt=fmt)
 
 
 def get_metadata(group: zarr.Group | str) -> dict:
@@ -1037,7 +881,6 @@ def write_multiscale_labels(
     scale: dict[str, float] | None = None,
     axes_units: dict[str, str] | None = None,
     compute: bool = True,
-    **metadata: JSONDict,
 ) -> list:
     """
     Write pyramidal image labels to disk.
@@ -1114,14 +957,10 @@ def write_multiscale_labels(
         :class:`dask.delayed.Delayed` representing the value to be computed by
         dask.
     """
+    from ome_zarr import OMEZarrImage, OMEZarrLabels
     group, fmt = check_group_fmt(group, fmt)
-    sub_group = group.require_group(f"labels/{name}")
-
-    # Ensure pyramid is all dask arrays
-    pyramid = [
-        da.from_array(level) if not isinstance(level, da.Array) else level
-        for level in pyramid
-    ]
+    dims = len(pyramid[0].shape)
+    axes = _get_valid_axes(dims, axes, axes_units=axes_units, fmt=fmt)
 
     if scale is None:
         _axes = _get_valid_axes(
@@ -1142,25 +981,50 @@ def write_multiscale_labels(
         )
         warnings.warn(msg, DeprecationWarning)
 
-    dask_delayed_jobs = _write_pyramid_to_zarr(
-        pyramid,
-        sub_group,
-        fmt=fmt,
-        scale=scale,
-        axes=list(scale.keys()),
-        axes_units=axes_units,
-        coordinate_transformations=coordinate_transformations,
+    sub_group = group.require_group(f"labels/{name}")
+
+    images: list[OMEZarrImage] = []
+    for level in pyramid:
+        relative_factor = np.asarray(level.shape) / np.asarray(pyramid[0].shape)
+        level_scale = {d: s / relative_factor[i] for i, (d, s) in enumerate(scale.items())}
+        images.append(
+            OMEZarrImage(
+                data=level,
+                scale=level_scale,
+                axes=list(scale.keys()),
+                name=name,
+                axes_units=axes_units,
+            )
+        )
+
+    ms = OMEZarrLabels(image=images)
+    if label_metadata is not None:
+        ms.image_label = label_metadata
+
+    dask_delayed_jobs = ms.to_ome_zarr(
+        group=sub_group,
         storage_options=storage_options,
-        name=name,
+        version=fmt.version,  # type: ignore[arg-type]
         compute=compute,
-        **metadata,
+        overwrite=True
     )
-    write_label_metadata(
-        group["labels"],
-        name,
-        fmt=fmt,
-        **({} if label_metadata is None else label_metadata),
-    )
+
+    label_list = []
+    if fmt.version in ("0.1", "0.2", "0.3", "0.4"):
+        node_metadata = group["labels"].attrs
+    else:
+        node_metadata = group["labels"].attrs.get("ome", {})
+
+    label_list = node_metadata.get("labels", [])
+    label_list.append(name)
+
+    if fmt.version in ("0.1", "0.2", "0.3", "0.4"):
+        group["labels"].attrs["labels"] = label_list
+    else:
+        group["labels"].attrs["ome"] = {
+            "version": fmt.version,
+            "labels": label_list,
+        }
 
     return dask_delayed_jobs
 
@@ -1320,7 +1184,10 @@ def write_labels(
         scale_factors=scale_factors,
         method=method,
     )
-    multiscales.image_label = image_label
+
+    if label_metadata is not None:
+        multiscales.image_label = label_metadata
+
     dask_delayed_jobs = multiscales.to_ome_zarr(
         group=sub_group,
         storage_options=storage_options,
@@ -1329,12 +1196,22 @@ def write_labels(
         overwrite=True,
     )
 
-    write_label_metadata(
-        group=group["labels"],
-        name=name,
-        fmt=fmt,
-        **({} if label_metadata is None else label_metadata),
-    )
+    label_list = []
+    if fmt.version in ("0.1", "0.2", "0.3", "0.4"):
+        node_metadata = group["labels"].attrs
+    else:
+        node_metadata = group["labels"].attrs.get("ome", {})
+
+    label_list = node_metadata.get("labels", [])
+    label_list.append(name)
+
+    if fmt.version in ("0.1", "0.2", "0.3", "0.4"):
+        group["labels"].attrs["labels"] = label_list
+    else:
+        group["labels"].attrs["ome"] = {
+            "version": fmt.version,
+            "labels": label_list,
+        }
 
     return dask_delayed_jobs
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -321,6 +321,7 @@ def write_multiscale(
         e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
     """
     from ome_zarr import OMEZarrImage, OMEZarrMultiscale
+
     group, fmt = check_group_fmt(group, fmt)
     dims = len(pyramid[0].shape)
     axes = _get_valid_axes(dims, axes, axes_units=axes_units, fmt=fmt)
@@ -342,32 +343,35 @@ def write_multiscale(
     images = []
     for level in pyramid:
         relative_factor = np.asarray(level.shape) / np.asarray(pyramid[0].shape)
-        level_scale = {d: s * relative_factor[i] for i, (d, s) in enumerate(scale.items())}
+        level_scale = {
+            d: s * relative_factor[i] for i, (d, s) in enumerate(scale.items())
+        }
         img = OMEZarrImage(
             data=level,
             axes=list(scale.keys()),
             scale=level_scale,
             axes_units=axes_units,
-            name=name
+            name=name,
         )
         images.append(img)
 
     ms = OMEZarrMultiscale(
         image=images,
-        )
+    )
 
     if fmt.version not in ("0.4", "0.5", "0.6.dev4"):
         raise ValueError(f"Unsupported format version: {fmt.version}")
-    
+
     dask_delayed = ms.to_ome_zarr(
         group,
         version=fmt.version,
         compute=compute,
         storage_options=storage_options,
         overwrite=True,
-        )
+    )
 
     return dask_delayed
+
 
 def write_plate_metadata(
     group: zarr.Group | str,
@@ -857,66 +861,67 @@ def write_multiscale_labels(
     compute: bool = True,
 ) -> list:
     """
-    Write precomputed pyramidal image labels to disk.
+        Write precomputed pyramidal image labels to disk.
 
-    This function writes a multiscale pyramid of label data to a zarr store,
-    along with the appropriate metadata according to the OME-Zarr specification.
-    The label data is saved under a `labels/{name}` subgroup at the specified `group` location.
+        This function writes a multiscale pyramid of label data to a zarr store,
+        along with the appropriate metadata according to the OME-Zarr specification.
+        The label data is saved under a `labels/{name}` subgroup at the specified `group` location.
 
-    Parameters
-    ----------
-    pyramid : list of numpy.ndarray
-        The image label data to save. The largest level should be first in the list.
-        All image arrays MUST be up to 5-dimensional with dimensions ordered (t, c,
-        z, y, x).
-    group : zarr.Group or str
-        The zarr group or path to write the data in.
-        The label data will be saved under a `labels/{name}` subgroup.
-    name : str
-        The name of this labels data.
-    fmt : ome_zarr.format.Format, optional
-        The format of the ome_zarr data which should be used.
-        Defaults to the most current.
-    axes : list of str or list of dicts, optional
-        The names of the axes, e.g. ["t", "c", "z", "y", "x"].
-    axes_units : dict of str to str, optional
-        The physical units for each dimension, e.g. {"t": "millisecond", "
-z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-        For a list of recommended units,
-        see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
-    coordinate_transformations : list of list of dict, optional
-        [DEPRECATED] For each resolution, a list of transformation dicts (not validated).
-    storage_options : dict or list of dict, optional
-        Options to be passed on to the storage backend.
-        A list would need to match the number of datasets in a multiresolution pyramid.
-        One can provide different chunk size for each level of a pyramid using this
-        option.
-        Regarding the key, value pairs in the dictionar(y)(ies), these depend both on the zarr_format used
-        for writing and the dask version being used. For dask version <=2025.11.0, please refer to
-        https://zarr.readthedocs.io/en/stable/api/zarr/create/#zarr.create for arguments that can be passed on.
-        For >=2026.3.0 and up, please refer to https://zarr.readthedocs.io/en/stable/api/zarr/create/#zarr.create_array.
-        It might be that you have to adjust the version of the docs. Note that the docs will also mention the
-        differences of allowed arguments between zarr_format 2 and 3.
+        Parameters
+        ----------
+        pyramid : list of numpy.ndarray
+            The image label data to save. The largest level should be first in the list.
+            All image arrays MUST be up to 5-dimensional with dimensions ordered (t, c,
+            z, y, x).
+        group : zarr.Group or str
+            The zarr group or path to write the data in.
+            The label data will be saved under a `labels/{name}` subgroup.
+        name : str
+            The name of this labels data.
+        fmt : ome_zarr.format.Format, optional
+            The format of the ome_zarr data which should be used.
+            Defaults to the most current.
+        axes : list of str or list of dicts, optional
+            The names of the axes, e.g. ["t", "c", "z", "y", "x"].
+        axes_units : dict of str to str, optional
+            The physical units for each dimension, e.g. {"t": "millisecond", "
+    z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+            For a list of recommended units,
+            see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
+        coordinate_transformations : list of list of dict, optional
+            [DEPRECATED] For each resolution, a list of transformation dicts (not validated).
+        storage_options : dict or list of dict, optional
+            Options to be passed on to the storage backend.
+            A list would need to match the number of datasets in a multiresolution pyramid.
+            One can provide different chunk size for each level of a pyramid using this
+            option.
+            Regarding the key, value pairs in the dictionar(y)(ies), these depend both on the zarr_format used
+            for writing and the dask version being used. For dask version <=2025.11.0, please refer to
+            https://zarr.readthedocs.io/en/stable/api/zarr/create/#zarr.create for arguments that can be passed on.
+            For >=2026.3.0 and up, please refer to https://zarr.readthedocs.io/en/stable/api/zarr/create/#zarr.create_array.
+            It might be that you have to adjust the version of the docs. Note that the docs will also mention the
+            differences of allowed arguments between zarr_format 2 and 3.
 
-        Note: for chunks the default of `auto` is not allowed. This because the argument here refers to zarr chunks and
-        autochunking here can result in different chunks then for the dask array. This can cause inconsistent overlap
-        between dask and zarr chunks, potentially resulting in corrupted data. The default will be that if no sharding
-        is specified, that the chunks correspond to the dask chunksize. This is also the case when chunks are provided as
-        `None` and no sharding is provided.
-    label_metadata : dict, optional
-        Image label metadata.
-        See [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#labels-metadata) for details.
-        If not passed, is computed from the label data and stored in the metadata.
-    scale : dict of str to float, optional
-        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
-        The pixel sizes for every passed resolution level are calculated directly from the defined `scale`
-        for each resolution level. If not passed, defaults to 1.0 for all dimensions.
-    axes_units : dict of str to str, optional
-        The physical units for each axis, e.g. {"z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-    compute : bool, optional
-        If True, compute immediately; otherwise, return a list of dask.delayed.Delayed objects.
+            Note: for chunks the default of `auto` is not allowed. This because the argument here refers to zarr chunks and
+            autochunking here can result in different chunks then for the dask array. This can cause inconsistent overlap
+            between dask and zarr chunks, potentially resulting in corrupted data. The default will be that if no sharding
+            is specified, that the chunks correspond to the dask chunksize. This is also the case when chunks are provided as
+            `None` and no sharding is provided.
+        label_metadata : dict, optional
+            Image label metadata.
+            See [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#labels-metadata) for details.
+            If not passed, is computed from the label data and stored in the metadata.
+        scale : dict of str to float, optional
+            The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
+            The pixel sizes for every passed resolution level are calculated directly from the defined `scale`
+            for each resolution level. If not passed, defaults to 1.0 for all dimensions.
+        axes_units : dict of str to str, optional
+            The physical units for each axis, e.g. {"z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        compute : bool, optional
+            If True, compute immediately; otherwise, return a list of dask.delayed.Delayed objects.
     """
     from ome_zarr import OMEZarrImage, OMEZarrLabels
+
     group, fmt = check_group_fmt(group, fmt)
     dims = len(pyramid[0].shape)
     axes = _get_valid_axes(dims, axes, axes_units=axes_units, fmt=fmt)
@@ -945,7 +950,9 @@ z": "micrometer", "y": "micrometer", "x": "micrometer"}.
     images: list[OMEZarrImage] = []
     for level in pyramid:
         relative_factor = np.asarray(level.shape) / np.asarray(pyramid[0].shape)
-        level_scale = {d: s / relative_factor[i] for i, (d, s) in enumerate(scale.items())}
+        level_scale = {
+            d: s / relative_factor[i] for i, (d, s) in enumerate(scale.items())
+        }
         images.append(
             OMEZarrImage(
                 data=level,
@@ -965,7 +972,7 @@ z": "micrometer", "y": "micrometer", "x": "micrometer"}.
         storage_options=storage_options,
         version=fmt.version,  # type: ignore[arg-type]
         compute=compute,
-        overwrite=True
+        overwrite=True,
     )
 
     label_list = []

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -274,44 +274,23 @@ def write_multiscale(
     axes_units: dict[str, str] | None = None,
 ) -> list:
     """
-    Write a pyramid with multiscale metadata to disk.
+    Write a pyramid with precomputed multiscale resolution levels to disk.
 
-    :type pyramid: list of :class:`numpy.ndarray` or :class:`dask.array.Array`
-    :param pyramid:
+    Parameters
+    ----------
+    pyramid: list of :class:`numpy.ndarray` or :class:`dask.array.Array`
         The image data to save. Largest level first. All image arrays MUST be up to
         5-dimensional with dimensions ordered (t, c, z, y, x)
-    :type group: :class:`zarr.Group`
-    :param group: The group within the zarr store to store the data in
-    :type scale: dict of str to float, optional
-    :param scale:
-        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
-        The pixel sizes for every resolution level are calculated directly from the defined `scale` and
-        `scale_factors` for each level.
-    :type chunks: int or tuple of ints, optional
-    :param chunks:
-        The size of the saved chunks to store the image.
-
-        .. deprecated:: 0.4.0
-            This argument is deprecated and will be removed in a future version.
-            Use :attr:`storage_options` instead.
-    :type fmt: :class:`ome_zarr.format.Format`, optional
-    :param fmt:
+    group: :class:`zarr.Group`
+        The group within the zarr store to store the data in
+    fmt: :class:`ome_zarr.format.Format`, optional
         The format of the ome_zarr data which should be used.
-        Defaults to the most current.
-    :type axes: str list of str or list of dict, optional
-    :param axes:
-        List of axes dicts, or names. Not needed for v0.1 or v0.2 or if 2D. Otherwise
-        this must be provided
-    :param axes_units:
-        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
-    :type coordinate_transformations: 2Dlist of dict, optional
-    :param coordinate_transformations:
-        List of transformations for each path.
-        Each list of dicts are added to each datasets in order and must include a
-        'scale' transform.
-    :type storage_options: dict or list of dict, optional
-    :param storage_options:
+        Defaults to the most current (:class:`ome_zarr.format.CurrentFormat`).
+    axes: list of str or list of dict, optional
+        List of axes dicts, or names, i.e. ["t", "c", "z", "y", "x"].
+    coordinate_transformations: list of list of dict, optional
+        [DEPRECATED] For each resolution, a list of transformation dicts (not validated).
+    storage_options: dict or list of dict, optional
         Options to be passed on to the storage backend.
         A list would need to match the number of datasets in a multiresolution pyramid.
         One can provide different chunk size and / or shards for each level of a pyramid using this
@@ -327,22 +306,19 @@ def write_multiscale(
         between dask and zarr chunks, potentially resulting in corrupted data. The default will be that if no sharding
         is specified, that the chunks correspond to the dask chunksize. This is also the case when chunks are provided as
         `None` and no sharding is provided.
-    :param compute:
-        If true compute immediately otherwise a list of :class:`dask.delayed.Delayed`
+    name: str, optional
+        The name of the image, to be included in the metadata. Defaults to "image".
+    compute: bool, optional
+        If true, compute immediately otherwise a list of :class:`dask.delayed.Delayed`
         is returned.
-    :type scale: dict of str to float, optional
-    :param scale:
+    scale: dict of str to float, optional
         The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
         For each additional resolution level, the pixel sizes are derived from this
         base `scale` and the relative shapes of the arrays provided in `pyramid`.
-    :type axes_units: dict of str to str, optional
-    :param axes_units:
-        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
-    :return:
-        Empty list if the compute flag is True, otherwise it returns a list of
-        :class:`dask.delayed.Delayed` representing the value to be computed by
-        dask.
+        If not provided, defaults to 1.0 for all dimensions.
+    axes_units: dict of str to str, optional
+        The physical units for each dimension,
+        e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
     """
     from ome_zarr import OMEZarrImage, OMEZarrMultiscale
     group, fmt = check_group_fmt(group, fmt)
@@ -883,44 +859,36 @@ def write_multiscale_labels(
     compute: bool = True,
 ) -> list:
     """
-    Write pyramidal image labels to disk.
+    Write precomputed pyramidal image labels to disk.
 
-    Including the multiscales and image-label metadata.
-    Creates the label data in the sub-group "labels/{name}"
+    This function writes a multiscale pyramid of label data to a zarr store,
+    along with the appropriate metadata according to the OME-Zarr specification.
+    The label data is saved under a `labels/{name}` subgroup at the specified `group` location.
 
-    :type pyramid: list of :class:`numpy.ndarray`
-    :param pyramid:
-      the image label data to save. Largest level first
-      All image arrays MUST be up to 5-dimensional with dimensions
-      ordered (t, c, z, y, x)
-    :type group: :class:`zarr.Group`
-    :param group: The zarr group or path to write the metadata in.
-    :type name: str, optional
-    :param name: The name of this labels data.
-    :type scale: dict of str to float, optional
-    :param scale:
-        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
-        The pixel sizes for every resolution level are calculated directly from the defined `scale` and
-        `scale_factors` for each level.
-    :type chunks: int or tuple of ints, optional
-    :type fmt: :class:`ome_zarr.format.Format`, optional
-    :param fmt:
-      The format of the ome_zarr data which should be used.
-      Defaults to the most current.
-    :type axes: list of str or list of dicts, optional
-    :param axes:
-      The names of the axes. e.g. ["t", "c", "z", "y", "x"].
-      Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
-    :type axes_units: dict of str to str, optional
-    :param axes_units:
-        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
-    :type coordinate_transformations: list of dict
-    :param coordinate_transformations:
-      For each resolution, we have a List of transformation Dicts (not validated).
-      Each list of dicts are added to each datasets in order.
-    :type storage_options: dict or list of dict, optional
-    :param storage_options:
+    Parameters
+    ----------
+    pyramid : list of numpy.ndarray
+        The image label data to save. The largest level should be first in the list.
+        All image arrays MUST be up to 5-dimensional with dimensions ordered (t, c,
+        z, y, x).
+    group : zarr.Group or str
+        The zarr group or path to write the data in.
+        The label data will be saved under a `labels/{name}` subgroup.
+    name : str
+        The name of this labels data.
+    fmt : ome_zarr.format.Format, optional
+        The format of the ome_zarr data which should be used.
+        Defaults to the most current.
+    axes : list of str or list of dicts, optional
+        The names of the axes, e.g. ["t", "c", "z", "y", "x"].
+    axes_units : dict of str to str, optional
+        The physical units for each dimension, e.g. {"t": "millisecond", "
+z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+        For a list of recommended units,
+        see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
+    coordinate_transformations : list of list of dict, optional
+        [DEPRECATED] For each resolution, a list of transformation dicts (not validated).
+    storage_options : dict or list of dict, optional
         Options to be passed on to the storage backend.
         A list would need to match the number of datasets in a multiresolution pyramid.
         One can provide different chunk size for each level of a pyramid using this
@@ -937,25 +905,18 @@ def write_multiscale_labels(
         between dask and zarr chunks, potentially resulting in corrupted data. The default will be that if no sharding
         is specified, that the chunks correspond to the dask chunksize. This is also the case when chunks are provided as
         `None` and no sharding is provided.
-    :type label_metadata: dict, optional
-    :param label_metadata:
-      Image label metadata. See :meth:`write_label_metadata` for details
-    :param compute:
-        If true compute immediately otherwise a list of :class:`dask.delayed.Delayed`
-        is returned.
-    :type scale: dict of str to float, optional
-    :param scale:
-        The physical pixel size for each dimension at the highest-resolution level,
-        e.g. {"z": 0.1, "y": 0.1, "x": 0.5}. Pixel sizes for lower-resolution
-        levels are inferred from the shapes of the arrays in `pyramid`.
-    :type axes_units: dict of str to str, optional
-    :param axes_units:
-        The physical units for each dimension, e.g. {"t": "millisecond", "z": "micrometer", "y": "micrometer", "x": "micrometer"}.
-        For a list of recommended units, see [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#axes-metadata).
-    :return:
-        Empty list if the compute flag is True, otherwise it returns a list of
-        :class:`dask.delayed.Delayed` representing the value to be computed by
-        dask.
+    label_metadata : dict, optional
+        Image label metadata.
+        See [ngff specification](https://ngff.openmicroscopy.org/specifications/0.5/index.html#labels-metadata) for details.
+        If not passed, is computed from the label data and stored in the metadata.
+    scale : dict of str to float, optional
+        The physical pixel size for each dimension, e.g. {"z": 0.1, "y": 0.1, "x": 0.5}.
+        The pixel sizes for every passed resolution level are calculated directly from the defined `scale`
+        for each resolution level. If not passed, defaults to 1.0 for all dimensions.
+    axes_units : dict of str to str, optional
+        The physical units for each axis, e.g. {"z": "micrometer", "y": "micrometer", "x": "micrometer"}.
+    compute : bool, optional
+        If True, compute immediately; otherwise, return a list of dask.delayed.Delayed objects.
     """
     from ome_zarr import OMEZarrImage, OMEZarrLabels
     group, fmt = check_group_fmt(group, fmt)

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -332,12 +332,7 @@ def write_multiscale(
         msg = (
             "The 'coordinate_transformations' argument is deprecated and will "
             "be removed in a future version. Please use the `scale` argument "
-            "to specify the physical pixel size for each dimension instead. "
-            "When `coordinate_transformations` is provided, it takes "
-            "precedence over `scale`, so `scale` is not applied. When "
-            "`coordinate_transformations` is not provided, the pixel sizes "
-            "for every resolution level are calculated from `scale` and "
-            "`scale_factors`."
+            "to specify the physical pixel size for each dimension instead."
         )
         warnings.warn(msg, DeprecationWarning)
 

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Any, Literal, TypeAlias, cast
 
 import dask.array as da
 import numpy as np
@@ -364,7 +364,7 @@ def write_multiscale(
 
     dask_delayed = ms.to_ome_zarr(
         group,
-        version=fmt.version,
+        version=cast(Literal["0.6.dev4", "0.5", "0.4"], fmt.version),
         compute=compute,
         storage_options=storage_options,
         overwrite=True,
@@ -644,7 +644,7 @@ def write_image(
     dask_delayed_jobs = multiscale.to_ome_zarr(
         group=group,
         storage_options=storage_options,
-        version=fmt.version,  # type: ignore[arg-type]
+        version=cast(Literal["0.6.dev4", "0.5", "0.4"], fmt.version),
         compute=compute,
         overwrite=True,
     )
@@ -970,7 +970,7 @@ def write_multiscale_labels(
     dask_delayed_jobs = ms.to_ome_zarr(
         group=sub_group,
         storage_options=storage_options,
-        version=fmt.version,  # type: ignore[arg-type]
+        version=cast(Literal["0.6.dev4", "0.5", "0.4"], fmt.version),
         compute=compute,
         overwrite=True,
     )
@@ -1121,8 +1121,6 @@ def write_labels(
     if method is None:
         method = Methods.NEAREST
 
-    image_label = metadata.get("image-label")
-
     if scaler is not None:
         msg = """
         The 'scaler' argument is deprecated and will be removed in version 0.13.0.
@@ -1151,13 +1149,14 @@ def write_labels(
         method=method,
     )
 
+    label_metadata = metadata.get("image-label")
     if label_metadata is not None:
         multiscales.image_label = label_metadata
 
     dask_delayed_jobs = multiscales.to_ome_zarr(
         group=sub_group,
         storage_options=storage_options,
-        version=fmt.version,  # type: ignore[arg-type]
+        version=cast(Literal["0.6.dev4", "0.5", "0.4"], fmt.version),
         compute=compute,
         overwrite=True,
     )

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -328,6 +328,9 @@ def write_multiscale(
     if scale is None:
         scale = dict.fromkeys(_extract_dims_from_axes(axes), 1.0)
 
+    if name is None:
+        name = "image"
+
     if coordinate_transformations is not None:
         msg = (
             "The 'coordinate_transformations' argument is deprecated and will "

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -156,7 +156,6 @@ class TestInvalid:
 
     def test_invalid_version(self):
         grp = create_zarr(str(self.path))
-        grp = zarr.open_group(str(self.path), mode="a")  # open in append mode
 
         # update version to something invalid
         attrs = get_metadata(grp)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -156,6 +156,8 @@ class TestInvalid:
 
     def test_invalid_version(self):
         grp = create_zarr(str(self.path))
+        grp = zarr.open_group(str(self.path), mode="a")  # open in append mode
+
         # update version to something invalid
         attrs = get_metadata(grp)
         attrs["multiscales"][0]["version"] = "invalid"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -42,7 +42,6 @@ from ome_zarr.writer import (
     write_labels,
     write_multiscale,
     write_multiscale_labels,
-    write_multiscales_metadata,
     write_plate_metadata,
     write_well_metadata,
 )
@@ -1100,270 +1099,6 @@ class TestWriter:
                 axes="xt",
             )
 
-
-class TestMultiscalesMetadata:
-    @pytest.fixture(autouse=True)
-    def initdir(self, tmpdir):
-        self.path = pathlib.Path(tmpdir.mkdir("data"))
-        # create zarr v2 group...
-        self.root = zarr.open_group(self.path, mode="w", zarr_format=2)
-
-        # let's create zarr v3 group too...
-        self.path_v3 = self.path / "v3"
-        self.root_v3 = zarr.open_group(self.path_v3, mode="w", zarr_format=3)
-
-    @pytest.mark.parametrize("fmt", (FormatV04(), FormatV05()))
-    def test_multi_levels_transformations(self, fmt):
-        datasets = []
-        for level, transf in enumerate(TRANSFORMATIONS):
-            datasets.append({"path": str(level), "coordinateTransformations": transf})
-        if fmt.version == "0.5":
-            path = self.path_v3
-        else:
-            path = self.path
-        write_multiscales_metadata(str(path), datasets, axes="tczyx", fmt=fmt)
-        # we want to be sure this is zarr v2 / v3
-        attrs = zarr.open_group(path).attrs
-        if fmt.version == "0.5":
-            attrs = attrs.get("ome")
-            assert "version" in attrs
-            json_text = (self.path_v3 / "zarr.json").read_text(encoding="utf-8")
-            attrs_json = json.loads(json_text).get("attributes", {}).get("ome", {})
-        else:
-            json_text = (self.path / ".zattrs").read_text(encoding="utf-8")
-            attrs_json = json.loads(json_text)
-            assert "version" in attrs["multiscales"][0]
-        assert "multiscales" in attrs_json
-        assert "multiscales" in attrs
-        assert attrs["multiscales"][0]["datasets"] == datasets
-        # No arrays, so this is expected:
-        with pytest.raises(
-            ValueError,
-            match=re.escape(
-                "Expected to find an array at 0, but no array was found there."
-            ),
-        ):
-            out = zarr.open_group(path)
-            if fmt.version == "0.4":
-                Models04Image.from_zarr(out)
-            if fmt.version == "0.5":
-                Models05Image.from_zarr(out)
-
-    @pytest.mark.parametrize(
-        "axes",
-        (
-            ["y", "x"],
-            ["c", "y", "x"],
-            ["z", "y", "x"],
-            ["t", "y", "x"],
-            ["t", "c", "y", "x"],
-            ["t", "z", "y", "x"],
-            ["c", "z", "y", "x"],
-            ["t", "c", "z", "y", "x"],
-        ),
-    )
-    def test_axes_V03(self, axes):
-        write_multiscales_metadata(
-            self.root, [{"path": "0"}], fmt=FormatV03(), axes=axes
-        )
-        assert "multiscales" in self.root.attrs
-        # for v0.3, axes is a list of names
-        assert self.root.attrs["multiscales"][0]["axes"] == axes
-        with pytest.raises(ValueError):
-            # for v0.4 and above, paths no-longer supported (need dataset dicts)
-            write_multiscales_metadata(self.root, ["0"], axes=axes, fmt=FormatV04())
-
-    @pytest.mark.parametrize(
-        "axes",
-        (
-            [],
-            ["i", "j"],
-            ["x", "y"],
-            ["y", "x", "c"],
-            ["x", "y", "z", "c", "t"],
-        ),
-    )
-    def test_invalid_0_3_axes(self, axes):
-        with pytest.raises(ValueError):
-            write_multiscales_metadata(self.root, ["0"], fmt=FormatV03(), axes=axes)
-
-    @pytest.mark.parametrize("datasets", ([], None, "0", ["0"], [{"key": 1}]))
-    def test_invalid_datasets(self, datasets):
-        with pytest.raises(ValueError):
-            write_multiscales_metadata(
-                self.root, datasets, axes=["t", "c", "z", "y", "x"], fmt=FormatV04()
-            )
-
-    @pytest.mark.parametrize(
-        "coordinateTransformations",
-        (
-            [{"type": "scale", "scale": [1, 1]}],
-            [
-                {"type": "scale", "scale": [1, 1]},
-                {"type": "translation", "translation": [0, 0]},
-            ],
-        ),
-    )
-    def test_valid_transformations(self, coordinateTransformations):
-        axes = [{"name": "y", "type": "space"}, {"name": "x", "type": "space"}]
-        datasets = [
-            {
-                "path": "0",
-                "coordinateTransformations": coordinateTransformations,
-            }
-        ]
-        write_multiscales_metadata(self.root, datasets, axes=axes, fmt=FormatV04())
-        assert "multiscales" in self.root.attrs
-        assert self.root.attrs["multiscales"][0]["axes"] == axes
-        assert self.root.attrs["multiscales"][0]["datasets"] == datasets
-        # No arrays, so this is expected:
-        with pytest.raises(
-            ValueError,
-            match=re.escape(
-                "Expected to find an array at 0, but no array was found there."
-            ),
-        ):
-            Models04Image.from_zarr(self.root)
-
-    @pytest.mark.parametrize(
-        "coordinateTransformations",
-        (
-            [],
-            None,
-            [{"type": "scale"}],
-            [{"scale": [1, 1]}],
-            [{"type": "scale", "scale": ["1", 1]}],
-            [{"type": "scale", "scale": [1, 1, 1]}],
-            [{"type": "scale", "scale": [1, 1]}, {"type": "scale", "scale": [1, 1]}],
-            [
-                {"type": "scale", "scale": [1, 1]},
-                {"type": "translation", "translation": ["0", 0]},
-            ],
-            [
-                {"type": "translation", "translation": [0, 0]},
-            ],
-            [
-                {"type": "scale", "scale": [1, 1]},
-                {"type": "translation", "translation": [0, 0, 0]},
-            ],
-            [
-                {"type": "translation", "translation": [0, 0]},
-                {"type": "scale", "scale": [1, 1]},
-            ],
-            [
-                {"type": "scale", "scale": [1, 1]},
-                {"type": "translation", "translation": [0, 0]},
-                {"type": "translation", "translation": [1, 0]},
-            ],
-            [
-                {"type": "scale", "scale": [1, 1]},
-                {"translation": [0, 0]},
-            ],
-            [
-                {"type": "scale", "scale": [1, 1]},
-                {"type": "translation", "translate": [0, 0]},
-            ],
-        ),
-    )
-    def test_invalid_transformations(self, coordinateTransformations):
-        axes = [{"name": "y", "type": "space"}, {"name": "x", "type": "space"}]
-        datasets = [
-            {"path": "0", "coordinateTransformations": coordinateTransformations}
-        ]
-        with pytest.raises(ValueError):
-            write_multiscales_metadata(self.root, datasets, axes=axes, fmt=FormatV04())
-
-    @pytest.mark.parametrize(
-        "metadata",
-        [
-            {
-                "channels": [
-                    {
-                        "color": "FF0000",
-                        "window": {"start": 0, "end": 255, "min": 0, "max": 255},
-                    }
-                ]
-            },
-            {"channels": [{"color": "FF000"}]},  # test wrong metadata
-            {"channels": [{"window": []}]},  # test wrong metadata
-            {
-                "channels": [  # test wrong metadata
-                    {"color": "FF0000", "window": {"start": 0, "end": 255, "min": 0}},
-                ]
-            },
-            None,
-        ],
-    )
-    def test_omero_metadata(self, metadata: dict[str, Any] | None):
-        datasets = []
-        for level, transf in enumerate(TRANSFORMATIONS):
-            datasets.append({"path": str(level), "coordinateTransformations": transf})
-        if metadata is None:
-            with pytest.raises(
-                KeyError,
-                match=re.escape("If `'omero'` is present, value cannot be `None`."),
-            ):
-                write_multiscales_metadata(
-                    self.root,
-                    datasets,
-                    axes="tczyx",
-                    metadata={"omero": metadata},
-                )
-        else:
-            window_metadata = (
-                metadata["channels"][0].get("window")
-                if "window" in metadata["channels"][0]
-                else None
-            )
-            color_metadata = (
-                metadata["channels"][0].get("color")
-                if "color" in metadata["channels"][0]
-                else None
-            )
-            if window_metadata is not None and len(window_metadata) < 4:
-                if isinstance(window_metadata, dict):
-                    with pytest.raises(KeyError, match="window"):
-                        write_multiscales_metadata(
-                            self.root,
-                            datasets,
-                            axes="tczyx",
-                            metadata={"omero": metadata},
-                            fmt=FormatV04(),
-                        )
-                elif isinstance(window_metadata, list):
-                    with pytest.raises(TypeError, match="window"):
-                        write_multiscales_metadata(
-                            self.root,
-                            datasets,
-                            axes="tczyx",
-                            metadata={"omero": metadata},
-                            fmt=FormatV04(),
-                        )
-            elif color_metadata is not None and len(color_metadata) != 6:
-                with pytest.raises(TypeError, match="color"):
-                    write_multiscales_metadata(
-                        self.root,
-                        datasets,
-                        axes="tczyx",
-                        metadata={"omero": metadata},
-                    )
-            else:
-                write_multiscales_metadata(
-                    self.root,
-                    datasets,
-                    axes="tczyx",
-                    metadata={"omero": metadata},
-                )
-                # no arrays, so this is expected
-                with pytest.raises(
-                    ValueError,
-                    match=re.escape(
-                        "Expected to find an array at 0, but no array was found there."
-                    ),
-                ):
-                    Models04Image.from_zarr(self.root)
-
-
 class TestPlateMetadata:
     @pytest.fixture(autouse=True)
     def initdir(self, tmpdir):
@@ -1841,7 +1576,14 @@ class TestLabelWriter:
         return request.param
 
     def verify_label_data(
-        self, img_path, label_name, label_data, fmt, shape, transformations, scale
+        self,
+        img_path,
+        label_name,
+        label_data,
+        fmt,
+        shape,
+        transformations,
+        scale,
     ):
         # Verify image data
         out = zarr.open_group(f"{img_path}/labels/{label_name}")
@@ -1868,17 +1610,15 @@ class TestLabelWriter:
             assert transfs[0]["type"] == "scale"
             assert len(transfs[0]["scale"]) == len(shape)
 
+            base_shape = node_data[0].shape
+            shape = node_data[level].shape
+            factor = np.asarray(base_shape) / np.asarray(shape)
+
             # default downsamples by factor 2 each level, except z-axis
             for idx, value in enumerate(transfs[0]["scale"]):
-                axis_name = axes[idx]
-                if axis_name == "z":
-                    # z-axis is not downsampled by default
-                    assert value == scale[axis_name]
-                elif axis_name in ("x", "y"):
+                if axes[idx] in ("x", "y", "z"):
                     # spatial dimensions are downsampled
-                    assert value == scale[axis_name] * shape[idx] / (
-                        shape[idx] // (2**level)
-                    )
+                    assert value == scale[axes[idx]] * factor[idx]
                 else:
                     # non-spatial dimensions (t, c) are not downsampled
                     assert value == 1.0
@@ -2135,17 +1875,19 @@ class TestLabelWriter:
             label_data, method="nearest", scale_factors=scale_factors, dims=dims
         )
 
+        scale = dict(zip(axes, transformations[0][0]["scale"][-len(shape) :]))
         write_multiscale_labels(
             pyramid,
             group,
             name=label_name,
             fmt=fmt,
             axes=axes,
+            scale=scale,
             coordinate_transformations=transformations,
         )
-        scale = dict(zip(axes, transformations[0][0]["scale"][-len(shape) :]))
+        
         self.verify_label_data(
-            img_path, label_name, label_data, fmt, shape, transformations, scale
+            img_path, label_name, label_data, fmt, shape, transformations, scale,
         )
 
     def test_write_multiscale_labels_storage_options(
@@ -2194,12 +1936,14 @@ class TestLabelWriter:
 
         storage_options = _make_storage_options(fmt, shape, axes)
 
+        scale = dict(zip(axes, transformations[0][0]["scale"][-len(shape) :]))
         write_multiscale_labels(
             pyramid,
             group,
             name=label_name,
             fmt=fmt,
             axes=axes,
+            scale=scale,
             coordinate_transformations=transformations[:-1],
             storage_options=storage_options,
         )
@@ -2274,7 +2018,6 @@ class TestLabelWriter:
         if fmt.version == "0.4":
             Models04Labels.from_zarr(group["labels"])
 
-        scale = dict(zip(axes, transformations[0][0]["scale"][-len(shape) :]))
         self.verify_label_data(
             img_path, label_name, label_data, fmt, shape, transformations, scale
         )
@@ -2335,9 +2078,11 @@ class TestLabelWriter:
                 name=label_name,
                 fmt=fmt,
                 axes=axes,
+                scale=dict(zip(axes, scale0)),
                 coordinate_transformations=transformations,
             )
-            scale = dict(zip(axes, transformations[0][0]["scale"][-len(shape) :]))
+            scale = dict(zip(axes, scale0))
+
             self.verify_label_data(
                 img_path, label_name, label_data, fmt, shape, transformations, scale
             )
@@ -2440,4 +2185,4 @@ class TestLabelWriter:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    pytest.main([__file__ + "::TestLabelWriter::test_two_label_images"])

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -70,6 +70,16 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("array_constructor", ARRAY_CONSTRUCTORS)
 
 
+def _codec_value(value):
+    """Return the plain value of a codec configuration attribute.
+
+    zarr < 3.3 exposes attributes such as ``BloscCodec.cname`` and
+    ``BytesCodec.endian`` as (non-str) ``Enum`` members, while zarr >= 3.3 uses
+    plain strings.
+    """
+    return getattr(value, "value", value)
+
+
 def _make_storage_options(fmt, shape, axes):
     from numcodecs import Blosc
     from zarr.codecs import (
@@ -2057,7 +2067,7 @@ class TestLabelWriter:
         if level0.compressors:
             if fmt.version == "0.5":
                 if USE_DASK_ARRAY_KWARGS:
-                    assert level0.compressors[0].cname.name == "zstd"
+                    assert _codec_value(level0.compressors[0].cname) == "zstd"
                 else:
                     assert level0.compressors[0].to_dict()["name"] == "zstd"
             else:
@@ -2066,7 +2076,7 @@ class TestLabelWriter:
                 assert level0.compressors[0].clevel == 3
                 if fmt.version == "0.5" and hasattr(level0, "serializer"):
                     assert (
-                        level0.metadata.codecs[0].index_codecs[0].endian.name
+                        _codec_value(level0.metadata.codecs[0].index_codecs[0].endian)
                         == "little"
                     )
             else:
@@ -2250,7 +2260,7 @@ class TestLabelWriter:
             if level.compressors:
                 if fmt.version == "0.5":
                     if USE_DASK_ARRAY_KWARGS:
-                        assert level.compressors[0].cname.name == "zstd"
+                        assert _codec_value(level.compressors[0].cname) == "zstd"
                     else:
                         assert level.compressors[0].to_dict()["name"] == "zstd"
                 else:
@@ -2259,7 +2269,9 @@ class TestLabelWriter:
                     assert level.compressors[0].clevel == 3
                     if fmt.version == "0.5" and hasattr(level, "serializer"):
                         assert (
-                            level.metadata.codecs[0].index_codecs[0].endian.name
+                            _codec_value(
+                                level.metadata.codecs[0].index_codecs[0].endian
+                            )
                             == "little"
                         )
                 else:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2198,7 +2198,3 @@ class TestLabelWriter:
 
         ms_test = OMEZarrMultiscale.from_ome_zarr(group)
         assert "third_labels" in ms_test.labels
-
-
-if __name__ == "__main__":
-    pytest.main([__file__ + "::TestLabelWriter::test_two_label_images"])

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,7 +1,5 @@
 import json
 import pathlib
-import re
-from typing import Any
 
 import dask.array as da
 import numpy as np
@@ -28,7 +26,6 @@ from ome_zarr import (
 )
 from ome_zarr.format import (
     CurrentFormat,
-    FormatV03,
     FormatV04,
     FormatV05,
     format_from_version,
@@ -1099,6 +1096,7 @@ class TestWriter:
                 axes="xt",
             )
 
+
 class TestPlateMetadata:
     @pytest.fixture(autouse=True)
     def initdir(self, tmpdir):
@@ -1885,9 +1883,15 @@ class TestLabelWriter:
             scale=scale,
             coordinate_transformations=transformations,
         )
-        
+
         self.verify_label_data(
-            img_path, label_name, label_data, fmt, shape, transformations, scale,
+            img_path,
+            label_name,
+            label_data,
+            fmt,
+            shape,
+            transformations,
+            scale,
         )
 
     def test_write_multiscale_labels_storage_options(


### PR DESCRIPTION
Re [this comment](https://github.com/ome/ome-zarr-py/pull/605#issuecomment-5141258404)

This PR introduces a medium-sized refactor of the `OMEZarrMultiscale` class, to not only accept a single instance of an `OMEZarrImage`, but also a *list of prebuilt `OMEZarrImage`s*. This has a number of applications:

- The older write functions `write_multiscale` and `write_multiscale_labels` can now also reroute all their internal functionality thourgh the use of the `OMEZarrMultiscale` class. This channels all writing through a single function and should make maintenance easier.
- There are usecases of working with pre-built pyramids which weren't supported nicely by the `OMEZarrMultiscale` framework before. I.e., remote ome-zarrs are essentially pre-built pyramids and ingesting these is made much easier with this change.
- We can deprecate some of the additional write pathways (i.e., `write_multiscale`, `write_image`) with a clear replacement.
- We can deprecate the `Format` class machinery along with these functions.

Rebased on https://github.com/ome/ome-zarr-py/pull/609