### PR TITLE
allow python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description="Implementation of images in Zarr files."
 license = "BSD-2-Clause"
 license-files = ["LICENSE"]
 
-requires-python = ">3.12"
+requires-python = ">=3.12"
 
 dependencies = [
     "numpy",


### PR DESCRIPTION
@will-moore not sure why the tests for 3.12 passed on main with `requires-python = ">3.12"` there. This PR relaxe this requirement to  `requires-python = ">=3.12"`.