### PR TITLE
bug: correctly normalize resolution level paths

### DIFF
--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -401,7 +401,8 @@ class OMEZarrMultiscaleBase:
                 if transform.input is None:
                     raise ValueError(
                         f"Transform input cannot be None in dataset {idx} "
-                        f"transform {transform}")
+                        f"transform {transform}"
+                    )
                 transform = transform.model_copy(
                     update={"input": transform.input.model_copy(update={"path": path})}
                 )

--- a/ome_zarr/classes/image.py
+++ b/ome_zarr/classes/image.py
@@ -394,10 +394,22 @@ class OMEZarrMultiscaleBase:
         if write_image_data:
             # Create a copy of metadata with normalized paths (s0, s1, etc.)
             # to match the paths used by _write_pyramid_to_zarr
-            write_datasets = tuple(
-                ds.model_copy(update={"path": f"s{idx}"})
-                for idx, ds in enumerate(self.metadata.datasets)
-            )
+            write_datasets = []
+            for idx, ds in enumerate(self.metadata.datasets):
+                path = f"s{idx}"
+                transform = ds.coordinateTransformations[0]
+                if transform.input is None:
+                    raise ValueError(
+                        f"Transform input cannot be None in dataset {idx} "
+                        f"transform {transform}")
+                transform = transform.model_copy(
+                    update={"input": transform.input.model_copy(update={"path": path})}
+                )
+                dataset = ds.model_copy(
+                    update={"path": path, "coordinateTransformations": (transform,)}
+                )
+                write_datasets.append(dataset)
+
             write_metadata = self.metadata.model_copy(
                 update={"datasets": write_datasets}
             )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1137,31 +1137,37 @@ class TestWriter:
             path = str(level)
             random_data = np.random.rand(125 >> level, 125 >> level)
             root_v3.create(path, data=random_data)
-            
-            datasets.append({
-                "path": path,
-                "coordinateTransformations": [{
-                    "type": "scale",
-                    "scale": [2**level, 2**level],
-                    "input": {"path": path},
-                    "output": {"name": "physical"}
-                }]
-            })
+
+            datasets.append(
+                {
+                    "path": path,
+                    "coordinateTransformations": [
+                        {
+                            "type": "scale",
+                            "scale": [2**level, 2**level],
+                            "input": {"path": path},
+                            "output": {"name": "physical"},
+                        }
+                    ],
+                }
+            )
 
         # Write metadata with non-normalized paths directly (bypassing writer)
         root_v3.attrs["ome"] = {
             "version": "0.6",
-            "multiscales": [{
-                "coordinateSystems": [
-                    {
-                        "name": "physical",
-                        "axes": [
-                            {"name": ax, "type": "space"} for ax in ["y", "x"]
-                        ]
-                    }
-                ],
-                "datasets": datasets,
-            }]
+            "multiscales": [
+                {
+                    "coordinateSystems": [
+                        {
+                            "name": "physical",
+                            "axes": [
+                                {"name": ax, "type": "space"} for ax in ["y", "x"]
+                            ],
+                        }
+                    ],
+                    "datasets": datasets,
+                }
+            ],
         }
 
         # Read back and verify paths were normalized to s0, s1, s2
@@ -1181,7 +1187,6 @@ class TestWriter:
             assert d["path"] == f"s{i}"
             assert d["coordinateTransformations"][0]["input"]["path"] == f"s{i}"
             assert d["coordinateTransformations"][0]["output"]["name"] == "physical"
-
 
 
 class TestMultiscalesMetadata:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1120,6 +1120,69 @@ class TestWriter:
                 axes="xt",
             )
 
+    def test_normalize_resolution_level_paths(self):
+        """
+        Some tools write resolution levels as, for instance,
+        0, 1, 2 instead of s0, s1, s2.
+        ome-zarr-py normalizes these paths to the s0, s1, s2 format.
+        This test checks whether this normalization is performed correctly.
+        """
+        # Create data at non-normalized paths (0, 1, 2)
+        path_v3 = self.path / "normalize_test"
+        root_v3 = zarr.open_group(path_v3, mode="w", zarr_format=3)
+
+        n_levels = 3
+        datasets = []
+        for level in range(n_levels):
+            path = str(level)
+            random_data = np.random.rand(125 >> level, 125 >> level)
+            root_v3.create(path, data=random_data)
+            
+            datasets.append({
+                "path": path,
+                "coordinateTransformations": [{
+                    "type": "scale",
+                    "scale": [2**level, 2**level],
+                    "input": {"path": path},
+                    "output": {"name": "physical"}
+                }]
+            })
+
+        # Write metadata with non-normalized paths directly (bypassing writer)
+        root_v3.attrs["ome"] = {
+            "version": "0.6",
+            "multiscales": [{
+                "coordinateSystems": [
+                    {
+                        "name": "physical",
+                        "axes": [
+                            {"name": ax, "type": "space"} for ax in ["y", "x"]
+                        ]
+                    }
+                ],
+                "datasets": datasets,
+            }]
+        }
+
+        # Read back and verify paths were normalized to s0, s1, s2
+        ms = OMEZarrMultiscale.from_ome_zarr(root_v3)
+
+        # write to a new group with normalized paths
+        path_v3_normalized = self.path / "normalize_test_normalized"
+        ms.to_ome_zarr(str(path_v3_normalized))
+
+        # Verify that the paths in the new group are normalized
+        grp = zarr.open_group(str(path_v3_normalized), mode="r")
+        for i in range(3):
+            assert f"s{i}" in grp
+
+        datasets = grp.attrs["ome"]["multiscales"][0]["datasets"]
+        for i, d in enumerate(datasets):
+            assert d["path"] == f"s{i}"
+            assert d["coordinateTransformations"][0]["input"]["path"] == f"s{i}"
+            assert d["coordinateTransformations"][0]["output"]["name"] == "physical"
+
+
 
 class TestMultiscalesMetadata:
     @pytest.fixture(autouse=True)
@@ -2462,4 +2525,4 @@ class TestLabelWriter:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    pytest.main([__file__ + "::TestWriter::test_normalize_resolution_level_paths"])


### PR DESCRIPTION
Bug I encountered that occurs when a remote ome-zarr is loaded and stored in a different place. If that remote ome-zarr uses a convention for the resolution levels that is **not** `s0`, `s1`, `s2`, etc but rather `0`, `1`, `2`. In that case, the metadata is copied under the hood in the writer path so that when this instance of `OMEZarrMultiscale` is saved, the resolution levels are normalized to `s0`, `s1`, `s2` and the `image.metadata` is not out of sync with the data that was originally opened.

**But**, the writer only updates the `path` field in the `datasets` field, but not the `datasets > coordinateTransformations > input > path` field 🙈 This is fixed by this PR along with a test for it.

*Edit*: @will-moore @kevinyamauchi I think if this goes in we could/should directly ship it as a patch release?