### PR TITLE
find_multiscales() handles scenes

### DIFF
--- a/ome_zarr/utils.py
+++ b/ome_zarr/utils.py
@@ -154,10 +154,20 @@ def find_multiscales(path_to_zattrs):
         if len(wells) > 0:
             path_to_zarr = path_to_zattrs / wells[0].get("path") / field
             plate_name = os.path.basename(path_to_zattrs)
+            # when used for "finder", show the plate as a single entry with thumbnail
             return [[path_to_zarr, plate_name, os.path.dirname(path_to_zattrs)]]
         else:
             LOGGER.info("No wells found in plate%s", path_to_zattrs)
             return []
+    elif "scene" in zattrs:
+        # use first input image as the representative for the scene
+        path_to_zarr = path_to_zattrs
+        for ct in zattrs["scene"].get("coordinateTransformations", []):
+            input_path = ct.get("input", {}).get("path")
+            if input_path is not None:
+                path_to_zarr = path_to_zattrs / input_path
+                break
+        return [[path_to_zarr, path_to_zattrs.name, os.path.dirname(path_to_zattrs)]]
     elif zattrs.get("bioformats2raw.layout") == 3:
         # Open OME/METADATA.ome.xml
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 from collections import deque
 from pathlib import Path
@@ -141,6 +142,24 @@ class TestCli:
         # main(["view", filename, "8000"])
         # we need dry_run to be True to avoid blocking the test with server
         view(filename, 8000, True)
+
+        # write minimal scene for test coverage
+        scene_dir = self.path / "scene.zarr"
+        scene_dir.mkdir()
+        with open(scene_dir / "zarr.json", "w") as f:
+            scene_json = {
+                "attributes": {
+                    "ome": {
+                        "scene": {
+                            "coordinateTransformations": [
+                                {"input": {"path": "image.zarr"}}
+                            ]
+                        }
+                    }
+                }
+            }
+            f.write(json.dumps(scene_json))
+        view(scene_dir, 8000, True)
 
     @pytest.mark.parametrize(
         "fmt",


### PR DESCRIPTION
This adds support for "scene" to the `ome_zarr view` command.

To test - I found this useful when viewing the output of docs build..

```
$ sphinx-build -b html docs/source/ docs/build/html

# list various zarrs...
$ find docs/ -type d -name "*.zarr"

# view the scene in validator
$ ome_zarr view docs/source/advanced/transforms/test_example_scene.zarr
```

In the 'finder' command the "scene" shows up as a single item (same as plate) in the BioFile Finder table. For each plate or scene, the FilePath passed to BFF is to the first image (so that we see a zarr thumbnail). Unfortunately the thumbnails aren't working for v0.6 data in BFF yet, but you can still e.g. open with Validator for each scene (opens first image).

```
$ ome_zarr finder docs/source/
```

BFF with the "scene" selected:

<img width="2001" height="634" alt="Screenshot 2026-08-28 at 15 02 51" src="https://github.com/user-attachments/assets/c02a372f-901b-49e0-86a3-a30ab7df0641" />

Showing Thumbnails:

<img width="2001" height="625" alt="Screenshot 2026-08-28 at 15 03 05" src="https://github.com/user-attachments/assets/d51031eb-3a0a-4429-8bfd-e26281960e3c" />
