### PR TITLE
Preserve metadata on write

### DIFF
--- a/docs/source/_toc.yml
+++ b/docs/source/_toc.yml
@@ -42,7 +42,7 @@ parts:
     chapters:
     - file: api
       sections:
-      - file: api/image
+      - file: api/classes
       - file: api/writer
       - file: api/reader
       - file: api/io

--- a/docs/source/advanced/transforms/add_transforms_to_multiscales.ipynb
+++ b/docs/source/advanced/transforms/add_transforms_to_multiscales.ipynb
@@ -20,8 +20,9 @@
       "outputs": [],
       "source": [
         "import numpy as np\n",
-        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale\n",
-        "from ome_zarr_models.v06.coordinate_transforms import Rotation, CoordinateSystem"
+        "from ome_zarr_models.v06.coordinate_transforms import CoordinateSystem, Rotation\n",
+        "\n",
+        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale"
       ]
     },
     {
@@ -83,8 +84,8 @@
         "\n",
         "$\n",
         "R = \\begin{bmatrix}\n",
-        "\\cos(45°) & -\\sin(45°) \\\\\n",
-        "\\sin(45°) & \\cos(45°)\n",
+        "\\cos(45\u00b0) & -\\sin(45\u00b0) \\\\\n",
+        "\\sin(45\u00b0) & \\cos(45\u00b0)\n",
         "\\end{bmatrix} = \\begin{bmatrix}\n",
         "\\cos(\\pi/4) & -\\sin(\\pi/4) \\\\\n",
         "\\sin(\\pi/4) & \\cos(\\pi/4)\n",

--- a/docs/source/advanced/transforms/add_transforms_to_multiscales.ipynb
+++ b/docs/source/advanced/transforms/add_transforms_to_multiscales.ipynb
@@ -20,8 +20,8 @@
       "outputs": [],
       "source": [
         "import numpy as np\n",
-        "\n",
-        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale"
+        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale\n",
+        "from ome_zarr_models.v06.coordinate_transforms import Rotation, CoordinateSystem"
       ]
     },
     {
@@ -71,6 +71,11 @@
       "id": "b515b640",
       "metadata": {},
       "source": [
+        "```{hint}\n",
+        "The coordinate systems are stored as {py:class}`ome_zarr_models.v06.coordinate_transforms.CoordinateSystem` objects internally.\n",
+        "To extend a multiscales to include additional coordinate systems, these objects need to be created up front and then passed to the {py:class}`ome_zarr.classes.image.OMEZarrMultiscale` constructor.\n",
+        "```\n",
+        "\n",
         "To attach another transformation to the multiscale image,\n",
         "we need to specify both the transform as well as the coordinate system it outputs to.\n",
         "In this case, we define a rotation transformation that outputs into a \"world\" coordinate system.\n",
@@ -78,8 +83,8 @@
         "\n",
         "$\n",
         "R = \\begin{bmatrix}\n",
-        "\\cos(45\u00b0) & -\\sin(45\u00b0) \\\\\n",
-        "\\sin(45\u00b0) & \\cos(45\u00b0)\n",
+        "\\cos(45°) & -\\sin(45°) \\\\\n",
+        "\\sin(45°) & \\cos(45°)\n",
         "\\end{bmatrix} = \\begin{bmatrix}\n",
         "\\cos(\\pi/4) & -\\sin(\\pi/4) \\\\\n",
         "\\sin(\\pi/4) & \\cos(\\pi/4)\n",
@@ -99,7 +104,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "rotation_transform = {\n",
+        "rotation_transform = Rotation.model_validate({\n",
         "    \"type\": \"rotation\",\n",
         "    \"rotation\": [\n",
         "        [np.cos(np.pi/4), -np.sin(np.pi/4)],\n",
@@ -107,15 +112,15 @@
         "    ],\n",
         "    \"input\": {\"name\": \"physical\"},\n",
         "    \"output\": {\"name\": \"world\"}\n",
-        "}\n",
+        "})\n",
         "\n",
-        "world_cs = {\n",
+        "world_cs = CoordinateSystem.model_validate({\n",
         "    \"name\": \"world\",\n",
         "    \"axes\": [\n",
         "        {\"name\": \"y\", \"type\": \"space\"},\n",
         "        {\"name\": \"x\", \"type\": \"space\"}\n",
         "    ],\n",
-        "}"
+        "})"
       ]
     },
     {
@@ -130,7 +135,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "id": "f0a56122",
       "metadata": {},
       "outputs": [],
@@ -183,7 +188,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "ome-zarr (3.13.12)",
+      "display_name": "maddys-techdev-conversion (3.13.12)",
       "language": "python",
       "name": "python3"
     },

--- a/docs/source/advanced/transforms/create_scenes.ipynb
+++ b/docs/source/advanced/transforms/create_scenes.ipynb
@@ -19,10 +19,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "from ome_zarr_models.v06.coordinate_transforms import CoordinateSystem, Translation\n",
         "from skimage import data\n",
         "\n",
-        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene\n",
-        "from ome_zarr_models.v06.coordinate_transforms import CoordinateSystem, Translation"
+        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene"
       ]
     },
     {

--- a/docs/source/advanced/transforms/create_scenes.ipynb
+++ b/docs/source/advanced/transforms/create_scenes.ipynb
@@ -14,14 +14,15 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 5,
       "id": "a49ec1c2",
       "metadata": {},
       "outputs": [],
       "source": [
         "from skimage import data\n",
         "\n",
-        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene"
+        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene\n",
+        "from ome_zarr_models.v06.coordinate_transforms import CoordinateSystem, Translation"
       ]
     },
     {
@@ -42,7 +43,7 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "c:\\Users\\johan\\Documents\\GitHub\\ome-zarr-py\\.venv\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+            "c:\\Users\\johan\\Documents\\GitHub\\maddys-techdev-conversion\\.venv\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
             "  from .autonotebook import tqdm as notebook_tqdm\n"
           ]
         },
@@ -94,23 +95,24 @@
       "metadata": {},
       "source": [
         "Next, we need to define a coordinate system into which all images are projected.\n",
-        "This is defined in accordance with the NGFF [coordinate systems specification](https://ngff.openmicroscopy.org/specifications/dev/index.html#coordinatesystems-metadata)."
+        "This is defined in accordance with the NGFF [coordinate systems specification](https://ngff.openmicroscopy.org/specifications/dev/index.html#coordinatesystems-metadata).\n",
+        "The coordinate systems can be defined using the {py:class}`ome_zarr_models.v06.coordinate_transforms.CoordinateSystem` class:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 6,
       "id": "994674c2",
       "metadata": {},
       "outputs": [],
       "source": [
-        "coordinate_system = {\n",
+        "coordinate_system = CoordinateSystem.model_validate({\n",
         "    \"name\": \"world\",\n",
         "    \"axes\": [\n",
         "        {\"name\": \"y\", \"type\": \"space\"},\n",
         "        {\"name\": \"x\", \"type\": \"space\"},\n",
         "    ],\n",
-        "}"
+        "})"
       ]
     },
     {
@@ -118,42 +120,54 @@
       "id": "c1d629be",
       "metadata": {},
       "source": [
+        "::::{hint}\n",
+        "{py:class}`ome_zarr_models.v06.coordinate_transforms.CoordinateSystem` is a [pydantic](https://pydantic.dev) class.\n",
+        "This means that it can be instantiated either from a to-be validated dictionary or from keyword arguments and subfields:\n",
+        "```python\n",
+        "coordinate_system = CoordinateSystem.model_validate({...})\n",
+        "coordinate_system = CoordinateSystem(name=\"world\", axes=[...])\n",
+        "```\n",
+        "\n",
+        "In the second case, the `axes` argument would need to be populated with the respective {py:class}`ome_zarr_models.v06.coordinate_transforms.Axis` instances.\n",
+        "\n",
+        "::::\n",
+        "\n",
         "We then define translations that move each tile into the appropriate position in the world coordinate system.\n",
         "In this example, these are simple translations in the y and x dimensions:"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 7,
       "id": "d6329caa",
       "metadata": {},
       "outputs": [],
       "source": [
         "coordinate_transformations = [\n",
-        "    {\n",
+        "    Translation.model_validate({\n",
         "        \"type\": \"translation\",\n",
         "        \"translation\": [0, 0],\n",
         "        \"input\": {\"path\": \"img1\", \"name\": \"physical\"},\n",
         "        \"output\": {\"name\": \"world\"},\n",
-        "    },\n",
-        "    {\n",
+        "    }),\n",
+        "    Translation.model_validate({\n",
         "        \"type\": \"translation\",\n",
         "        \"translation\": [256, 0],\n",
         "        \"input\": {\"path\": \"img2\", \"name\": \"physical\"},\n",
         "        \"output\": {\"name\": \"world\"},\n",
-        "    },\n",
-        "    {\n",
+        "    }),\n",
+        "    Translation.model_validate({\n",
         "        \"type\": \"translation\",\n",
         "        \"translation\": [0, 256],\n",
         "        \"input\": {\"path\": \"img3\", \"name\": \"physical\"},\n",
         "        \"output\": {\"name\": \"world\"},\n",
-        "    },\n",
-        "    {\n",
+        "    }),\n",
+        "    Translation.model_validate({\n",
         "        \"type\": \"translation\",\n",
         "        \"translation\": [256, 256],\n",
         "        \"input\": {\"path\": \"img4\", \"name\": \"physical\"},\n",
         "        \"output\": {\"name\": \"world\"},\n",
-        "    },\n",
+        "    }),\n",
         "]"
       ]
     },
@@ -167,16 +181,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 8,
       "id": "d05be093",
       "metadata": {},
       "outputs": [
         {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Writing images: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4/4 [00:00<00:00,  7.08it/s]\n"
-          ]
+          "data": {
+            "text/plain": [
+              "[]"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -199,10 +216,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 9,
       "id": "8b87b923",
       "metadata": {},
       "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "c:\\Users\\johan\\Documents\\GitHub\\maddys-techdev-conversion\\.venv\\Lib\\site-packages\\pydantic\\main.py:716: ValidationWarning: Version number is '0.6', converting to '0.6.dev4'\n",
+            "  return cls.__pydantic_validator__.validate_python(\n"
+          ]
+        },
         {
           "data": {
             "text/plain": [
@@ -212,7 +237,7 @@
               " Translation(type='translation', input=CoordinateSystemIdentifier(name='physical', path='img4'), output=CoordinateSystemIdentifier(name='world', path=None), name=None, translation=(256.0, 256.0)))"
             ]
           },
-          "execution_count": 12,
+          "execution_count": 9,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -233,7 +258,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "ome-zarr (3.13.12)",
+      "display_name": "maddys-techdev-conversion (3.13.12)",
       "language": "python",
       "name": "python3"
     },

--- a/docs/source/advanced/transforms/scene_2d_to_3d.ipynb
+++ b/docs/source/advanced/transforms/scene_2d_to_3d.ipynb
@@ -26,9 +26,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "from ome_zarr_models.v06.coordinate_transforms import Sequence\n",
         "from skimage import data\n",
-        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene\n",
-        "from ome_zarr_models.v06.coordinate_transforms import Sequence"
+        "\n",
+        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene"
       ]
     },
     {

--- a/docs/source/advanced/transforms/scene_2d_to_3d.ipynb
+++ b/docs/source/advanced/transforms/scene_2d_to_3d.ipynb
@@ -21,14 +21,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "id": "ac4f951d",
       "metadata": {},
       "outputs": [],
       "source": [
         "from skimage import data\n",
-        "\n",
-        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene"
+        "from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene\n",
+        "from ome_zarr_models.v06.coordinate_transforms import Sequence"
       ]
     },
     {
@@ -120,7 +120,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "transform_to_3d = {\n",
+        "transform_to_3d = Sequence.model_validate({\n",
         "    \"type\": \"sequence\",\n",
         "    \"input\": {\"path\": \"cells3d_slice\", \"name\": \"physical\"},\n",
         "    \"output\": {\"path\": \"cells3d\", \"name\": \"physical\"},\n",
@@ -134,7 +134,7 @@
         "            \"translation\": [0, 30, 0, 0]\n",
         "        }\n",
         "    ]\n",
-        "}"
+        "})"
       ]
     },
     {
@@ -157,24 +157,19 @@
       "metadata": {},
       "outputs": [
         {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Writing images: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:01<00:00,  1.98it/s]\n"
-          ]
+          "data": {
+            "text/plain": [
+              "[]"
+            ]
+          },
+          "execution_count": 7,
+          "metadata": {},
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "scene.to_ome_zarr(\"scene_2d_to_3d.zarr\", overwrite=True)"
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "062391f5",
-      "metadata": {},
-      "outputs": [],
-      "source": []
     }
   ],
   "metadata": {

--- a/docs/source/api/classes.rst
+++ b/docs/source/api/classes.rst
@@ -9,3 +9,6 @@ OMEZarr classes (``ome_zarr.classes``)
 
 .. autoclass:: ome_zarr.classes.image.OMEZarrLabels
    :members:
+
+.. autoclass:: ome_zarr.classes.image.OMEZarrScene
+   :members:

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -31,7 +31,7 @@ from ome_zarr_models.v06.multiscales import (
 from ome_zarr_models.v06.multiscales import (
     Multiscale as MultiscaleV06,
 )
-from pydantic import TypeAdapter, ValidationError
+from pydantic import ValidationError
 
 from ome_zarr.scale import Methods
 
@@ -159,9 +159,7 @@ class OMEZarrMultiscaleBase:
         self,
         image: OMEZarrImage,
         scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] | None = None,
-        coordinate_transformations: (
-            tuple[AnyTransform, ...] |  None
-        ) = None,
+        coordinate_transformations: tuple[AnyTransform, ...] | None = None,
         coordinate_systems: list[CoordinateSystem] | None = None,
         method: str | Methods | None = Methods.RESIZE,
         default_coordinate_system_name: str = "physical",
@@ -800,9 +798,7 @@ class OMEZarrMultiscale(OMEZarrMultiscaleBase):
         image: OMEZarrImage,
         scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] | None = None,
         method: str | Methods | None = Methods.RESIZE,
-        coordinate_transformations: (
-            tuple[AnyTransform, ...] | None
-        ) = None,
+        coordinate_transformations: tuple[AnyTransform, ...] | None = None,
         coordinate_systems: list[CoordinateSystem] | None = None,
         default_coordinate_system_name: str = "physical",
         labels: (

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -160,9 +160,9 @@ class OMEZarrMultiscaleBase:
         image: OMEZarrImage,
         scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] | None = None,
         coordinate_transformations: (
-            tuple[AnyTransform, ...] | list[dict[str, Any]] | None
+            tuple[AnyTransform, ...] |  None
         ) = None,
-        coordinate_systems: list[CoordinateSystem] | list[dict[str, Any]] | None = None,
+        coordinate_systems: list[CoordinateSystem] | None = None,
         method: str | Methods | None = Methods.RESIZE,
         default_coordinate_system_name: str = "physical",
     ):
@@ -266,14 +266,7 @@ class OMEZarrMultiscaleBase:
             # coerce coordinate_systems to ozmp object if passed as dict
             additional_cs = []
             for idx, cs in enumerate(coordinate_systems):
-                if isinstance(cs, dict):
-                    additional_cs.append(
-                        TypeAdapter(CoordinateSystem).validate_python(cs)
-                    )
-                elif isinstance(cs, CoordinateSystem):
-                    additional_cs.append(cs)
-                else:
-                    raise ValueError(f"Invalid coordinate system at index {idx}: {cs}")
+                additional_cs.append(cs)
 
         coordinate_systems = [
             CoordinateSystem(
@@ -287,14 +280,7 @@ class OMEZarrMultiscaleBase:
         if coordinate_transformations is not None:
             transforms = []
             for idx, tf in enumerate(coordinate_transformations):
-                if isinstance(tf, dict):
-                    transforms.append(TypeAdapter(AnyTransform).validate_python(tf))
-                elif tf is AnyTransform:
-                    transforms.append(tf)
-                else:
-                    raise ValueError(
-                        f"Invalid coordinate transformation at index {idx}: {tf}"
-                    )
+                transforms.append(tf)
             transforms = tuple(transforms)
 
             # Some checks on the transform's input and output coordinate system
@@ -815,9 +801,9 @@ class OMEZarrMultiscale(OMEZarrMultiscaleBase):
         scale_factors: list[int] | tuple[int, ...] | list[dict[str, int]] | None = None,
         method: str | Methods | None = Methods.RESIZE,
         coordinate_transformations: (
-            tuple[AnyTransform, ...] | list[dict[str, Any]] | None
+            tuple[AnyTransform, ...] | None
         ) = None,
-        coordinate_systems: list[CoordinateSystem] | list[dict[str, Any]] | None = None,
+        coordinate_systems: list[CoordinateSystem] | None = None,
         default_coordinate_system_name: str = "physical",
         labels: (
             OMEZarrLabels | list[OMEZarrLabels] | dict[str, OMEZarrLabels] | None

--- a/ome_zarr/classes/scene.py
+++ b/ome_zarr/classes/scene.py
@@ -263,7 +263,10 @@ class OMEZarrScene:
         # Always update scene metadata
         metadata_dict = self.metadata.model_dump(exclude_none=True)
 
-        zarr_group.attrs["ome"] = {"scene": metadata_dict, "version": "0.6"}
+        # Preserve existing ome metadata, update only scene field
+        ome: dict = zarr_group.attrs.get("ome", {})
+        ome.update({"scene": metadata_dict, "version": "0.6"})
+        zarr_group.attrs["ome"] = ome
 
         return delayed
 

--- a/ome_zarr/classes/scene.py
+++ b/ome_zarr/classes/scene.py
@@ -11,7 +11,6 @@ from ome_zarr_models.v06.coordinate_transforms import (
     CoordinateSystem,
 )
 from ome_zarr_models.v06.scene import SceneAttrs
-from pydantic import TypeAdapter
 from zarr.storage import StoreLike
 
 from .image import OMEZarrMultiscale
@@ -21,8 +20,8 @@ class OMEZarrScene:
     def __init__(
         self,
         images: list[OMEZarrMultiscale] | dict[str, OMEZarrMultiscale],
-        coordinate_transformations: Sequence[AnyTransform] | list[dict[str, Any]],
-        coordinate_systems: Sequence[CoordinateSystem] | Sequence[dict[str, Any]] = (),
+        coordinate_transformations: Sequence[AnyTransform],
+        coordinate_systems: Sequence[CoordinateSystem] = (),
         coordinate_displacements: dict[str, OMEZarrMultiscale] | None = None,
     ):
         """
@@ -32,13 +31,13 @@ class OMEZarrScene:
             Either a list of images (keyed internally by metadata.name) or a dict
             mapping zarr group paths to images. The dict form gives explicit control
             over the paths where images will be stored in the zarr hierarchy.
-        coordinate_transformations : Sequence[ome_zarr_models.v06.coordinate_transforms.AnyTransform] | list[dict[str, Any]]
+        coordinate_transformations : Sequence[ome_zarr_models.v06.coordinate_transforms.AnyTransform]
             A sequence of coordinate transformations that define how to map between
             different coordinate systems in the scene.
             Each transformation can be provided as an AnyTransform instance
             or as a dictionary that can be validated into an AnyTransform.
             For more information see [ngff specification](https://ngff.openmicroscopy.org/specifications/dev/index.html#coordinatetransformations-metadata).
-        coordinate_systems : Sequence[ome_zarr_models.v06.coordinate_transforms.CoordinateSystem] | Sequence[dict[str, Any]], optional
+        coordinate_systems : Sequence[ome_zarr_models.v06.coordinate_transforms.CoordinateSystem]
             A sequence of coordinate systems that define the coordinate spaces used
             in the scene.
             Each coordinate system can be provided as a CoordinateSystem instance
@@ -71,10 +70,8 @@ class OMEZarrScene:
 
         # metadata is the single source of truth
         self._metadata = SceneAttrs(
-            coordinateSystems=self._parse_coordinate_systems(coordinate_systems),
-            coordinateTransformations=self._parse_transforms(
-                coordinate_transformations
-            ),
+            coordinateSystems=tuple(coordinate_systems),
+            coordinateTransformations=tuple(coordinate_transformations),
         )
 
         self._build_graph()
@@ -85,10 +82,10 @@ class OMEZarrScene:
 
     @coordinate_systems.setter
     def coordinate_systems(
-        self, value: Sequence[CoordinateSystem] | Sequence[dict[str, Any]]
+        self, value: Sequence[CoordinateSystem]
     ) -> None:
         self._metadata = self._metadata.model_copy(
-            update={"coordinateSystems": self._parse_coordinate_systems(value)}
+            update={"coordinateSystems": value}
         )
 
     @property
@@ -100,7 +97,7 @@ class OMEZarrScene:
         self, value: Sequence[AnyTransform] | list[dict[str, Any]]
     ) -> None:
         self._metadata = self._metadata.model_copy(
-            update={"coordinateTransformations": self._parse_transforms(value)}
+            update={"coordinateTransformations": value}
         )
 
     @property
@@ -348,46 +345,6 @@ class OMEZarrScene:
         )
 
         return scene
-
-    @staticmethod
-    def _parse_transforms(
-        transforms: Sequence[AnyTransform] | list[dict[str, Any]],
-    ) -> tuple[AnyTransform, ...]:
-        """
-        Helper method to parse a sequence of coordinate transformations that may be provided as either
-        AnyTransform instances or dictionaries.
-        This ensures that all transformations are stored as AnyTransform objects in the scene metadata.
-        """
-        tf_adapter = TypeAdapter(AnyTransform)
-        parsed_transforms = []
-
-        for tf in transforms:
-            if isinstance(tf, dict):
-                parsed_transforms.append(tf_adapter.validate_python(tf))
-            else:
-                parsed_transforms.append(tf)
-
-        return tuple(parsed_transforms)
-
-    @staticmethod
-    def _parse_coordinate_systems(
-        coordinate_systems: Sequence[CoordinateSystem] | Sequence[dict[str, Any]],
-    ) -> tuple[CoordinateSystem, ...]:
-        """
-        Helper method to parse a sequence of coordinate systems that may be provided as either
-        CoordinateSystem instances or dictionaries.
-        This ensures that all coordinate systems are stored as CoordinateSystem objects in the scene metadata.
-        If coordinate_systems is None, it will be returned as None.
-        """
-
-        parsed_coordinate_systems = []
-        for cs in coordinate_systems:
-            if isinstance(cs, dict):
-                parsed_coordinate_systems.append(CoordinateSystem.model_validate(cs))
-            elif isinstance(cs, CoordinateSystem):
-                parsed_coordinate_systems.append(cs)
-
-        return tuple(parsed_coordinate_systems)
 
     def _ozmp_tf_to_tnd(
         self,

--- a/ome_zarr/classes/scene.py
+++ b/ome_zarr/classes/scene.py
@@ -43,7 +43,7 @@ class OMEZarrScene:
             Each coordinate system can be provided as a CoordinateSystem instance
             or as a dictionary that can be validated into a CoordinateSystem.
             For more information see [ngff specification](https://ngff.openmicroscopy.org/specifications/dev/index.html#coordinatesystems-metadata).
-        coordinates_displacements : dict[str, OMEZarrMultiscale] | None, optional
+        coordinate_displacements : dict[str, OMEZarrMultiscale] | None, optional
             A dictionary mapping zarr group paths to displacement field images
             or coordinate arrays, which are referenced by the [displacements and
             coordinates transformations](https://ngff.openmicroscopy.org/specifications/dev/index.html#coordinates-and-displacements) in the scene metadata.
@@ -66,7 +66,7 @@ class OMEZarrScene:
         else:
             self.images = images
 
-        self.coordinates_displacements = coordinate_displacements
+        self.coordinate_displacements = coordinate_displacements
 
         # metadata is the single source of truth
         self._metadata = SceneAttrs(
@@ -81,12 +81,8 @@ class OMEZarrScene:
         return tuple(self._metadata.coordinateSystems or ())
 
     @coordinate_systems.setter
-    def coordinate_systems(
-        self, value: Sequence[CoordinateSystem]
-    ) -> None:
-        self._metadata = self._metadata.model_copy(
-            update={"coordinateSystems": value}
-        )
+    def coordinate_systems(self, value: Sequence[CoordinateSystem]) -> None:
+        self._metadata = self._metadata.model_copy(update={"coordinateSystems": value})
 
     @property
     def coordinate_transformations(self) -> tuple[AnyTransform, ...]:
@@ -251,7 +247,7 @@ class OMEZarrScene:
                 subgroup, overwrite=True, version="0.6", compute=compute
             )
 
-        for disp_path, disp_img in (self.coordinates_displacements or {}).items():
+        for disp_path, disp_img in (self.coordinate_displacements or {}).items():
             # Skip if already written (incremental mode)
             if not overwrite and disp_path in zarr_group:
                 continue
@@ -292,15 +288,15 @@ class OMEZarrScene:
 
         # load coordinateTransformations array data, if it exists
         if "coordinateTransformations" in zarr_group:
-            coordinates_displacements = {}
+            coordinate_displacements = {}
             for disp_path in zarr_group["coordinateTransformations"].group_keys():
                 disp_group = zarr_group["coordinateTransformations"][disp_path]
                 disp_img = cast(
                     OMEZarrMultiscale, OMEZarrMultiscale.from_ome_zarr(disp_group)
                 )
-                coordinates_displacements[disp_path] = disp_img
+                coordinate_displacements[disp_path] = disp_img
         else:
-            coordinates_displacements = None
+            coordinate_displacements = None
 
         # Load scene metadata
         scene_metadata = BaseSceneAttrs.model_validate(zarr_group.attrs.get("ome", {}))
@@ -341,7 +337,7 @@ class OMEZarrScene:
             coordinate_systems=(
                 coordinate_systems if coordinate_systems is not None else ()
             ),
-            coordinate_displacements=coordinates_displacements,
+            coordinate_displacements=coordinate_displacements,
         )
 
         return scene
@@ -403,8 +399,8 @@ class OMEZarrScene:
             if zarr_context and path_to_dfield:
                 path_to_dfield = posixpath.join(zarr_context, path_to_dfield)
 
-            if self.coordinates_displacements is not None:
-                dfield = self.coordinates_displacements.get(
+            if self.coordinate_displacements is not None:
+                dfield = self.coordinate_displacements.get(
                     posixpath.basename(path_to_dfield)
                 )
                 if dfield is not None:

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -533,6 +533,7 @@ def test_scene_with_displacements(test_data_dir):
         assert image.axes_types["c"] == "displacement"
     assert dfield_img.metadata.coordinateSystems[0].axes[0].discrete
 
+
 def test_metadata_preservation(test_data_dir):
     """
     Create a scene with two images and a single coordinate transformation

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -3,18 +3,27 @@ import pytest
 import zarr
 
 from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene
+from pydantic import TypeAdapter
+from ome_zarr_models.v06.coordinate_transforms import (
+    CoordinateSystem,
+    CoordinateSystemIdentifier,
+    Translation,
+    AnyTransform,
+)
+
+transform_adapter = TypeAdapter(AnyTransform)
 
 TRANSFORMS = [
-    {"type": "scale", "scale": [1.0, 1.0]},
-    {"type": "translation", "translation": [0.0, 0.0]},
-    {"type": "rotation", "rotation": [[0.0, -1.0], [1.0, 0.0]]},
-    {"type": "affine", "affine": [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]},
-    {"type": "mapAxis", "mapAxis": [1, 0]},
+    {"type": "scale", "scale": (1.0, 1.0)},
+    {"type": "translation", "translation": (0.0, 0.0)},
+    {"type": "rotation", "rotation": ((0.0, -1.0), (1.0, 0.0))},
+    {"type": "affine", "affine": ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0))},
+    {"type": "mapAxis", "mapAxis": (1, 0)},
     {
         "type": "sequence",
         "transformations": [
-            {"type": "scale", "scale": [1.0, 1.0]},
-            {"type": "translation", "translation": [0.0, 0.0]},
+            {"type": "scale", "scale": (1.0, 1.0)},
+            {"type": "translation", "translation": (0.0, 0.0)},
         ],
     },
     {
@@ -23,16 +32,18 @@ TRANSFORMS = [
             {
                 "input_axes": [1],
                 "output_axes": [1],
-                "transformation": {"type": "translation", "translation": [0.0]},
+                "transformation": {"type": "translation", "translation": (0.0,)},
             },
             {
                 "input_axes": [0],
                 "output_axes": [0],
-                "transformation": {"type": "scale", "scale": [1.0]},
+                "transformation": {"type": "scale", "scale": (1.0,)},
             },
         ],
     },
 ]
+
+TRANSFORMS = [transform_adapter.validate_python(t) for t in TRANSFORMS]
 
 
 @pytest.fixture
@@ -75,20 +86,20 @@ def test_create_scene_without_coordinate_systems(test_data_dir, transform):
         scale={"y": 1.0, "x": 1.0},
     )
 
-    additional_cs = {
+    additional_cs = CoordinateSystem.model_validate({
         "name": "additional",
         "axes": [
             {"name": "y", "type": "space"},
             {"name": "x", "type": "space"},
         ],
-    }
+    })
 
-    additional_tf = {
+    additional_tf = TypeAdapter(AnyTransform).validate_python({
         "type": "rotation",
-        "rotation": [[0.0, -1.0], [1.0, 0.0]],
+        "rotation": ((0.0, -1.0), (1.0, 0.0)),
         "input": {"name": "physical"},
         "output": {"name": "additional"},
-    }
+    })
 
     img_a_ms = OMEZarrMultiscale(image=img_a)
     img_b_ms = OMEZarrMultiscale(
@@ -99,8 +110,12 @@ def test_create_scene_without_coordinate_systems(test_data_dir, transform):
 
     # avoid leaking transform mutations into other tests
     transform = transform.copy()
-    transform["input"] = {"name": "physical", "path": "imageA"}
-    transform["output"] = {"name": "additional", "path": "imageB"}
+    transform = transform.model_copy(
+        update={
+            "input": CoordinateSystemIdentifier(name="physical", path="imageA"),
+            "output": CoordinateSystemIdentifier(name="physical", path="imageB"),
+        }
+    )
 
     scene = OMEZarrScene(
         images=[img_a_ms, img_b_ms],
@@ -121,7 +136,7 @@ def test_create_scene_without_coordinate_systems(test_data_dir, transform):
 
     # make sure transform matrix is square
     # bydimension transforms cannot easily be expressed as matrix
-    if transform["type"] != "byDimension":
+    if transform.type != "byDimension":
         affine = tf.simplify().to_affine().matrix
         assert affine.shape[0] == affine.shape[1]
 
@@ -152,7 +167,7 @@ def test_create_scene_without_coordinate_systems(test_data_dir, transform):
     transform_md = ome_metadata["scene"]["coordinateTransformations"][0]
 
     # make sure that the loaded transform is the same as the original
-    assert transform_md == transform
+    assert transform_md == transform.model_dump(exclude_unset=True, mode="json")
 
 
 @pytest.mark.parametrize("transform", TRANSFORMS)
@@ -179,26 +194,38 @@ def test_create_scene_with_coordinate_systems(test_data_dir, transform):
     img_a_ms = OMEZarrMultiscale(image=img_a)
     img_b_ms = OMEZarrMultiscale(image=img_b)
 
-    world1_cs = {
+    world1_cs = CoordinateSystem.model_validate({
         "name": "world",
         "axes": [ax.model_dump() for ax in img_a_ms.metadata.coordinateSystems[0].axes],
-    }
-    world2_cs = {
+    })
+    world2_cs = CoordinateSystem.model_validate({
         "name": "world2",
         "axes": [ax.model_dump() for ax in img_b_ms.metadata.coordinateSystems[0].axes],
-    }
+    })
 
     transform1 = transform.copy()
-    transform1["input"] = {"name": "physical", "path": "imageA"}
-    transform1["output"] = {"name": "world"}
+    transform1 = transform1.model_copy(
+        update={
+            "input": CoordinateSystemIdentifier(name="physical", path="imageA"),
+            "output": CoordinateSystemIdentifier(name="world"),
+        }
+    )
 
     transform2 = transform.copy()
-    transform2["input"] = {"name": "world"}
-    transform2["output"] = {"name": "world2"}
+    transform2 = transform2.model_copy(
+        update={
+            "input": CoordinateSystemIdentifier(name="world"),
+            "output": CoordinateSystemIdentifier(name="world2"),
+        }
+    )
 
     transform3 = transform.copy()
-    transform3["input"] = {"name": "world2"}
-    transform3["output"] = {"name": "physical", "path": "imageB"}
+    transform3 = transform3.model_copy(
+        update={
+            "input": CoordinateSystemIdentifier(name="world2"),
+            "output": CoordinateSystemIdentifier(name="physical", path="imageB"),
+        }
+    )
 
     scene = OMEZarrScene(
         images=[img_a_ms, img_b_ms],

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -533,6 +533,57 @@ def test_scene_with_displacements(test_data_dir):
         assert image.axes_types["c"] == "displacement"
     assert dfield_img.metadata.coordinateSystems[0].axes[0].discrete
 
+def test_metadata_preservation(test_data_dir):
+    """
+    Create a scene with two images and a single coordinate transformation
+    between them. The data is saved and loaded back in the test.
+    We then add some other metadata under the ome key (i.e., `plate`) metadata,
+    and save the scene again. We check that the existing metadata is preserved
+    and that the scene metadata is updated.
+    """
+    img_a = OMEZarrImage(
+        data=create_data((64, 64)),
+        name="imageA",
+        axes=["y", "x"],
+        scale={"y": 1.0, "x": 1.0},
+    )
+    img_b = OMEZarrImage(
+        data=create_data((64, 64)),
+        name="imageB",
+        axes=["y", "x"],
+        scale={"y": 1.0, "x": 1.0},
+    )
 
-if __name__ == "__main__":
-    pytest.main([__file__])
+    img_a_ms = OMEZarrMultiscale(image=img_a)
+    img_b_ms = OMEZarrMultiscale(image=img_b)
+
+    tf1 = TRANSFORMS[0].copy()
+    tf1 = tf1.model_copy(
+        update={
+            "input": CoordinateSystemIdentifier(name="physical", path="imageA"),
+            "output": CoordinateSystemIdentifier(name="physical", path="imageB"),
+        }
+    )
+
+    scene = OMEZarrScene(
+        images=[img_a_ms, img_b_ms],
+        coordinate_transformations=(tf1,),
+    )
+
+    scene.to_ome_zarr(str(test_data_dir / "test_scene_metadata.zarr"), overwrite=True)
+
+    # add some other metadata under the ome key
+    # doesn't have to be a valid ome-zarr metadata field, just for testing
+    grp = zarr.open_group(str(test_data_dir / "test_scene_metadata.zarr"), mode="a")
+    ome = dict(grp.attrs["ome"])
+    ome["plate"] = {"name": "test_plate", "id": "12345"}
+    grp.attrs["ome"] = ome
+    scene.to_ome_zarr(str(test_data_dir / "test_scene_metadata.zarr"), overwrite=False)
+
+    # now check that the existing metadata is preserved and that the scene metadata is updated
+    grp = zarr.open_group(str(test_data_dir / "test_scene_metadata.zarr"), mode="r")
+    assert "ome" in grp.attrs
+    ome_metadata = grp.attrs["ome"]
+    assert "scene" in ome_metadata
+    assert "plate" in ome_metadata
+    assert ome_metadata["plate"]["name"] == "test_plate"

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,15 +1,14 @@
 import numpy as np
 import pytest
 import zarr
-
-from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene
-from pydantic import TypeAdapter
 from ome_zarr_models.v06.coordinate_transforms import (
+    AnyTransform,
     CoordinateSystem,
     CoordinateSystemIdentifier,
-    Translation,
-    AnyTransform,
 )
+from pydantic import TypeAdapter
+
+from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene
 
 transform_adapter = TypeAdapter(AnyTransform)
 
@@ -86,20 +85,24 @@ def test_create_scene_without_coordinate_systems(test_data_dir, transform):
         scale={"y": 1.0, "x": 1.0},
     )
 
-    additional_cs = CoordinateSystem.model_validate({
-        "name": "additional",
-        "axes": [
-            {"name": "y", "type": "space"},
-            {"name": "x", "type": "space"},
-        ],
-    })
+    additional_cs = CoordinateSystem.model_validate(
+        {
+            "name": "additional",
+            "axes": [
+                {"name": "y", "type": "space"},
+                {"name": "x", "type": "space"},
+            ],
+        }
+    )
 
-    additional_tf = TypeAdapter(AnyTransform).validate_python({
-        "type": "rotation",
-        "rotation": ((0.0, -1.0), (1.0, 0.0)),
-        "input": {"name": "physical"},
-        "output": {"name": "additional"},
-    })
+    additional_tf = TypeAdapter(AnyTransform).validate_python(
+        {
+            "type": "rotation",
+            "rotation": ((0.0, -1.0), (1.0, 0.0)),
+            "input": {"name": "physical"},
+            "output": {"name": "additional"},
+        }
+    )
 
     img_a_ms = OMEZarrMultiscale(image=img_a)
     img_b_ms = OMEZarrMultiscale(
@@ -194,14 +197,22 @@ def test_create_scene_with_coordinate_systems(test_data_dir, transform):
     img_a_ms = OMEZarrMultiscale(image=img_a)
     img_b_ms = OMEZarrMultiscale(image=img_b)
 
-    world1_cs = CoordinateSystem.model_validate({
-        "name": "world",
-        "axes": [ax.model_dump() for ax in img_a_ms.metadata.coordinateSystems[0].axes],
-    })
-    world2_cs = CoordinateSystem.model_validate({
-        "name": "world2",
-        "axes": [ax.model_dump() for ax in img_b_ms.metadata.coordinateSystems[0].axes],
-    })
+    world1_cs = CoordinateSystem.model_validate(
+        {
+            "name": "world",
+            "axes": [
+                ax.model_dump() for ax in img_a_ms.metadata.coordinateSystems[0].axes
+            ],
+        }
+    )
+    world2_cs = CoordinateSystem.model_validate(
+        {
+            "name": "world2",
+            "axes": [
+                ax.model_dump() for ax in img_b_ms.metadata.coordinateSystems[0].axes
+            ],
+        }
+    )
 
     transform1 = transform.copy()
     transform1 = transform1.model_copy(
@@ -515,9 +526,9 @@ def test_scene_with_displacements(test_data_dir):
 
     # read displacements back in and check that the (meta)data is correct
     scene_read = OMEZarrScene.from_ome_zarr(save_grp)
-    assert "displacementField" in scene_read.coordinates_displacements
+    assert "displacementField" in scene_read.coordinate_displacements
 
-    dfield_img = scene_read.coordinates_displacements["displacementField"]
+    dfield_img = scene_read.coordinate_displacements["displacementField"]
     for image in dfield_img.images:
         assert image.axes_types["c"] == "displacement"
     assert dfield_img.metadata.coordinateSystems[0].axes[0].discrete

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -135,8 +135,8 @@ class TestWriter:
     def test_additional_transforms(self):
         from ome_zarr_models.v06.coordinate_transforms import (
             CoordinateSystem,
-            Sequence,
             CoordinateSystemIdentifier,
+            Sequence,
         )
 
         data = self.create_data((2, 128, 128))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -133,11 +133,15 @@ class TestWriter:
         return request.param
 
     def test_additional_transforms(self):
+        from ome_zarr_models.v06.coordinate_transforms import (
+            Sequence,
+            CoordinateSystem
+        )
         data = self.create_data((2, 128, 128))
 
         image = OMEZarrImage(data=data, axes="cyx", scale={"y": 0.5, "x": 0.5})
 
-        additional_transforms = {
+        additional_transforms = Sequence.model_validate({
             "type": "sequence",
             "input": {"name": "physical"},
             "output": {"name": "world"},
@@ -151,17 +155,17 @@ class TestWriter:
                     "translation": [0.0, 10.0, 10.0],
                 },
             ],
-        }
+        })
 
         additional_cs = [
-            {
+            CoordinateSystem.model_validate({
                 "name": "world",
                 "axes": [
                     {"name": "c", "type": "channel", "unit": "none"},
                     {"name": "y", "type": "space", "unit": "micrometer"},
                     {"name": "x", "type": "space", "unit": "micrometer"},
                 ],
-            }
+            })
         ]
 
         # this call lacks the coordinate system "world"
@@ -171,18 +175,18 @@ class TestWriter:
                 image=image,
                 scale_factors=None,
                 method=None,
-                coordinate_transformations=[
+                coordinate_transformations=(
                     additional_transforms,
-                ],
+                ),
             )
 
         ms = OMEZarrMultiscale(
             image=image,
             scale_factors=None,
             method=None,
-            coordinate_transformations=[
+            coordinate_transformations=(
                 additional_transforms,
-            ],
+            ),
             coordinate_systems=additional_cs,
             default_coordinate_system_name="physical",
         )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -133,39 +133,41 @@ class TestWriter:
         return request.param
 
     def test_additional_transforms(self):
-        from ome_zarr_models.v06.coordinate_transforms import (
-            Sequence,
-            CoordinateSystem
-        )
+        from ome_zarr_models.v06.coordinate_transforms import CoordinateSystem, Sequence
+
         data = self.create_data((2, 128, 128))
 
         image = OMEZarrImage(data=data, axes="cyx", scale={"y": 0.5, "x": 0.5})
 
-        additional_transforms = Sequence.model_validate({
-            "type": "sequence",
-            "input": {"name": "physical"},
-            "output": {"name": "world"},
-            "transformations": [
-                {
-                    "type": "scale",
-                    "scale": [1.0, 0.5, 0.5],
-                },
-                {
-                    "type": "translation",
-                    "translation": [0.0, 10.0, 10.0],
-                },
-            ],
-        })
+        additional_transforms = Sequence.model_validate(
+            {
+                "type": "sequence",
+                "input": {"name": "physical"},
+                "output": {"name": "world"},
+                "transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [1.0, 0.5, 0.5],
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [0.0, 10.0, 10.0],
+                    },
+                ],
+            }
+        )
 
         additional_cs = [
-            CoordinateSystem.model_validate({
-                "name": "world",
-                "axes": [
-                    {"name": "c", "type": "channel", "unit": "none"},
-                    {"name": "y", "type": "space", "unit": "micrometer"},
-                    {"name": "x", "type": "space", "unit": "micrometer"},
-                ],
-            })
+            CoordinateSystem.model_validate(
+                {
+                    "name": "world",
+                    "axes": [
+                        {"name": "c", "type": "channel", "unit": "none"},
+                        {"name": "y", "type": "space", "unit": "micrometer"},
+                        {"name": "x", "type": "space", "unit": "micrometer"},
+                    ],
+                }
+            )
         ]
 
         # this call lacks the coordinate system "world"
@@ -175,18 +177,14 @@ class TestWriter:
                 image=image,
                 scale_factors=None,
                 method=None,
-                coordinate_transformations=(
-                    additional_transforms,
-                ),
+                coordinate_transformations=(additional_transforms,),
             )
 
         ms = OMEZarrMultiscale(
             image=image,
             scale_factors=None,
             method=None,
-            coordinate_transformations=(
-                additional_transforms,
-            ),
+            coordinate_transformations=(additional_transforms,),
             coordinate_systems=additional_cs,
             default_coordinate_system_name="physical",
         )
@@ -199,15 +197,13 @@ class TestWriter:
         # make transform go bad
         additional_transforms = additional_transforms.model_copy(
             update={"output": {"name": "nonexistent"}}
-            )
+        )
         with pytest.raises(ValueError):
             OMEZarrMultiscale(
                 image=image,
                 scale_factors=None,
                 method=None,
-                coordinate_transformations=(
-                    additional_transforms,
-                ),
+                coordinate_transformations=(additional_transforms,),
                 coordinate_systems=additional_cs,
                 default_coordinate_system_name="physical",
             )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -133,7 +133,11 @@ class TestWriter:
         return request.param
 
     def test_additional_transforms(self):
-        from ome_zarr_models.v06.coordinate_transforms import CoordinateSystem, Sequence
+        from ome_zarr_models.v06.coordinate_transforms import (
+            CoordinateSystem,
+            Sequence,
+            CoordinateSystemIdentifier,
+        )
 
         data = self.create_data((2, 128, 128))
 
@@ -196,7 +200,7 @@ class TestWriter:
 
         # make transform go bad
         additional_transforms = additional_transforms.model_copy(
-            update={"output": {"name": "nonexistent"}}
+            update={"output": CoordinateSystemIdentifier(name="nonexistent")}
         )
         with pytest.raises(ValueError):
             OMEZarrMultiscale(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -197,15 +197,17 @@ class TestWriter:
         )
 
         # make transform go bad
-        additional_transforms["output"]["name"] = "nonexistent"
+        additional_transforms = additional_transforms.model_copy(
+            update={"output": {"name": "nonexistent"}}
+            )
         with pytest.raises(ValueError):
             OMEZarrMultiscale(
                 image=image,
                 scale_factors=None,
                 method=None,
-                coordinate_transformations=[
+                coordinate_transformations=(
                     additional_transforms,
-                ],
+                ),
                 coordinate_systems=additional_cs,
                 default_coordinate_system_name="physical",
             )


### PR DESCRIPTION
Built on top of #623 . In a future (and actually already present) ome-zarr-verse, a zarr group can be both a Scene *and* a plate, i.e., both keys could be present. This PR makes sure that when we are writing to a zarr group in `overwrite=False` aka append mode, we are not deleting metadata that may have already been there under the `ome` key.

✅ Added a test to make sure it works