### PR TITLE
Fix failing pre-release test on main

### DIFF
--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: windows-latest, python_Version: '3.11', toxenv: 'py311'}
-          - {os: macos-latest, python_Version: '3.11', toxenv: 'py311'}
+          - {os: windows-latest, python_version: '3.13', toxenv: 'py313'}
+          - {os: macos-latest, python_version: '3.13', toxenv: 'py313'}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
@will-moore I'm not *exactly* sure what the action does, but some gh action only running on main was using Python 3.11, which we deprecated support for in some of the recent PRs, so we have failing tests on master at the momet.