### PR TITLE
Bump ozmp

### DIFF
--- a/ome_zarr/classes/scene.py
+++ b/ome_zarr/classes/scene.py
@@ -449,8 +449,8 @@ class OMEZarrScene:
             tnd_sub_transforms = [
                 tnd.transforms.by_dimension.SubTransform(
                     transform=self._ozmp_tf_to_tnd(sub_tf.transformation),
-                    input_axes=sub_tf.input_axes,
-                    output_axes=sub_tf.output_axes,
+                    input_axes=sub_tf.inputAxes,
+                    output_axes=sub_tf.outputAxes,
                 )
                 for sub_tf in sub_transformations
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "toolz",
     "rangehttpserver",
     "transformnd>=0.6.0,<0.8.0",
-    "ome-zarr-models>=1.8.0",
+    "ome-zarr-models>=1.8.1",
     "Deprecated",
 ]
 classifiers = [

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -29,13 +29,13 @@ TRANSFORMS = [
         "type": "byDimension",
         "transformations": [
             {
-                "input_axes": [1],
-                "output_axes": [1],
+                "inputAxes": [1],
+                "outputAxes": [1],
                 "transformation": {"type": "translation", "translation": (0.0,)},
             },
             {
-                "input_axes": [0],
-                "output_axes": [0],
+                "inputAxes": [0],
+                "outputAxes": [0],
                 "transformation": {"type": "scale", "scale": (1.0,)},
             },
         ],


### PR DESCRIPTION
@will-moore I discovered a bug I discovered while working on #648 

I pushed a fix over at ome-zarr-models-py, where the fields for the byDimension transform were still `input_axes` and `output_axes` instead of `inputAxes` and `outputAxes`. This was changed in the ngff specification [here](https://ngff.openmicroscopy.org/specifications/dev/version_history.html#changed).

I fixed it and cut a new release, so we can directly mirror this here.