### PR TITLE
deps: bump ome-zarr-models dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "toolz",
     "rangehttpserver",
     "transformnd>=0.6.0",
-    "ome-zarr-models==1.8.0rc2",
+    "ome-zarr-models>=1.8.0",
     "Deprecated",
 ]
 classifiers = [


### PR DESCRIPTION
With ome-zarr-models-py 1.8.0 [released](https://github.com/ome-zarr-models/ome-zarr-models-py/releases/tag/v1.8.0), I'm bumping the dependency here.