### PR TITLE
feat: download scenes

### DIFF
--- a/ome_zarr/utils.py
+++ b/ome_zarr/utils.py
@@ -24,7 +24,7 @@ from dask.diagnostics import ProgressBar
 # Not needed with python 3.15+? https://github.com/python/cpython/issues/86809
 from RangeHTTPServer import RangeRequestHandler
 
-from . import USE_DASK_ARRAY_KWARGS
+from . import USE_DASK_ARRAY_KWARGS, OMEZarrScene
 from .format import format_from_version
 from .io import parse_url
 from .reader import Multiscales, Node, Reader
@@ -332,6 +332,14 @@ def download(input_path: str, output_dir: str = ".") -> None:
     """
     location = parse_url(input_path)
     assert location, f"not a zarr: {location}"
+
+    if "scene" in location.root_attrs:
+        # ponytail: scene coordinate systems/axes vary by version; the
+        # ome_zarr_models-backed OMEZarrScene already handles this round-trip.
+        name = Path(location.path).name or "scene.zarr"
+        scene = OMEZarrScene.from_ome_zarr(location.store)
+        scene.to_ome_zarr(Path(output_dir) / name, overwrite=True)
+        return
 
     reader = Reader(location)
     nodes: list[Node] = list()

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -129,7 +129,9 @@ def test_create_scene_without_coordinate_systems(test_data_dir, transform):
     scene.to_ome_zarr(test_data_dir / "test_scene.zarr", overwrite=True)
 
     # test "downloading" the scene elsewhere
-    download(test_data_dir / "test_scene.zarr", test_data_dir / "test_scene_downloaded.zarr")
+    download(
+        test_data_dir / "test_scene.zarr", test_data_dir / "test_scene_downloaded.zarr"
+    )
 
     # check that the graph is created correctly
     assert scene._graph is not None
@@ -175,6 +177,7 @@ def test_create_scene_without_coordinate_systems(test_data_dir, transform):
 
     # make sure that the loaded transform is the same as the original
     assert transform_md == transform.model_dump(exclude_unset=True, mode="json")
+
 
 @pytest.mark.parametrize("transform", TRANSFORMS)
 def test_create_scene_with_coordinate_systems(test_data_dir, transform):
@@ -255,7 +258,10 @@ def test_create_scene_with_coordinate_systems(test_data_dir, transform):
     scene.to_ome_zarr(str(test_data_dir / "test_scene_with_cs.zarr"), overwrite=True)
 
     # test "downloading" the scene elsewhere
-    download(test_data_dir / "test_scene_with_cs.zarr", test_data_dir / "test_scene_with_cs_downloaded.zarr")
+    download(
+        test_data_dir / "test_scene_with_cs.zarr",
+        test_data_dir / "test_scene_with_cs_downloaded.zarr",
+    )
 
     # read in saved scene and check everything's there
     scene_read = OMEZarrScene.from_ome_zarr(

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -9,6 +9,7 @@ from ome_zarr_models.v06.coordinate_transforms import (
 from pydantic import TypeAdapter
 
 from ome_zarr import OMEZarrImage, OMEZarrMultiscale, OMEZarrScene
+from ome_zarr.utils import download
 
 transform_adapter = TypeAdapter(AnyTransform)
 
@@ -125,7 +126,10 @@ def test_create_scene_without_coordinate_systems(test_data_dir, transform):
         coordinate_transformations=[transform],
     )
 
-    scene.to_ome_zarr("test_scene.zarr", overwrite=True)
+    scene.to_ome_zarr(test_data_dir / "test_scene.zarr", overwrite=True)
+
+    # test "downloading" the scene elsewhere
+    download(test_data_dir / "test_scene.zarr", test_data_dir / "test_scene_downloaded.zarr")
 
     # check that the graph is created correctly
     assert scene._graph is not None
@@ -171,7 +175,6 @@ def test_create_scene_without_coordinate_systems(test_data_dir, transform):
 
     # make sure that the loaded transform is the same as the original
     assert transform_md == transform.model_dump(exclude_unset=True, mode="json")
-
 
 @pytest.mark.parametrize("transform", TRANSFORMS)
 def test_create_scene_with_coordinate_systems(test_data_dir, transform):
@@ -250,6 +253,11 @@ def test_create_scene_with_coordinate_systems(test_data_dir, transform):
     assert len(scene._graph.graph.nodes) == 4
 
     scene.to_ome_zarr(str(test_data_dir / "test_scene_with_cs.zarr"), overwrite=True)
+
+    # test "downloading" the scene elsewhere
+    download(test_data_dir / "test_scene_with_cs.zarr", test_data_dir / "test_scene_with_cs_downloaded.zarr")
+
+    # read in saved scene and check everything's there
     scene_read = OMEZarrScene.from_ome_zarr(
         str(test_data_dir / "test_scene_with_cs.zarr")
     )


### PR DESCRIPTION
Fixes https://github.com/ome/ome-zarr-py/issues/507

Small PR that injects the `from_ome_zarr` and `to_ome_zarr` io pathway in the `download` utility function. This will probably be a good way to go for handling the download of other kinds of ome-zarrs as well. 

I added the download function to the tests that are already in the scene tests, but in the long-term it will probably be good to have a suite of test data somewhere so we don't need to generate dummy data over and over again in the tests here.

Merging this could constitute another patch release?